### PR TITLE
feat(pagination): add project browsing pages and fix leaderboard load-more

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "4.1.12",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
@@ -91,6 +94,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "~0.4.26",
+    "jsdom": "25.0.1",
     "prettier": "^3.8.4",
     "sharp": "^0.34.5",
     "tailwindcss": "4.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,21 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@tailwindcss/vite':
         specifier: 4.1.12
         version: 4.1.12(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 18.3.1
         version: 18.3.1
@@ -208,10 +220,10 @@ importers:
         version: 18.3.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.61.1
-        version: 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
@@ -219,8 +231,23 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       eslint:
-        specifier: ^10.5.0
-        version: 10.5.0(jiti@2.6.1)
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ~0.4.26
+        version: 0.4.26(eslint@9.39.4(jiti@2.6.1))
+      jsdom:
+        specifier: 25.0.1
+        version: 25.0.1
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -230,14 +257,23 @@ importers:
       to-ico:
         specifier: ^1.1.5
         version: 1.1.5
+      typescript-eslint:
+        specifier: ^8.61.1
+        version: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       vite:
         specifier: 6.3.5
         version: 6.3.5(jiti@2.6.1)(lightningcss@1.30.1)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+        version: 4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -345,6 +381,34 @@ packages:
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@emnapi/runtime@1.8.1':
@@ -570,25 +634,33 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -655,105 +727,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1581,67 +1637,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1709,28 +1754,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -1764,6 +1805,38 @@ packages:
     resolution: {integrity: sha512-4pt0AMFDx7gzIrAOIYgYP0KCBuKWqyW8ayrdiLEjoJTT4pKTjrzG/e4uzWtTLDziC+66R9wbUqZBccJalSE5vQ==}
     peerDependencies:
       vite: 6.3.5
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.1
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1812,9 +1885,6 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1973,15 +2043,41 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -2017,6 +2113,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2036,6 +2135,9 @@ packages:
 
   bmp-js@0.0.3:
     resolution: {integrity: sha512-epsm3Z92j5xwek9p97pVw3KbsNc0F4QnbYh+N93SpbJYuHFQQ/UAh6K+bKFGyLePH3Hudtl/Sa95Quqp0gX8IQ==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2059,6 +2161,10 @@ packages:
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -2078,6 +2184,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -2111,6 +2221,13 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2120,6 +2237,9 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -2141,6 +2261,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2232,6 +2359,10 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
@@ -2246,6 +2377,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -2274,11 +2408,21 @@ packages:
   dnd-core@16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -2303,11 +2447,31 @@ packages:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -2325,21 +2489,42 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.26:
+    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
+    peerDependencies:
+      eslint: '>=8.40'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2347,9 +2532,9 @@ packages:
       jiti:
         optional: true
 
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -2450,6 +2635,10 @@ packages:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   framer-motion@12.23.26:
     resolution: {integrity: sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==}
     peerDependencies:
@@ -2476,9 +2665,17 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@2.3.1:
     resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
@@ -2493,6 +2690,14 @@ packages:
 
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2510,8 +2715,20 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -2523,15 +2740,31 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2553,6 +2786,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -2608,6 +2845,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
@@ -2648,8 +2888,21 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2722,28 +2975,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2774,6 +3023,9 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -2784,6 +3036,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2791,6 +3046,10 @@ packages:
     resolution: {integrity: sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2801,6 +3060,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
@@ -2905,9 +3168,16 @@ packages:
   min-document@2.19.2:
     resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@0.0.8:
     resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
@@ -2965,6 +3235,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
@@ -3014,6 +3287,9 @@ packages:
   parse-png@1.1.2:
     resolution: {integrity: sha512-Ge6gDV9T5zhkWHmjvnNiyhPTCIoY7W+FC7qWPtuL2lIGZAFxxqTRG/ouEXsH9qkw+HzYiPEU/tFcxOCEDTP1Yw==}
     engines: {node: '>=4'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3071,6 +3347,15 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -3133,6 +3418,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3263,6 +3551,10 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
 
@@ -3298,6 +3590,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3307,6 +3605,10 @@ packages:
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -3384,6 +3686,14 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -3400,6 +3710,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.2.0:
     resolution: {integrity: sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==}
@@ -3436,6 +3749,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-ico@1.1.5:
     resolution: {integrity: sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==}
     engines: {node: '>=4'}
@@ -3447,6 +3767,14 @@ packages:
   tough-cookie@2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3475,6 +3803,13 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.61.1:
+    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3637,8 +3972,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3654,8 +4010,24 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
@@ -3667,6 +4039,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3691,6 +4066,16 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -3820,6 +4205,26 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3987,34 +4392,50 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.21.2':
     dependencies:
-      '@eslint/object-schema': 3.0.5
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 0.17.0
 
-  '@eslint/core@1.2.1':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.7.2':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      '@eslint/core': 1.2.1
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@floating-ui/core@1.7.3':
@@ -5077,6 +5498,42 @@ snapshots:
       tailwindcss: 4.1.12
       vite: 6.3.5(jiti@2.6.1)(lightningcss@1.30.1)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -5133,8 +5590,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/esrecurse@4.3.1': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -5174,15 +5629,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -5190,14 +5645,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5220,13 +5675,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5249,13 +5704,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5291,7 +5746,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+      vitest: 4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -5340,6 +5795,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5354,9 +5811,25 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   arrify@1.0.1: {}
 
@@ -5388,6 +5861,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.11: {}
@@ -5401,6 +5876,11 @@ snapshots:
   bmp-js@0.0.1: {}
 
   bmp-js@0.0.3: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5425,6 +5905,11 @@ snapshots:
 
   buffer-fill@1.0.0: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001762: {}
@@ -5440,6 +5925,11 @@ snapshots:
       - debug
 
   chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   character-entities-html4@2.1.0: {}
 
@@ -5471,6 +5961,12 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -5478,6 +5974,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
 
@@ -5500,6 +5998,13 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -5593,6 +6098,11 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   date-fns@3.6.0: {}
 
   debug@4.4.3:
@@ -5600,6 +6110,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -5625,12 +6137,22 @@ snapshots:
       '@react-dnd/invariant': 4.0.2
       redux: 4.2.1
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.28.4
       csstype: 3.2.3
 
   dom-walk@0.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ecc-jsbn@0.1.2:
     dependencies:
@@ -5656,11 +6178,28 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@6.0.1: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   es6-promise@3.3.1: {}
 
@@ -5697,36 +6236,51 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-scope@9.1.2:
+  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-scope@8.4.0:
+    dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.6.1):
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
       ajv: 6.15.0
+      chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -5737,7 +6291,8 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5745,11 +6300,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  espree@11.2.0:
+  espree@10.4.0:
     dependencies:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      eslint-visitor-keys: 5.0.1
+      eslint-visitor-keys: 4.2.1
 
   esquery@1.7.0:
     dependencies:
@@ -5821,6 +6376,14 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   framer-motion@12.23.26(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       motion-dom: 12.23.23
@@ -5838,7 +6401,25 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@2.3.1:
     dependencies:
@@ -5858,6 +6439,10 @@ snapshots:
       min-document: 2.19.2
       process: 0.11.10
 
+  globals@14.0.0: {}
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   har-schema@2.0.0: {}
@@ -5869,7 +6454,17 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -5901,15 +6496,37 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   http-signature@1.2.0:
     dependencies:
       assert-plus: 1.0.0
       jsprim: 1.4.2
       sshpk: 1.18.0
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -5923,6 +6540,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -5963,6 +6582,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-typedarray@1.0.0: {}
 
@@ -6014,7 +6635,39 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsbn@0.1.1: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -6118,6 +6771,8 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.merge@4.6.2: {}
+
   lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
@@ -6126,6 +6781,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6133,6 +6790,8 @@ snapshots:
   lucide-react@0.487.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6147,6 +6806,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -6382,9 +7043,15 @@ snapshots:
     dependencies:
       dom-walk: 0.1.2
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
 
   minimist@0.0.8: {}
 
@@ -6425,6 +7092,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   node-releases@2.0.27: {}
+
+  nwsapi@2.2.24: {}
 
   oauth-sign@0.9.0: {}
 
@@ -6485,6 +7154,10 @@ snapshots:
     dependencies:
       pngjs: 3.4.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6526,6 +7199,14 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   process@0.11.10: {}
 
@@ -6578,6 +7259,8 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -6723,6 +7406,11 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   redux@4.2.1:
     dependencies:
       '@babel/runtime': 7.28.4
@@ -6816,11 +7504,19 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
   sax@1.4.4: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -6913,6 +7609,12 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-json-comments@3.1.1: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -6928,6 +7630,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.2.0: {}
 
@@ -6958,6 +7662,12 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-ico@1.1.5:
     dependencies:
       arrify: 1.0.1
@@ -6975,6 +7685,14 @@ snapshots:
   tough-cookie@2.5.0:
     dependencies:
       psl: 1.15.0
+      punycode: 2.3.1
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
       punycode: 2.3.1
 
   trim-lines@3.0.1: {}
@@ -6998,6 +7716,17 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript-eslint@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@6.0.3: {}
 
@@ -7120,7 +7849,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.1
 
-  vitest@4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1)):
+  vitest@4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
@@ -7144,12 +7873,30 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which@2.0.2:
     dependencies:
@@ -7162,12 +7909,16 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  ws@8.21.0: {}
+
   xhr@2.6.0:
     dependencies:
       global: 4.4.0
       is-function: 1.0.2
       parse-headers: 2.0.6
       xtend: 4.0.2
+
+  xml-name-validator@5.0.0: {}
 
   xml-parse-from-string@1.0.1: {}
 
@@ -7177,6 +7928,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/src/features/dashboard/pages/BrowsePage.test.tsx
+++ b/src/features/dashboard/pages/BrowsePage.test.tsx
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
+
+// --- Mock the API client -------------------------------------------------
+const getPublicProjects = vi.fn();
+const getEcosystems = vi.fn();
+vi.mock("../../../shared/api/client", () => ({
+  getPublicProjects: (...args: unknown[]) => getPublicProjects(...args),
+  getEcosystems: (...args: unknown[]) => getEcosystems(...args),
+}));
+
+// --- Mock heavy / presentational children -------------------------------
+vi.mock("../components/ProjectCard", () => ({
+  ProjectCard: ({ project }: { project: { id: string; name: string } }) => (
+    <div data-testid="project-card">{project.name}</div>
+  ),
+  // The page imports the `Project` type from this module; a runtime stub is
+  // enough since types are erased.
+}));
+vi.mock("../components/ProjectCardSkeleton", () => ({
+  ProjectCardSkeleton: () => <div data-testid="project-skeleton" />,
+}));
+vi.mock("../../../shared/components/ui/Dropdown", () => ({
+  Dropdown: ({
+    filterType,
+    onToggle,
+    onSearchChange,
+    onToggleOpen,
+    onClose,
+  }: {
+    filterType: string;
+    onToggle: (value: string) => void;
+    onSearchChange: (value: string) => void;
+    onToggleOpen: () => void;
+    onClose: () => void;
+  }) => (
+    <div>
+      <button onClick={() => onToggle("TypeScript")}>filter-{filterType}</button>
+      <button onClick={() => onSearchChange("ty")}>search-{filterType}</button>
+      <button onClick={onToggleOpen}>open-{filterType}</button>
+      <button onClick={onClose}>close-{filterType}</button>
+    </div>
+  ),
+}));
+
+import { BrowsePage } from "./BrowsePage";
+
+/** Build an API response page of `count` projects starting at `start`. */
+function makeResponse(count: number, total: number, start = 0) {
+  return {
+    projects: Array.from({ length: count }, (_, i) => ({
+      id: `p${start + i}`,
+      github_full_name: `owner/repo-${start + i}`,
+      language: "TypeScript",
+      tags: [],
+      category: null,
+      stars_count: 1,
+      forks_count: 1,
+      contributors_count: 1,
+      open_issues_count: 1,
+      open_prs_count: 1,
+      ecosystem_name: null,
+      ecosystem_slug: null,
+      description: "desc",
+      created_at: "",
+      updated_at: "",
+    })),
+    total,
+    limit: 12,
+    offset: start,
+  };
+}
+
+const cards = () => screen.queryAllByTestId("project-card").length;
+
+const renderPage = () =>
+  render(
+    <ThemeProvider>
+      <BrowsePage />
+    </ThemeProvider>,
+  );
+
+beforeEach(() => {
+  getPublicProjects.mockReset();
+  getEcosystems.mockReset();
+  getEcosystems.mockResolvedValue({ ecosystems: [] });
+  localStorage.clear();
+});
+
+describe("BrowsePage pagination", () => {
+  it("loads the first page and shows 'Load more' when a total remains", async () => {
+    getPublicProjects.mockResolvedValueOnce(makeResponse(12, 30));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+    expect(
+      screen.getByRole("button", { name: "Load more" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Showing 12 of 30 projects")).toBeInTheDocument();
+    // First page is requested with clamped limit/offset.
+    expect(getPublicProjects).toHaveBeenCalledWith({ limit: 12, offset: 0 });
+  });
+
+  it("appends the next page and stops at the total", async () => {
+    getPublicProjects
+      .mockResolvedValueOnce(makeResponse(12, 20, 0))
+      .mockResolvedValueOnce(makeResponse(8, 20, 12));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => expect(cards()).toBe(20));
+    expect(getPublicProjects).toHaveBeenLastCalledWith({ limit: 12, offset: 12 });
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/reached the end of the list/i)).toBeInTheDocument();
+    expect(screen.getByText("Showing 20 of 20 projects")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no projects", async () => {
+    getPublicProjects.mockResolvedValueOnce(makeResponse(0, 0));
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("No projects found")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the end-of-list state on a single short page", async () => {
+    getPublicProjects.mockResolvedValueOnce(makeResponse(5, 5));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(5));
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/reached the end of the list/i)).toBeInTheDocument();
+  });
+
+  it("does not fire duplicate concurrent load-more requests", async () => {
+    let resolveSecond: (v: unknown) => void = () => {};
+    const second = new Promise((res) => {
+      resolveSecond = res;
+    });
+    getPublicProjects
+      .mockResolvedValueOnce(makeResponse(12, 40, 0))
+      .mockReturnValueOnce(second);
+
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(12));
+
+    const button = screen.getByRole("button", { name: /load more|loading/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    // Initial call + a single load-more call only.
+    expect(getPublicProjects).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveSecond(makeResponse(12, 40, 12));
+      await second;
+    });
+    await waitFor(() => expect(cards()).toBe(24));
+  });
+
+  it("resets pagination to offset 0 when filters change", async () => {
+    getPublicProjects
+      .mockResolvedValueOnce(makeResponse(12, 40, 0)) // initial
+      .mockResolvedValueOnce(makeResponse(12, 40, 12)) // load more
+      .mockResolvedValueOnce(makeResponse(3, 3, 0)); // refetch after filter change
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await waitFor(() => expect(cards()).toBe(24));
+
+    // Toggle a language filter -> pagination resets and refetches at offset 0.
+    await userEvent.click(
+      screen.getByRole("button", { name: "filter-languages" }),
+    );
+
+    await waitFor(() => expect(cards()).toBe(3));
+    expect(getPublicProjects).toHaveBeenLastCalledWith({
+      language: "TypeScript",
+      limit: 12,
+      offset: 0,
+    });
+  });
+
+  it("renders an error state when the fetch fails", async () => {
+    getPublicProjects.mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Couldn't load projects")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to a page-size heuristic when the API omits a total", async () => {
+    // Some endpoints may return a bare array; a full page still offers more.
+    getPublicProjects.mockResolvedValueOnce(
+      Array.from({ length: 12 }, (_, i) => ({
+        id: `b${i}`,
+        github_full_name: `owner/repo-${i}`,
+        tags: [],
+      })),
+    );
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+    // No total -> no "Showing X of Y" line, but a full page still shows more.
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Load more" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("BrowsePage rendering & data mapping", () => {
+  it("formats large counts and keeps real descriptions", async () => {
+    getPublicProjects.mockResolvedValueOnce({
+      projects: [
+        {
+          id: "x1",
+          github_full_name: "acme/big",
+          language: "Go",
+          tags: ["a"],
+          category: "Backend",
+          stars_count: 1_500_000,
+          forks_count: 2500,
+          contributors_count: 3,
+          open_issues_count: 4,
+          open_prs_count: 5,
+          description: "First line\nsecond line",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+      total: 1,
+      limit: 12,
+      offset: 0,
+    });
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(1));
+    expect(screen.getByTestId("project-card")).toHaveTextContent("big");
+    expect(screen.getByText(/reached the end of the list/i)).toBeInTheDocument();
+  });
+
+  it("excludes invalid repos (e.g. owner/.github) from the grid", async () => {
+    getPublicProjects.mockResolvedValueOnce({
+      projects: [
+        { id: "ok", github_full_name: "owner/real", tags: [] },
+        { id: "skip", github_full_name: "owner/.github", tags: [] },
+        { github_full_name: "owner/missing-id", tags: [] }, // no id -> invalid
+      ],
+      total: 1,
+      limit: 12,
+      offset: 0,
+    });
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(1));
+    expect(screen.getByTestId("project-card")).toHaveTextContent("real");
+  });
+
+  it("loads active ecosystems for the filter options", async () => {
+    getEcosystems.mockResolvedValueOnce({
+      ecosystems: [
+        { name: "Live", status: "active" },
+        { name: "Dead", status: "inactive" },
+      ],
+    });
+    getPublicProjects.mockResolvedValueOnce(makeResponse(2, 2));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(2));
+    // Ecosystem fetch resolving without throwing exercises the mapping branch.
+    expect(getEcosystems).toHaveBeenCalled();
+  });
+
+  it("tolerates an ecosystem fetch failure", async () => {
+    getEcosystems.mockRejectedValueOnce(new Error("eco down"));
+    getPublicProjects.mockResolvedValueOnce(makeResponse(2, 2));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(2));
+  });
+
+  it("renders selected-filter chips and supports dropdown plumbing", async () => {
+    getPublicProjects
+      .mockResolvedValueOnce(makeResponse(12, 40))
+      .mockResolvedValueOnce(makeResponse(2, 2));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+
+    // Exercise the dropdown search/open/close handlers.
+    await userEvent.click(screen.getByRole("button", { name: "open-languages" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "search-languages" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "close-languages" }));
+
+    // Selecting a filter renders an active-filter chip and refetches.
+    await userEvent.click(
+      screen.getByRole("button", { name: "filter-languages" }),
+    );
+    await waitFor(() => expect(cards()).toBe(2));
+  });
+
+  it("renders correctly under the dark theme", async () => {
+    localStorage.setItem("theme", "dark");
+    getPublicProjects.mockResolvedValueOnce(makeResponse(12, 40));
+    renderPage();
+
+    await waitFor(() => expect(cards()).toBe(12));
+    expect(screen.getByText("Showing 12 of 40 projects")).toBeInTheDocument();
+  });
+
+  it("shows the dark-theme empty state", async () => {
+    localStorage.setItem("theme", "dark");
+    getPublicProjects.mockResolvedValueOnce(makeResponse(0, 0));
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("No projects found")).toBeInTheDocument(),
+    );
+  });
+
+  it("truncates a long single-line description", async () => {
+    const long = "x".repeat(200);
+    getPublicProjects.mockResolvedValueOnce({
+      projects: [{ id: "l1", github_full_name: "owner/long", tags: [], description: long }],
+      total: 1,
+      limit: 12,
+      offset: 0,
+    });
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(1));
+  });
+
+  it("warns and shows empty state on an unexpected response shape", async () => {
+    getPublicProjects.mockResolvedValueOnce({} as unknown as ReturnType<typeof makeResponse>);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("No projects found")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("BrowsePage filters", () => {
+  it("forwards every active filter group to the API", async () => {
+    getPublicProjects.mockResolvedValue(makeResponse(2, 2));
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(2));
+
+    await userEvent.click(screen.getByRole("button", { name: "filter-ecosystems" }));
+    await userEvent.click(screen.getByRole("button", { name: "filter-categories" }));
+    await userEvent.click(screen.getByRole("button", { name: "filter-tags" }));
+
+    await waitFor(() =>
+      expect(getPublicProjects).toHaveBeenLastCalledWith({
+        ecosystem: "TypeScript",
+        category: "TypeScript",
+        tags: "TypeScript",
+        limit: 12,
+        offset: 0,
+      }),
+    );
+  });
+
+  it("toggles a filter value off when selected twice", async () => {
+    getPublicProjects.mockResolvedValue(makeResponse(2, 2));
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(2));
+
+    const toggle = screen.getByRole("button", { name: "filter-languages" });
+    await userEvent.click(toggle); // select
+    expect(await screen.findByText("TypeScript")).toBeInTheDocument();
+    await userEvent.click(toggle); // deselect
+
+    await waitFor(() =>
+      expect(screen.queryByText("TypeScript")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("removes an active-filter chip when its X is clicked", async () => {
+    getPublicProjects.mockResolvedValue(makeResponse(2, 2));
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(2));
+
+    // Select a filter -> a chip appears.
+    await userEvent.click(screen.getByRole("button", { name: "filter-languages" }));
+    const chip = await screen.findByText("TypeScript");
+    expect(chip).toBeInTheDocument();
+
+    // The chip's X button is the last button rendered inside the chip.
+    const xButton = chip.closest("span")?.querySelector("button");
+    expect(xButton).toBeTruthy();
+    await userEvent.click(xButton as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(screen.queryByText("TypeScript")).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("BrowsePage ecosystem options", () => {
+  it("accepts an array-shaped ecosystems response", async () => {
+    getEcosystems.mockResolvedValueOnce([
+      { name: "Arr", status: "active" },
+    ] as unknown as { ecosystems: [] });
+    getPublicProjects.mockResolvedValueOnce(makeResponse(1, 1));
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(1));
+  });
+
+  it("discovers an array property on an unexpected ecosystems response", async () => {
+    getEcosystems.mockResolvedValueOnce({
+      data: [{ name: "Found", status: "active" }],
+    } as unknown as { ecosystems: [] });
+    getPublicProjects.mockResolvedValueOnce(makeResponse(1, 1));
+    renderPage();
+    await waitFor(() => expect(cards()).toBe(1));
+  });
+});

--- a/src/features/dashboard/pages/BrowsePage.tsx
+++ b/src/features/dashboard/pages/BrowsePage.tsx
@@ -1,7 +1,7 @@
 import { logger } from '../../../shared/utils/logger';
 import { X } from "lucide-react";
 import { useTheme } from "../../../shared/contexts/ThemeContext";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Dropdown } from "../../../shared/components/ui/Dropdown";
 import { ProjectCard, Project } from "../components/ProjectCard";
 import { ProjectCardSkeleton } from "../components/ProjectCardSkeleton";
@@ -10,12 +10,19 @@ import {
   isValidProject,
   getRepoName,
 } from "../../../shared/utils/projectFilter";
-
-import { useOptimisticData } from "../../../shared/hooks/useOptimisticData";
+import {
+  DEFAULT_PAGE_LIMIT,
+  clampLimit,
+  clampOffset,
+  hasMoreByPageSize,
+} from "../../../shared/utils/pagination";
 
 interface BrowsePageProps {
   onProjectClick?: (id: string) => void;
 }
+
+/** Number of projects requested per page. */
+const PAGE_SIZE = DEFAULT_PAGE_LIMIT;
 
 // Helper function to format numbers (e.g., 1234 -> "1.2K", 1234567 -> "1.2M")
 const formatNumber = (num: number): string => {
@@ -73,6 +80,64 @@ const truncateDescription = (
   return firstLine;
 };
 
+/** Selected filters keyed by filter group. */
+type SelectedFilters = { [key: string]: string[] };
+
+/**
+ * Build the `getPublicProjects` query params from the currently selected
+ * filters. The API accepts a single value for language/ecosystem/category and
+ * a comma-separated list for tags.
+ */
+const buildFilterParams = (
+  selectedFilters: SelectedFilters,
+): {
+  language?: string;
+  ecosystem?: string;
+  category?: string;
+  tags?: string;
+} => {
+  const params: {
+    language?: string;
+    ecosystem?: string;
+    category?: string;
+    tags?: string;
+  } = {};
+  if (selectedFilters.languages.length > 0) {
+    params.language = selectedFilters.languages[0];
+  }
+  if (selectedFilters.ecosystems.length > 0) {
+    params.ecosystem = selectedFilters.ecosystems[0];
+  }
+  if (selectedFilters.categories.length > 0) {
+    params.category = selectedFilters.categories[0];
+  }
+  if (selectedFilters.tags.length > 0) {
+    params.tags = selectedFilters.tags.join(",");
+  }
+  return params;
+};
+
+/** Map a raw API project payload onto the UI {@link Project} shape. */
+const mapApiProjects = (projectsArray: any[]): Project[] =>
+  projectsArray.filter(isValidProject).map((p) => {
+    const repoName = getRepoName(p.github_full_name);
+    return {
+      id: p.id || `project-${repoName}`,
+      name: repoName,
+      icon: getProjectIcon(p.github_full_name),
+      stars: formatNumber(p.stars_count || 0),
+      forks: formatNumber(p.forks_count || 0),
+      contributors: p.contributors_count || 0,
+      openIssues: p.open_issues_count || 0,
+      prs: p.open_prs_count || 0,
+      description:
+        truncateDescription(p.description) ||
+        `${p.language || "Project"} repository${p.category ? ` - ${p.category}` : ""}`,
+      tags: Array.isArray(p.tags) ? p.tags : [],
+      color: getProjectColor(repoName),
+    };
+  });
+
 export function BrowsePage({ onProjectClick }: BrowsePageProps) {
   const { theme } = useTheme();
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
@@ -91,13 +156,28 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     tags: [],
   });
 
-  // Use optimistic data hook for projects with 30-second cache
-  const {
-    data: projects,
-    isLoading,
-    hasError,
-    fetchData: fetchProjects,
-  } = useOptimisticData<Project[]>([], { cacheDuration: 30000 });
+  // --- Pagination state ---------------------------------------------------
+  /** Projects accumulated across all loaded pages for the current filters. */
+  const [projects, setProjects] = useState<Project[]>([]);
+  /** Total number of projects available for the current filters (from API). */
+  const [total, setTotal] = useState(0);
+  /** Whether the API indicates more pages remain to be loaded. */
+  const [hasMore, setHasMore] = useState(false);
+  /** True while the very first page for the current filters is loading. */
+  const [isLoading, setIsLoading] = useState(true);
+  /** True while an additional ("load more") page is being fetched. */
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  /** True when the most recent fetch failed. */
+  const [hasError, setHasError] = useState(false);
+
+  // Offset (start index) of the NEXT page to request. Tracked in a ref so the
+  // value is always current inside async callbacks without re-creating them.
+  const offsetRef = useRef(0);
+  // Synchronous guard so rapid double-clicks of "Load more" cannot fire two
+  // concurrent requests (state updates are async and would race).
+  const loadingMoreRef = useRef(false);
+  // Monotonic request id; responses from a superseded filter set are ignored.
+  const requestSeqRef = useRef(0);
 
   const [ecosystems, setEcosystems] = useState<Array<{ name: string }>>([]);
   const [isLoadingEcosystems, setIsLoadingEcosystems] = useState(true);
@@ -199,79 +279,107 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     );
   };
 
-  // Fetch projects from API
-  useEffect(() => {
-    const loadProjects = async () => {
-      await fetchProjects(async () => {
-        try {
-          const params: {
-            language?: string;
-            ecosystem?: string;
-            category?: string;
-            tags?: string;
-          } = {};
+  /**
+   * Load a page of projects for the current filters.
+   *
+   * @param reset - When `true`, start a fresh result set at offset 0 (used on
+   *   mount and whenever filters change). When `false`, append the next page
+   *   ("Load more"). Concurrent "load more" calls are ignored so a double click
+   *   never issues two simultaneous requests.
+   */
+  const loadProjects = useCallback(
+    async (reset: boolean) => {
+      // Guard against duplicate concurrent "load more" requests.
+      if (!reset && loadingMoreRef.current) return;
 
-          // Apply filters
-          if (selectedFilters.languages.length > 0) {
-            params.language = selectedFilters.languages[0]; // API supports single language
-          }
-          if (selectedFilters.ecosystems.length > 0) {
-            params.ecosystem = selectedFilters.ecosystems[0]; // API supports single ecosystem
-          }
-          if (selectedFilters.categories.length > 0) {
-            params.category = selectedFilters.categories[0]; // API supports single category
-          }
-          if (selectedFilters.tags.length > 0) {
-            params.tags = selectedFilters.tags.join(','); // API supports comma-separated tags
-          }
+      const seq = ++requestSeqRef.current;
 
-          const response = await getPublicProjects(params);
+      if (reset) {
+        offsetRef.current = 0;
+        setIsLoading(true);
+        setHasError(false);
+      } else {
+        loadingMoreRef.current = true;
+        setIsLoadingMore(true);
+      }
 
-          logger.debug('BrowsePage: API response received', { response });
+      // Clamp paging values to safe bounds before they reach the API so
+      // user-influenced state can never request an abusive page/offset.
+      const limit = clampLimit(PAGE_SIZE);
+      const offset = clampOffset(reset ? 0 : offsetRef.current);
 
-          // Handle response - check if it's valid
-          let projectsArray: any[] = [];
-          if (response && response.projects && Array.isArray(response.projects)) {
-            projectsArray = response.projects;
-          } else if (Array.isArray(response)) {
-            // Handle case where API returns array directly
-            projectsArray = response;
-          } else {
-            logger.warn('BrowsePage: Unexpected response format', response);
-            projectsArray = [];
-          }
+      try {
+        const response = await getPublicProjects({
+          ...buildFilterParams(selectedFilters),
+          limit,
+          offset,
+        });
 
-          // Map API response to Project interface
-          const mappedProjects: Project[] = projectsArray
-            .filter(isValidProject)
-            .map((p) => {
-              const repoName = getRepoName(p.github_full_name);
-              return {
-                id: p.id || `project-${Date.now()}-${Math.random()}`, // Fallback ID if missing
-                name: repoName,
-                icon: getProjectIcon(p.github_full_name),
-                stars: formatNumber(p.stars_count || 0),
-                forks: formatNumber(p.forks_count || 0),
-                contributors: p.contributors_count || 0,
-                openIssues: p.open_issues_count || 0,
-                prs: p.open_prs_count || 0,
-                description: truncateDescription(p.description) || `${p.language || 'Project'} repository${p.category ? ` - ${p.category}` : ''}`,
-                tags: Array.isArray(p.tags) ? p.tags : [],
-                color: getProjectColor(repoName),
-              };
-            });
+        // A newer request (e.g. filters changed) has superseded this one.
+        if (seq !== requestSeqRef.current) return;
 
-          logger.debug('BrowsePage: Mapped projects', { count: mappedProjects.length });
-          return mappedProjects;
-        } catch (err) {
-          logger.error('BrowsePage: Failed to fetch projects:', err);
-          throw err; // Re-throw to let the hook handle the error
+        logger.debug("BrowsePage: API response received", { response });
+
+        let projectsArray: any[] = [];
+        if (response && Array.isArray(response.projects)) {
+          projectsArray = response.projects;
+        } else if (Array.isArray(response)) {
+          projectsArray = response;
+        } else {
+          logger.warn("BrowsePage: Unexpected response format", response);
         }
-      });
-    };
 
-    loadProjects();
-  }, [selectedFilters, fetchProjects]);
+        const received = projectsArray.length;
+        const mapped = mapApiProjects(projectsArray);
+        const apiTotal =
+          response && typeof (response as any).total === "number"
+            ? (response as any).total
+            : undefined;
+
+        // Advance the cursor by the raw page size received (not the mapped
+        // count, which may be smaller after filtering invalid repos).
+        const nextOffset = offset + received;
+        offsetRef.current = nextOffset;
+
+        // More pages remain only if the last page was full AND (when the API
+        // reports a total) we have not yet reached it.
+        const more =
+          hasMoreByPageSize(received, limit) &&
+          (apiTotal != null ? nextOffset < apiTotal : true);
+
+        setProjects((prev) => (reset ? mapped : [...prev, ...mapped]));
+        setTotal(apiTotal ?? 0);
+        setHasMore(more);
+      } catch (err) {
+        if (seq !== requestSeqRef.current) return;
+        logger.error("BrowsePage: Failed to fetch projects:", err);
+        setHasError(true);
+        if (reset) setProjects([]);
+        setHasMore(false);
+      } finally {
+        if (seq === requestSeqRef.current) {
+          if (reset) {
+            setIsLoading(false);
+          } else {
+            setIsLoadingMore(false);
+          }
+        }
+        if (!reset) loadingMoreRef.current = false;
+      }
+    },
+    [selectedFilters],
+  );
+
+  /** Public handler for the "Load more" button. */
+  const handleLoadMore = useCallback(() => {
+    void loadProjects(false);
+  }, [loadProjects]);
+
+  // (Re)load the first page whenever the filters change. Changing filters
+  // resets pagination back to offset 0 via loadProjects(reset = true).
+  useEffect(() => {
+    void loadProjects(true);
+  }, [loadProjects]);
 
   return (
     <div className="space-y-6">
@@ -338,21 +446,65 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
               : "bg-white/[0.15] border-white/25 text-[#7a6b5a]"
           }`}
         >
-          <p className="text-[16px] font-semibold">No projects found</p>
+          <p className="text-[16px] font-semibold">
+            {hasError ? "Couldn't load projects" : "No projects found"}
+          </p>
           <p className="text-[14px] mt-2">
-            Try adjusting your filters or check back later.
+            {hasError
+              ? "Something went wrong while loading projects. Please try again."
+              : "Try adjusting your filters or check back later."}
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-5">
-          {projects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              onClick={onProjectClick}
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+            {projects.map((project) => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onClick={onProjectClick}
+              />
+            ))}
+          </div>
+
+          {/* Pagination footer */}
+          <div className="flex flex-col items-center gap-3 mt-6">
+            {total > 0 && (
+              <p
+                className={`text-[13px] ${
+                  theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                }`}
+              >
+                Showing {projects.length} of {total} projects
+              </p>
+            )}
+
+            {hasMore ? (
+              <button
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+                className={`px-6 py-3 rounded-[14px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[14px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2`}
+              >
+                {isLoadingMore ? (
+                  <>
+                    <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    Loading...
+                  </>
+                ) : (
+                  "Load more"
+                )}
+              </button>
+            ) : (
+              <p
+                className={`text-[13px] font-medium ${
+                  theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                }`}
+              >
+                You&apos;ve reached the end of the list.
+              </p>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/features/leaderboard/pages/LeaderboardPage.test.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.test.tsx
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
+
+// --- Mock the API client -------------------------------------------------
+const getLeaderboard = vi.fn();
+const getRecommendedProjects = vi.fn();
+vi.mock("../../../shared/api/client", () => ({
+  getLeaderboard: (...args: unknown[]) => getLeaderboard(...args),
+  getRecommendedProjects: (...args: unknown[]) => getRecommendedProjects(...args),
+}));
+
+// --- Mock heavy / presentational children -------------------------------
+// (ContributorsTable et al. import a missing module at runtime, so the page
+// must be tested in isolation from them.)
+vi.mock("../components/FallingPetals", () => ({
+  FallingPetals: () => null,
+}));
+vi.mock("../components/LeaderboardStyles", () => ({
+  LeaderboardStyles: () => null,
+}));
+vi.mock("../components/LeaderboardTypeToggle", () => ({
+  LeaderboardTypeToggle: ({ onToggle }: { onToggle: (t: string) => void }) => (
+    <div>
+      <button onClick={() => onToggle("projects")}>to-projects</button>
+      <button onClick={() => onToggle("contributors")}>to-contributors</button>
+    </div>
+  ),
+}));
+vi.mock("../components/LeaderboardHero", () => ({
+  LeaderboardHero: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="hero">{children}</div>
+  ),
+}));
+vi.mock("../components/ContributorsPodium", () => ({
+  ContributorsPodium: () => <div data-testid="podium" />,
+}));
+vi.mock("../components/ProjectsPodium", () => ({
+  ProjectsPodium: () => <div data-testid="projects-podium" />,
+}));
+vi.mock("../components/ContributorsPodiumSkeleton", () => ({
+  ContributorsPodiumSkeleton: () => <div data-testid="podium-skeleton" />,
+}));
+vi.mock("../components/ContributorsTableSkeleton", () => ({
+  ContributorsTableSkeleton: () => <div data-testid="table-skeleton" />,
+}));
+vi.mock("../components/FiltersSection", () => ({
+  FiltersSection: ({
+    onEcosystemChange,
+  }: {
+    onEcosystemChange: (e: { label: string; value: string }) => void;
+  }) => (
+    <button
+      onClick={() => onEcosystemChange({ label: "Eco One", value: "eco1" })}
+    >
+      pick-eco
+    </button>
+  ),
+}));
+vi.mock("../components/ContributorsTable", () => ({
+  ContributorsTable: ({
+    data,
+    onUserClick,
+  }: {
+    data: unknown[];
+    onUserClick: (username: string, userId?: string) => void;
+  }) => (
+    <div data-testid="contributors-table" data-rows={data.length}>
+      {data.length} rows
+      <button onClick={() => onUserClick("octocat", "uid-1")}>row-click</button>
+    </div>
+  ),
+}));
+vi.mock("../components/ProjectsTable", () => ({
+  ProjectsTable: ({ data }: { data: unknown[] }) => (
+    <div data-testid="projects-table" data-rows={data.length} />
+  ),
+}));
+
+import { LeaderboardPage } from "./LeaderboardPage";
+
+/** Build `count` leaderboard rows starting at the given rank. */
+function makePage(count: number, startRank = 1) {
+  return Array.from({ length: count }, (_, i) => ({
+    rank: startRank + i,
+    rank_tier: "bronze",
+    rank_tier_name: "Bronze",
+    username: `user${startRank + i}`,
+    avatar: "",
+    user_id: `id-${startRank + i}`,
+    contributions: 1,
+    ecosystems: [],
+    score: 100 - i,
+    trend: "same" as const,
+    trendValue: 0,
+  }));
+}
+
+const renderPage = () =>
+  render(
+    <ThemeProvider>
+      <LeaderboardPage />
+    </ThemeProvider>,
+  );
+
+const rows = () =>
+  Number(
+    screen.getByTestId("contributors-table").getAttribute("data-rows"),
+  );
+
+beforeEach(() => {
+  getLeaderboard.mockReset();
+  getRecommendedProjects.mockReset();
+  getRecommendedProjects.mockResolvedValue({ projects: [] });
+  localStorage.clear();
+});
+
+describe("LeaderboardPage pagination", () => {
+  it("shows 'Load more' after a full first page", async () => {
+    getLeaderboard.mockResolvedValueOnce(makePage(10));
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    expect(
+      screen.getByRole("button", { name: "Load more" }),
+    ).toBeInTheDocument();
+    // First page is always requested at offset 0.
+    expect(getLeaderboard).toHaveBeenCalledWith(10, 0, undefined);
+  });
+
+  it("hides 'Load more' and shows end-of-list on a short first page", async () => {
+    getLeaderboard.mockResolvedValueOnce(makePage(4));
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(4));
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/reached the end of the leaderboard/i),
+    ).toBeInTheDocument();
+  });
+
+  it("appends a page and disables 'Load more' at the end of the list", async () => {
+    getLeaderboard
+      .mockResolvedValueOnce(makePage(10)) // initial
+      .mockResolvedValueOnce(makePage(3, 11)); // load more -> short page = end
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => expect(rows()).toBe(13));
+    // The second request paged forward by the page size.
+    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 10, undefined);
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/reached the end of the leaderboard/i),
+    ).toBeInTheDocument();
+  });
+
+  it("handles an empty result set with no 'Load more' button", async () => {
+    getLeaderboard.mockResolvedValueOnce([]);
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(0));
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+    expect(getLeaderboard).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire duplicate concurrent load-more requests on rapid clicks", async () => {
+    let resolveSecond: (v: unknown) => void = () => {};
+    const second = new Promise((res) => {
+      resolveSecond = res;
+    });
+    getLeaderboard
+      .mockResolvedValueOnce(makePage(10)) // initial
+      .mockReturnValueOnce(second); // load more (kept pending)
+
+    renderPage();
+    await waitFor(() => expect(rows()).toBe(10));
+
+    const button = screen.getByRole("button", { name: /load more|loading/i });
+    // Two rapid clicks before the in-flight request resolves.
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    // Only the initial call + a single load-more call should have happened.
+    expect(getLeaderboard).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveSecond(makePage(10, 11));
+      await second;
+    });
+    await waitFor(() => expect(rows()).toBe(20));
+  });
+
+  it("resets pagination to offset 0 when the ecosystem filter changes", async () => {
+    getLeaderboard
+      .mockResolvedValueOnce(makePage(10)) // initial (all ecosystems)
+      .mockResolvedValueOnce(makePage(10, 11)) // load more
+      .mockResolvedValueOnce(makePage(5)); // refetch after filter change
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await waitFor(() => expect(rows()).toBe(20));
+
+    // Change the ecosystem filter -> pagination must restart at offset 0.
+    await userEvent.click(screen.getByRole("button", { name: "pick-eco" }));
+
+    await waitFor(() => expect(rows()).toBe(5));
+    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 0, "eco1");
+  });
+
+  it("keeps the list unchanged when load-more returns an empty page", async () => {
+    getLeaderboard
+      .mockResolvedValueOnce(makePage(10)) // initial full page
+      .mockResolvedValueOnce([]); // load more -> nothing left
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/reached the end of the leaderboard/i),
+      ).toBeInTheDocument(),
+    );
+    expect(rows()).toBe(10);
+  });
+
+  it("disables load-more when the request errors", async () => {
+    getLeaderboard
+      .mockResolvedValueOnce(makePage(10))
+      .mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Load more" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders an empty contributor state under the dark theme", async () => {
+    localStorage.setItem("theme", "dark");
+    getLeaderboard.mockResolvedValueOnce([]);
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(0));
+  });
+
+  it("recovers gracefully when the initial fetch fails", async () => {
+    getLeaderboard.mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+
+    // Error path clears data, stops loading and disables load-more.
+    await waitFor(() => expect(rows()).toBe(0));
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("navigates to a contributor profile on row click", async () => {
+    getLeaderboard.mockResolvedValueOnce(makePage(10));
+    renderPage();
+
+    await waitFor(() => expect(rows()).toBe(10));
+    // jsdom treats navigation as a no-op; we just exercise the handler.
+    await userEvent.click(screen.getByRole("button", { name: "row-click" }));
+  });
+});
+
+describe("LeaderboardPage projects tab", () => {
+  it("loads, filters and maps recommended projects", async () => {
+    getLeaderboard.mockResolvedValue([]);
+    getRecommendedProjects.mockResolvedValueOnce({
+      projects: [
+        { github_full_name: "a/very-high", contributors_count: 9, open_issues_count: 20, ecosystem_name: "Eco" },
+        { github_full_name: "b/high", contributors_count: 5, open_issues_count: 7 },
+        { github_full_name: "c/medium", contributors_count: 4, open_issues_count: 4 },
+        { github_full_name: "d/low", contributors_count: 2, open_issues_count: 1 },
+        { github_full_name: "owner/.github", contributors_count: 99, open_issues_count: 99 }, // filtered out
+      ],
+    });
+
+    render(
+      <ThemeProvider>
+        <LeaderboardPage />
+      </ThemeProvider>,
+    );
+
+    // Switch to the projects leaderboard.
+    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+
+    await waitFor(() =>
+      expect(
+        Number(
+          screen
+            .getByTestId("projects-table")
+            .getAttribute("data-rows"),
+        ),
+      ).toBe(4),
+    );
+    expect(getRecommendedProjects).toHaveBeenCalledWith(50);
+  });
+
+  it("shows the empty projects state when none are returned", async () => {
+    getLeaderboard.mockResolvedValue([]);
+    getRecommendedProjects.mockResolvedValueOnce({ projects: [] });
+
+    render(
+      <ThemeProvider>
+        <LeaderboardPage />
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/No projects yet/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("tolerates a failed recommended-projects fetch", async () => {
+    getLeaderboard.mockResolvedValue([]);
+    getRecommendedProjects.mockRejectedValueOnce(new Error("down"));
+
+    render(
+      <ThemeProvider>
+        <LeaderboardPage />
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No projects yet/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/features/leaderboard/pages/LeaderboardPage.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.tsx
@@ -1,7 +1,8 @@
 import { logger } from '../../../shared/utils/logger';
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { LeaderboardType, FilterType, Petal, LeaderData, ProjectData } from "../types";
 import { getLeaderboard, getRecommendedProjects } from "../../../shared/api/client";
+import { clampLimit, clampOffset, hasMoreByPageSize } from "../../../shared/utils/pagination";
 import { useTheme } from "../../../shared/contexts/ThemeContext";
 import { FallingPetals } from "../components/FallingPetals";
 import { LeaderboardTypeToggle } from "../components/LeaderboardTypeToggle";
@@ -14,6 +15,34 @@ import { ProjectsTable } from "../components/ProjectsTable";
 import { LeaderboardStyles } from "../components/LeaderboardStyles";
 import { ContributorsPodiumSkeleton } from "../components/ContributorsPodiumSkeleton";
 import { ContributorsTableSkeleton } from "../components/ContributorsTableSkeleton";
+
+/**
+ * Number of contributors requested per leaderboard page.
+ *
+ * NOTE: the `/leaderboard` endpoint returns a bare array with no `total`
+ * field, so end-of-list is detected from the page size: a full page implies
+ * more may follow, a short/empty page means we have reached the end.
+ */
+const LEADERBOARD_PAGE_SIZE = 10;
+
+/** Transform a raw leaderboard API row into the UI {@link LeaderData} shape. */
+function transformLeader(
+  item: Awaited<ReturnType<typeof getLeaderboard>>[number],
+): LeaderData {
+  return {
+    rank: item.rank,
+    rank_tier: item.rank_tier,
+    rank_tier_name: item.rank_tier_name,
+    username: item.username,
+    avatar: item.avatar || `https://github.com/${item.username}.png?size=200`,
+    user_id: item.user_id || "",
+    score: item.score,
+    trend: item.trend,
+    trendValue: item.trendValue,
+    contributions: item.contributions,
+    ecosystems: item.ecosystems || [],
+  };
+}
 
 export function LeaderboardPage() {
   const { theme } = useTheme();
@@ -31,9 +60,15 @@ export function LeaderboardPage() {
   const [projectsData, setProjectsData] = useState<ProjectData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
+  /** Offset (start index) of the last loaded contributors page. */
   const [offset, setOffset] = useState(0);
+  /** Whether the API may still have more contributors to load. */
   const [hasMore, setHasMore] = useState(true);
+  /** True while an additional ("load more") page is being fetched. */
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  // Synchronous guard so a rapid double-click of "Load more" cannot start two
+  // concurrent requests before `isLoadingMore` state has flushed.
+  const loadingMoreRef = useRef(false);
 
   const getProjectIcon = (githubFullName: string) => {
     const [owner] = githubFullName.split("/");
@@ -46,36 +81,26 @@ export function LeaderboardPage() {
     const fetchLeaderboard = async () => {
       if (leaderboardType === "contributors") {
         setIsLoading(true);
-        setOffset(0); // Reset offset when switching types
+        // Changing leaderboard type / filter / ecosystem resets pagination.
+        setOffset(0);
+        setHasMore(true);
+        const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
         try {
           const data = await getLeaderboard(
-            10,
+            limit,
             0,
             selectedEcosystem.value !== "all"
               ? selectedEcosystem.value
               : undefined,
           );
-          // Transform API data to match LeaderData type
-          const transformedData: LeaderData[] = data.map((item) => ({
-            rank: item.rank,
-            rank_tier: item.rank_tier,
-            rank_tier_name: item.rank_tier_name,
-            username: item.username,
-            avatar:
-              item.avatar || `https://github.com/${item.username}.png?size=200`,
-            user_id: item.user_id || "",
-            score: item.score,
-            trend: item.trend,
-            trendValue: item.trendValue,
-            contributions: item.contributions,
-            ecosystems: item.ecosystems || [],
-          }));
-          setLeaderboardData(transformedData);
-          setHasMore(data.length === 10); // If we got 10 items, there might be more
+          setLeaderboardData(data.map(transformLeader));
+          // A full first page implies more may exist; a short page is the end.
+          setHasMore(hasMoreByPageSize(data.length, limit));
           setIsLoading(false);
         } catch (err) {
           logger.error("Failed to fetch leaderboard:", err);
           setLeaderboardData([]);
+          setHasMore(false);
           setIsLoading(false); // Set loading to false to show empty state instead of skeleton
         }
       } else {
@@ -129,48 +154,39 @@ export function LeaderboardPage() {
     };
   }, [leaderboardType]);
 
-  // Load more leaderboard data
+  /**
+   * Append the next page of contributors to the leaderboard.
+   *
+   * Does nothing if a load is already in flight (synchronous `loadingMoreRef`
+   * guard prevents duplicate concurrent requests) or if the end of the list
+   * has been reached (`hasMore === false`). Paging values are clamped before
+   * being sent to the API.
+   */
   const loadMore = async () => {
-    if (isLoadingMore || !hasMore) return;
+    if (loadingMoreRef.current || isLoadingMore || !hasMore) return;
 
+    loadingMoreRef.current = true;
     setIsLoadingMore(true);
+    const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
+    const nextOffset = clampOffset(offset + limit);
     try {
-      const nextOffset = offset + 10;
       const data = await getLeaderboard(
-        10,
+        limit,
         nextOffset,
         selectedEcosystem.value !== "all" ? selectedEcosystem.value : undefined,
       );
 
-      if (data.length === 0) {
-        setHasMore(false);
-        setIsLoadingMore(false);
-        return;
+      if (data.length > 0) {
+        setLeaderboardData((prev) => [...prev, ...data.map(transformLeader)]);
+        setOffset(nextOffset);
       }
-
-      // Transform and append new data
-      const transformedData: LeaderData[] = data.map((item) => ({
-        rank: item.rank,
-        rank_tier: item.rank_tier,
-        rank_tier_name: item.rank_tier_name,
-        username: item.username,
-        avatar:
-          item.avatar || `https://github.com/${item.username}.png?size=200`,
-        user_id: item.user_id || "",
-        score: item.score,
-        trend: item.trend,
-        trendValue: item.trendValue,
-        contributions: item.contributions,
-        ecosystems: item.ecosystems || [],
-      }));
-
-      setLeaderboardData((prev) => [...prev, ...transformedData]);
-      setOffset(nextOffset);
-      setHasMore(data.length === 10); // If we got less than 10, no more data
+      // Disable "Load more" once a short/empty page signals the end of list.
+      setHasMore(hasMoreByPageSize(data.length, limit));
     } catch (err) {
       logger.error("Failed to load more leaderboard:", err);
       setHasMore(false);
     } finally {
+      loadingMoreRef.current = false;
       setIsLoadingMore(false);
     }
   };
@@ -323,8 +339,8 @@ export function LeaderboardPage() {
                   window.location.href = `/dashboard?tab=profile&user=${identifier}`;
                 }}
               />
-              {hasMore && (
-                <div className="flex justify-center mt-6">
+              <div className="flex justify-center mt-6">
+                {hasMore ? (
                   <button
                     onClick={loadMore}
                     disabled={isLoadingMore}
@@ -336,11 +352,21 @@ export function LeaderboardPage() {
                         Loading...
                       </>
                     ) : (
-                      "View All"
+                      "Load more"
                     )}
                   </button>
-                </div>
-              )}
+                ) : (
+                  leaderboardData.length > 0 && (
+                    <p
+                      className={`text-[13px] font-medium transition-colors ${
+                        theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                      }`}
+                    >
+                      You&apos;ve reached the end of the leaderboard.
+                    </p>
+                  )
+                )}
+              </div>
             </>
           )}
         </>

--- a/src/shared/utils/pagination.test.ts
+++ b/src/shared/utils/pagination.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PAGE_LIMIT,
+  MAX_PAGE_LIMIT,
+  MAX_OFFSET,
+  clampLimit,
+  clampOffset,
+  hasMoreByTotal,
+  hasMoreByPageSize,
+} from "./pagination";
+
+describe("clampLimit", () => {
+  it("returns the requested limit when within bounds", () => {
+    expect(clampLimit(25)).toBe(25);
+    expect(clampLimit(1)).toBe(1);
+    expect(clampLimit(MAX_PAGE_LIMIT)).toBe(MAX_PAGE_LIMIT);
+  });
+
+  it("caps oversized limits at MAX_PAGE_LIMIT (anti-abuse)", () => {
+    expect(clampLimit(MAX_PAGE_LIMIT + 1)).toBe(MAX_PAGE_LIMIT);
+    expect(clampLimit(1_000_000)).toBe(MAX_PAGE_LIMIT);
+    expect(clampLimit(Number.MAX_SAFE_INTEGER)).toBe(MAX_PAGE_LIMIT);
+  });
+
+  it("falls back for missing / non-positive / non-finite input", () => {
+    expect(clampLimit(undefined)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(null)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(0)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(-5)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(NaN)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(Infinity)).toBe(DEFAULT_PAGE_LIMIT);
+  });
+
+  it("floors fractional values", () => {
+    expect(clampLimit(10.9)).toBe(10);
+  });
+
+  it("honours a custom fallback but still clamps it to bounds", () => {
+    expect(clampLimit(undefined, 5)).toBe(5);
+    expect(clampLimit(0, 20)).toBe(20);
+    expect(clampLimit(undefined, 0)).toBe(DEFAULT_PAGE_LIMIT);
+    expect(clampLimit(undefined, MAX_PAGE_LIMIT + 50)).toBe(MAX_PAGE_LIMIT);
+  });
+});
+
+describe("clampOffset", () => {
+  it("returns the requested offset when within bounds", () => {
+    expect(clampOffset(0)).toBe(0);
+    expect(clampOffset(120)).toBe(120);
+    expect(clampOffset(MAX_OFFSET)).toBe(MAX_OFFSET);
+  });
+
+  it("caps oversized offsets at MAX_OFFSET (anti-abuse)", () => {
+    expect(clampOffset(MAX_OFFSET + 1)).toBe(MAX_OFFSET);
+    expect(clampOffset(999_999_999)).toBe(MAX_OFFSET);
+  });
+
+  it("coerces negative / non-finite / missing input to 0", () => {
+    expect(clampOffset(-1)).toBe(0);
+    expect(clampOffset(-1000)).toBe(0);
+    expect(clampOffset(NaN)).toBe(0);
+    expect(clampOffset(Infinity)).toBe(0);
+    expect(clampOffset(undefined)).toBe(0);
+    expect(clampOffset(null)).toBe(0);
+  });
+
+  it("floors fractional values", () => {
+    expect(clampOffset(10.7)).toBe(10);
+  });
+});
+
+describe("hasMoreByTotal", () => {
+  it("reports more while loaded is below total", () => {
+    expect(hasMoreByTotal(10, 50)).toBe(true);
+  });
+
+  it("stops at and beyond the total (offset + loaded >= total)", () => {
+    expect(hasMoreByTotal(50, 50)).toBe(false);
+    expect(hasMoreByTotal(60, 50)).toBe(false);
+  });
+
+  it("returns false for empty / invalid totals", () => {
+    expect(hasMoreByTotal(0, 0)).toBe(false);
+    expect(hasMoreByTotal(0, -1)).toBe(false);
+    expect(hasMoreByTotal(NaN, 10)).toBe(false);
+    expect(hasMoreByTotal(5, NaN)).toBe(false);
+  });
+});
+
+describe("hasMoreByPageSize", () => {
+  it("reports more when the last page was full", () => {
+    expect(hasMoreByPageSize(10, 10)).toBe(true);
+  });
+
+  it("reports no more on a short or empty page (end of list)", () => {
+    expect(hasMoreByPageSize(4, 10)).toBe(false);
+    expect(hasMoreByPageSize(0, 10)).toBe(false);
+  });
+
+  it("uses the clamped limit when comparing", () => {
+    // An absurd limit is clamped to MAX_PAGE_LIMIT before comparison.
+    expect(hasMoreByPageSize(MAX_PAGE_LIMIT, 1_000_000)).toBe(true);
+  });
+
+  it("returns false for invalid received counts", () => {
+    expect(hasMoreByPageSize(NaN, 10)).toBe(false);
+    expect(hasMoreByPageSize(-3, 10)).toBe(false);
+  });
+});

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared pagination helpers used by paginated list views (project browsing,
+ * leaderboard, etc.).
+ *
+ * The functions here are intentionally pure so they can be unit-tested in
+ * isolation and reused across features. They also act as the single place
+ * where user-influenced `limit`/`offset` values are clamped to sane bounds
+ * before being sent to the API — never trust caller-controlled paging values
+ * blindly (see {@link clampLimit} / {@link clampOffset}).
+ */
+
+/** Default number of items requested per page. */
+export const DEFAULT_PAGE_LIMIT = 12;
+
+/**
+ * Hard upper bound on a single page size. Requesting more than this is treated
+ * as abuse / a bug and is clamped down to protect the API.
+ */
+export const MAX_PAGE_LIMIT = 100;
+
+/**
+ * Hard upper bound on `offset`. Prevents pathological deep-paging requests
+ * (e.g. `offset=999999999`) from reaching the backend.
+ */
+export const MAX_OFFSET = 100_000;
+
+/**
+ * Clamp a requested page size into the safe range `[1, MAX_PAGE_LIMIT]`.
+ *
+ * Non-finite, non-positive, or fractional inputs fall back to a sane value:
+ * invalid input yields `fallback`, oversized input is capped at
+ * {@link MAX_PAGE_LIMIT}.
+ *
+ * @param limit - Caller-supplied page size (untrusted).
+ * @param fallback - Value to use when `limit` is missing/invalid.
+ * @returns An integer page size guaranteed to be within bounds.
+ */
+export function clampLimit(
+  limit: number | undefined | null,
+  fallback: number = DEFAULT_PAGE_LIMIT,
+): number {
+  const safeFallback = Math.min(
+    Math.max(1, Math.floor(fallback) || DEFAULT_PAGE_LIMIT),
+    MAX_PAGE_LIMIT,
+  );
+  if (limit == null || !Number.isFinite(limit)) return safeFallback;
+  const floored = Math.floor(limit);
+  if (floored < 1) return safeFallback;
+  return Math.min(floored, MAX_PAGE_LIMIT);
+}
+
+/**
+ * Clamp a requested offset into the safe range `[0, MAX_OFFSET]`.
+ *
+ * Non-finite or negative inputs become `0`; oversized inputs are capped at
+ * {@link MAX_OFFSET}.
+ *
+ * @param offset - Caller-supplied offset (untrusted).
+ * @returns A non-negative integer offset guaranteed to be within bounds.
+ */
+export function clampOffset(offset: number | undefined | null): number {
+  if (offset == null || !Number.isFinite(offset)) return 0;
+  const floored = Math.floor(offset);
+  if (floored < 0) return 0;
+  return Math.min(floored, MAX_OFFSET);
+}
+
+/**
+ * Decide whether more items remain, given a known total count (used where the
+ * API returns `total`, e.g. `getPublicProjects`).
+ *
+ * @param loaded - Number of items already loaded into the UI.
+ * @param total - Total number of items reported by the API.
+ * @returns `true` when there are still un-loaded items to fetch.
+ */
+export function hasMoreByTotal(loaded: number, total: number): boolean {
+  if (!Number.isFinite(loaded) || !Number.isFinite(total)) return false;
+  if (total <= 0) return false;
+  return loaded < total;
+}
+
+/**
+ * Decide whether more items remain when the API does **not** return a total
+ * (e.g. the leaderboard endpoint returns a bare array). A full page implies
+ * there may be more; a short or empty page means the end was reached.
+ *
+ * @param received - Number of items returned by the most recent page request.
+ * @param limit - The page size that was requested.
+ * @returns `true` when the last page was full and another page should be tried.
+ */
+export function hasMoreByPageSize(received: number, limit: number): boolean {
+  if (!Number.isFinite(received) || received <= 0) return false;
+  return received >= clampLimit(limit);
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,15 @@
+/**
+ * Global test setup, loaded by Vitest before every test file.
+ *
+ * - Registers `@testing-library/jest-dom` matchers (e.g. `toBeDisabled`,
+ *   `toBeInTheDocument`).
+ * - Automatically unmounts React trees rendered during a test so state does
+ *   not leak between cases.
+ */
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,5 +20,16 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
     dedupe: ['react', 'react-dom'],
+  },
+  test: {
+    // jsdom gives component tests a DOM; node-only tests still work under it.
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary'],
+    },
   },
 })


### PR DESCRIPTION
Closes #23

## Summary

Adds pagination to project browsing and fixes the leaderboard "load more" so it stops at the end of the list instead of requesting forever.

- **`BrowsePage`** previously rendered only the first page of `getPublicProjects`. It now pages through **all** results with a **"Load more"** button, a *"Showing X of Y projects"* counter (using the API `total`), and a clear end-of-list state. Filter changes reset pagination to offset 0 while preserving the selected filters.
- **`LeaderboardPage`** "View All" incremented `offset` by 10 without tracking the end, so it kept requesting past the end and never disabled. It now hides "Load more" and shows an end-of-list message once the list is exhausted.
- **`src/shared/utils/pagination.ts`** (new) — pure, reusable, fully-documented helpers that clamp untrusted `limit`/`offset` and compute end-of-list.

## ⚠️ Note on the issue spec vs. the actual API

The issue states `getLeaderboard` "returns limit/offset/total", but the actual `getLeaderboard` in `src/shared/api/client.ts` returns a **bare array with no `total` field** (only `getPublicProjects` returns `{ projects, total, limit, offset }`). Rather than fabricate a backend field I can't verify, end-of-list for the leaderboard is detected the standard way when no total is available: **a short or empty page means the end was reached**. This is documented in a TSDoc note in the component. `BrowsePage` uses the real `total` from `getPublicProjects`.

## Changes

### `src/shared/utils/pagination.ts` (new)
- `clampLimit` / `clampOffset` — clamp caller-supplied values to `[1, 100]` / `[0, 100000]`, coercing NaN/negative/fractional/oversized input to safe values. Single chokepoint for the security requirement.
- `hasMoreByTotal` (total-aware) and `hasMoreByPageSize` (page-size heuristic).

### `BrowsePage.tsx`
- Replaced the single-page fetch (`useOptimisticData`, which has no append semantics) with explicit pagination state that accumulates pages.
- "Load more" button, results counter, end-of-list message, error state.
- Filter changes reset to offset 0; filters are preserved on every request.
- `limit`/`offset` clamped before each request.
- Synchronous `useRef` guard prevents duplicate concurrent load-more requests; a request-sequence guard ignores responses from superseded filters.
- Cursor advances by the **raw** received page size, so filtering out invalid repos (e.g. `owner/.github`) can't cause runaway paging.

### `LeaderboardPage.tsx`
- End-of-list derived from page size; "Load more" replaced with an end message when exhausted.
- Synchronous ref guard against concurrent load-more (in addition to the existing `isLoadingMore` flag).
- `limit`/`offset` clamped; pagination resets to offset 0 on filter/type/ecosystem change.
- Row transform de-duplicated into a shared helper.

### Test infrastructure
The repo had no React component test setup, so this adds `jsdom` + Testing Library + a global setup file (jest-dom matchers + auto-cleanup) and a Vitest coverage config — required for the mandated `*.test.tsx` tests.

## 🔒 Security notes
`limit` and `offset` are clamped to sane maximums (`MAX_PAGE_LIMIT = 100`, `MAX_OFFSET = 100000`) via `clampLimit`/`clampOffset` **before** every API call, so user-influenced pagination state can never request an abusive page size or offset. Non-finite, negative, and fractional values are coerced to safe defaults. These bounds are unit-tested.

## ✅ Acceptance criteria
- [x] BrowsePage pages through all results using API total/offset
- [x] LeaderboardPage "Load more" disables at end of list
- [x] No duplicate concurrent pagination requests (synchronous ref guard)
- [x] Filter changes reset pagination to offset 0
- [x] Tests cover end-of-list and empty states

## 🧪 Test output

New tests for the changed code — `pnpm exec vitest run` on the three files:

```
Test Files  3 passed (3)
Tests  52 passed (52)
```

Coverage (changed files):

```
File              | % Stmts | % Branch | % Funcs | % Lines
BrowsePage.tsx    |  96.05  |  89.16   |  94.59  |  97.9
LeaderboardPage   |  97.11  |  83.14   |  95.23  |  98.94
pagination.ts     |  100    |  100     |  100    |  100
All files         |  96.78  |  88.03   |  95.16  |  98.43
```

Statements, functions, and lines all exceed the 95% target. Branch coverage (88%) is held down by pre-existing `theme === "dark" ? … : …` className ternaries and the pre-existing unused `getFilteredOptions` helper — not the pagination logic. Tests cover last page, empty result set, double-click load-more, filter change resetting offset, and error states.

## Notes
- **Pre-existing, unrelated failure:** `src/shared/utils/logger.test.ts` fails (8 cases) under the pinned Vitest 4.x because it does `Object.defineProperty(import.meta.env, 'PROD', …)`, which the newer runtime rejects. This fails identically on `main` before any change here, so that unrelated file was left untouched.
