### PR TITLE
feat(a11y): add focus trapping and keyboard support to overlay components

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "4.1.12",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
@@ -91,6 +95,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "~0.4.26",
+    "jsdom": "^25.0.1",
     "prettier": "^3.8.4",
     "sharp": "^0.34.5",
     "tailwindcss": "4.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,24 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@tailwindcss/vite':
         specifier: 4.1.12
         version: 4.1.12(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 18.3.1
         version: 18.3.1
@@ -208,10 +223,10 @@ importers:
         version: 18.3.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.61.1
-        version: 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
@@ -219,8 +234,23 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       eslint:
-        specifier: ^10.5.0
-        version: 10.5.0(jiti@2.6.1)
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ~0.4.26
+        version: 0.4.26(eslint@9.39.4(jiti@2.6.1))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -230,14 +260,23 @@ importers:
       to-ico:
         specifier: ^1.1.5
         version: 1.1.5
+      typescript-eslint:
+        specifier: ^8.61.1
+        version: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       vite:
         specifier: 6.3.5
         version: 6.3.5(jiti@2.6.1)(lightningcss@1.30.1)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+        version: 4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -283,10 +322,6 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -345,6 +380,34 @@ packages:
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@emnapi/runtime@1.8.1':
@@ -570,25 +633,33 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -655,105 +726,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1581,67 +1636,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1709,28 +1753,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -1764,6 +1804,38 @@ packages:
     resolution: {integrity: sha512-4pt0AMFDx7gzIrAOIYgYP0KCBuKWqyW8ayrdiLEjoJTT4pKTjrzG/e4uzWtTLDziC+66R9wbUqZBccJalSE5vQ==}
     peerDependencies:
       vite: 6.3.5
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.1
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1812,9 +1884,6 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1918,6 +1987,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1973,15 +2043,38 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -2017,6 +2110,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2036,6 +2132,9 @@ packages:
 
   bmp-js@0.0.3:
     resolution: {integrity: sha512-epsm3Z92j5xwek9p97pVw3KbsNc0F4QnbYh+N93SpbJYuHFQQ/UAh6K+bKFGyLePH3Hudtl/Sa95Quqp0gX8IQ==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2059,6 +2158,10 @@ packages:
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -2078,6 +2181,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -2111,6 +2218,13 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2120,6 +2234,9 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -2141,6 +2258,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2232,6 +2356,10 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
@@ -2246,6 +2374,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -2274,11 +2405,21 @@ packages:
   dnd-core@16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -2303,11 +2444,31 @@ packages:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -2325,21 +2486,42 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.26:
+    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
+    peerDependencies:
+      eslint: '>=8.40'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2347,9 +2529,9 @@ packages:
       jiti:
         optional: true
 
-  espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -2450,6 +2632,10 @@ packages:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   framer-motion@12.23.26:
     resolution: {integrity: sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==}
     peerDependencies:
@@ -2476,9 +2662,17 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@2.3.1:
     resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
@@ -2493,6 +2687,14 @@ packages:
 
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2510,8 +2712,20 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -2523,15 +2737,31 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2553,6 +2783,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -2608,6 +2842,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
@@ -2648,8 +2885,21 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2722,28 +2972,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2774,6 +3020,9 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -2784,6 +3033,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2791,6 +3043,10 @@ packages:
     resolution: {integrity: sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2801,6 +3057,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
@@ -2905,9 +3165,16 @@ packages:
   min-document@2.19.2:
     resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@0.0.8:
     resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
@@ -2965,6 +3232,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
@@ -3014,6 +3284,9 @@ packages:
   parse-png@1.1.2:
     resolution: {integrity: sha512-Ge6gDV9T5zhkWHmjvnNiyhPTCIoY7W+FC7qWPtuL2lIGZAFxxqTRG/ouEXsH9qkw+HzYiPEU/tFcxOCEDTP1Yw==}
     engines: {node: '>=4'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3071,6 +3344,15 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -3133,6 +3415,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3259,9 +3544,14 @@ packages:
   recharts@2.15.2:
     resolution: {integrity: sha512-xv9lVztv3ingk7V3Jf05wfAZbM9Q2umJzu5t/cfnAK7LUslNrGT7LPBr74G+ok8kSCeFMaePmWMg0rcYOnczTw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
@@ -3298,6 +3588,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3307,6 +3603,10 @@ packages:
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -3384,6 +3684,14 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -3401,6 +3709,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.2.0:
     resolution: {integrity: sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==}
 
@@ -3414,6 +3725,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3436,6 +3748,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-ico@1.1.5:
     resolution: {integrity: sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==}
     engines: {node: '>=4'}
@@ -3447,6 +3766,14 @@ packages:
   tough-cookie@2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3475,6 +3802,13 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.61.1:
+    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3534,7 +3868,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vaul@1.1.2:
@@ -3637,8 +3971,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3654,8 +4009,24 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
@@ -3667,6 +4038,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3692,9 +4066,19 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -3749,7 +4133,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -3759,8 +4143,6 @@ snapshots:
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -3812,7 +4194,7 @@ snapshots:
   '@babel/types@7.28.5':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:
@@ -3820,6 +4202,26 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3987,34 +4389,50 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.21.2':
     dependencies:
-      '@eslint/object-schema': 3.0.5
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 0.17.0
 
-  '@eslint/core@1.2.1':
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.7.2':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
-      '@eslint/core': 1.2.1
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@floating-ui/core@1.7.3':
@@ -5077,6 +5495,42 @@ snapshots:
       tailwindcss: 4.1.12
       vite: 6.3.5(jiti@2.6.1)(lightningcss@1.30.1)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -5133,8 +5587,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/esrecurse@4.3.1': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -5174,15 +5626,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -5190,14 +5642,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5220,13 +5672,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5249,13 +5701,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5291,7 +5743,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
+      vitest: 4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -5340,12 +5792,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ajv@6.12.6:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -5354,9 +5801,25 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   arrify@1.0.1: {}
 
@@ -5388,6 +5851,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.11: {}
@@ -5401,6 +5866,11 @@ snapshots:
   bmp-js@0.0.1: {}
 
   bmp-js@0.0.3: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5425,6 +5895,11 @@ snapshots:
 
   buffer-fill@1.0.0: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001762: {}
@@ -5440,6 +5915,11 @@ snapshots:
       - debug
 
   chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   character-entities-html4@2.1.0: {}
 
@@ -5471,6 +5951,12 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -5478,6 +5964,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
 
@@ -5500,6 +5988,13 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -5593,6 +6088,11 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   date-fns@3.6.0: {}
 
   debug@4.4.3:
@@ -5600,6 +6100,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -5625,12 +6127,22 @@ snapshots:
       '@react-dnd/invariant': 4.0.2
       redux: 4.2.1
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.28.4
       csstype: 3.2.3
 
   dom-walk@0.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ecc-jsbn@0.1.2:
     dependencies:
@@ -5656,11 +6168,28 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@6.0.1: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   es6-promise@3.3.1: {}
 
@@ -5697,36 +6226,51 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-scope@9.1.2:
+  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-scope@8.4.0:
+    dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.6.1):
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
       ajv: 6.15.0
+      chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -5737,7 +6281,8 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5745,11 +6290,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  espree@11.2.0:
+  espree@10.4.0:
     dependencies:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      eslint-visitor-keys: 5.0.1
+      eslint-visitor-keys: 4.2.1
 
   esquery@1.7.0:
     dependencies:
@@ -5821,6 +6366,14 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   framer-motion@12.23.26(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       motion-dom: 12.23.23
@@ -5838,7 +6391,25 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@2.3.1:
     dependencies:
@@ -5858,18 +6429,32 @@ snapshots:
       min-document: 2.19.2
       process: 0.11.10
 
+  globals@14.0.0: {}
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   har-schema@2.0.0: {}
 
   har-validator@5.1.5:
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.15.0
       har-schema: 2.0.0
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -5901,15 +6486,37 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   http-signature@1.2.0:
     dependencies:
       assert-plus: 1.0.0
       jsprim: 1.4.2
       sshpk: 1.18.0
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -5923,6 +6530,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -5963,6 +6572,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-typedarray@1.0.0: {}
 
@@ -6014,7 +6625,39 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsbn@0.1.1: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -6118,6 +6761,8 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.merge@4.6.2: {}
+
   lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
@@ -6126,6 +6771,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6133,6 +6780,8 @@ snapshots:
   lucide-react@0.487.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6147,6 +6796,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -6382,9 +7033,15 @@ snapshots:
     dependencies:
       dom-walk: 0.1.2
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
 
   minimist@0.0.8: {}
 
@@ -6425,6 +7082,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   node-releases@2.0.27: {}
+
+  nwsapi@2.2.24: {}
 
   oauth-sign@0.9.0: {}
 
@@ -6485,6 +7144,10 @@ snapshots:
     dependencies:
       pngjs: 3.4.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6526,6 +7189,14 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   process@0.11.10: {}
 
@@ -6578,6 +7249,8 @@ snapshots:
       react: 18.3.1
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -6723,6 +7396,11 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   redux@4.2.1:
     dependencies:
       '@babel/runtime': 7.28.4
@@ -6816,11 +7494,19 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
   sax@1.4.4: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -6913,6 +7599,12 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-json-comments@3.1.1: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -6928,6 +7620,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.2.0: {}
 
@@ -6958,6 +7652,12 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-ico@1.1.5:
     dependencies:
       arrify: 1.0.1
@@ -6975,6 +7675,14 @@ snapshots:
   tough-cookie@2.5.0:
     dependencies:
       psl: 1.15.0
+      punycode: 2.3.1
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
       punycode: 2.3.1
 
   trim-lines@3.0.1: {}
@@ -6998,6 +7706,17 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript-eslint@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@6.0.3: {}
 
@@ -7120,7 +7839,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.1
 
-  vitest@4.1.9(@vitest/coverage-v8@4.1.9)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1)):
+  vitest@4.1.9(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@6.3.5(jiti@2.6.1)(lightningcss@1.30.1))
@@ -7144,12 +7863,30 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which@2.0.2:
     dependencies:
@@ -7162,12 +7899,16 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  ws@8.21.0: {}
+
   xhr@2.6.0:
     dependencies:
       global: 4.4.0
       is-function: 1.0.2
       parse-headers: 2.0.6
       xtend: 4.0.2
+
+  xml-name-validator@5.0.0: {}
 
   xml-parse-from-string@1.0.1: {}
 
@@ -7177,6 +7918,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/src/features/leaderboard/components/FiltersSection.tsx
+++ b/src/features/leaderboard/components/FiltersSection.tsx
@@ -81,23 +81,6 @@ export function FiltersSection({
           label: e.name,
           value: e.slug,
         }));
-        const activeEcosystems = data.ecosystems
-          .filter((e) => e.status === "active")
-          .map((e) => ({
-            label: e.name,
-            value: e.slug,
-          }));
-
-        setEcosystemOptions([
-          { label: "All Ecosystems", value: "all" },
-          ...activeEcosystems,
-        ]);
-      } catch (err) {
-        logger.error("Failed to fetch ecosystems:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
 
       setEcosystemOptions([
         { label: "All Ecosystems", value: "all" },

--- a/src/shared/components/FilterDropdown.test.tsx
+++ b/src/shared/components/FilterDropdown.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FilterDropdown } from './FilterDropdown';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+const OPTIONS = ['All Languages', 'TypeScript', 'JavaScript', 'Python'];
+
+function FilterHarness({ onChange }: { onChange?: (value: string) => void }) {
+  const [value, setValue] = useState('all');
+  return (
+    <FilterDropdown
+      label="Language"
+      options={OPTIONS}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe('FilterDropdown accessibility', () => {
+  it('exposes listbox aria attributes on the trigger', () => {
+    renderWithTheme(<FilterHarness />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens a labelled listbox and focuses the search input', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('listbox', { name: 'Language' })).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(OPTIONS.length);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search language')).toHaveFocus();
+    });
+  });
+
+  it('filters options as the user types', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+
+    await user.type(screen.getByLabelText('Search language'), 'Script');
+    const options = screen.getAllByRole('option');
+    expect(options.map((o) => o.textContent)).toEqual(['TypeScript', 'JavaScript']);
+  });
+
+  it('shows an empty state when nothing matches', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+    await user.type(screen.getByLabelText('Search language'), 'zzz');
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getByText('No options found.')).toBeInTheDocument();
+  });
+
+  it('marks the selected option with aria-selected', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+
+    // Default value 'all' maps to the "All Languages" option.
+    expect(screen.getByRole('option', { name: 'All Languages' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('navigates with arrow keys and selects with Enter, returning focus to the trigger', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness onChange={onChange} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+
+    const input = screen.getByLabelText('Search language');
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // -> All Languages
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // -> TypeScript
+    await waitFor(() => expect(screen.getByRole('option', { name: 'TypeScript' })).toHaveFocus());
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'TypeScript' }), { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('TypeScript');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('maps an "All …" option back to the "all" value when selected', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'All Languages' }));
+
+    expect(onChange).toHaveBeenCalledWith('all');
+  });
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByLabelText('Search language'), { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('wraps with ArrowUp from the first option to the last', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+
+    const input = screen.getByLabelText('Search language');
+    // ArrowUp from the initial (-1) state moves to the last option.
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Python' })).toHaveFocus());
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'JavaScript' })).toHaveFocus());
+  });
+
+  it('clears the search query with the clear button', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+    const input = screen.getByLabelText('Search language');
+    await user.type(input, 'Type');
+    expect(input).toHaveValue('Type');
+
+    await user.click(screen.getByRole('button', { name: 'Clear search' }));
+    expect(input).toHaveValue('');
+  });
+
+  it('closes when clicking outside', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<FilterHarness />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+});

--- a/src/shared/components/FilterDropdown.tsx
+++ b/src/shared/components/FilterDropdown.tsx
@@ -1,5 +1,5 @@
 import { logger } from '../../shared/utils/logger';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId, type KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { ChevronDown, Search, X } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
@@ -12,17 +12,36 @@ interface FilterDropdownProps {
   placeholder?: string;
 }
 
+/**
+ * Searchable filter dropdown rendered through a portal.
+ *
+ * Accessibility contract:
+ * - The trigger exposes `aria-haspopup="listbox"`, `aria-expanded` and
+ *   `aria-controls` (the listbox id).
+ * - The options container is a `role="listbox"`; each option is a
+ *   `role="option"` with `aria-selected` reflecting the current `value`.
+ * - On open, focus moves to the search input.
+ * - <kbd>Arrow Down</kbd>/<kbd>Arrow Up</kbd> move through the (filtered)
+ *   options, <kbd>Enter</kbd> selects the active option, and <kbd>Escape</kbd>
+ *   closes the menu and returns focus to the trigger.
+ * - The outside-click `mousedown` listener is removed on unmount/close, so no
+ *   listeners leak.
+ */
 export function FilterDropdown({ label, options, value, onChange, placeholder }: FilterDropdownProps) {
   const { theme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(-1);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const listboxId = useId();
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
 
   logger.debug('FilterDropdown render:', { label, isOpen, value, optionsCount: options.length });
 
-  // Update dropdown position when opened
+  // Update dropdown position when opened and move focus to the search input.
   useEffect(() => {
     if (isOpen && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
@@ -33,6 +52,8 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
       };
       logger.debug('Setting dropdown position:', position);
       setDropdownPosition(position);
+      setActiveIndex(-1);
+      searchInputRef.current?.focus();
     }
   }, [isOpen]);
 
@@ -61,16 +82,64 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
     option.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  // Keep the active option in sync with focus while navigating with the keyboard.
+  useEffect(() => {
+    if (activeIndex >= 0) {
+      optionRefs.current[activeIndex]?.focus();
+    }
+  }, [activeIndex]);
+
+  const closeAndRestoreFocus = () => {
+    setIsOpen(false);
+    setSearchQuery('');
+    setActiveIndex(-1);
+    buttonRef.current?.focus();
+  };
+
   const handleSelect = (option: string) => {
     logger.debug('Option selected:', option);
     onChange(option);
-    setIsOpen(false);
-    setSearchQuery('');
+    closeAndRestoreFocus();
   };
 
   const handleButtonClick = () => {
     logger.debug('Button clicked, toggling isOpen from', isOpen, 'to', !isOpen);
     setIsOpen(!isOpen);
+  };
+
+  // Map a filtered option back to the value passed to `onChange`.
+  const toOptionValue = (option: string) =>
+    option.toLowerCase().startsWith('all ') ? 'all' : option;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        closeAndRestoreFocus();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        if (filteredOptions.length > 0) {
+          setActiveIndex((index) => (index + 1) % filteredOptions.length);
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (filteredOptions.length > 0) {
+          setActiveIndex((index) =>
+            index <= 0 ? filteredOptions.length - 1 : index - 1,
+          );
+        }
+        break;
+      case 'Enter':
+        if (activeIndex >= 0 && activeIndex < filteredOptions.length) {
+          event.preventDefault();
+          handleSelect(toOptionValue(filteredOptions[activeIndex]));
+        }
+        break;
+      default:
+        break;
+    }
   };
 
   const displayValue = value === 'all' ? label : value;
@@ -81,8 +150,12 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
     <>
       <button
         ref={buttonRef}
+        type="button"
         onClick={handleButtonClick}
-        className={`w-full px-4 py-3 rounded-[12px] backdrop-blur-[30px] border text-[14px] font-medium transition-all flex items-center justify-between ${
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        className={`w-full px-4 py-3 rounded-[12px] backdrop-blur-[30px] border text-[14px] font-medium transition-all flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[#c9983a] ${
           theme === 'dark'
             ? 'bg-[#1a1512]/[0.6] border-white/15 text-[#e8dfd0] hover:bg-[#1a1512]/[0.8] hover:border-[#c9983a]/30'
             : 'bg-white/[0.25] border-white/35 text-[#2d2820] hover:bg-white/[0.35] hover:border-[#c9983a]/40'
@@ -95,6 +168,7 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
       {isOpen && createPortal(
         <div
           ref={dropdownRef}
+          onKeyDown={handleKeyDown}
           style={{
             position: 'fixed',
             top: `${dropdownPosition.top}px`,
@@ -115,18 +189,23 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
                 ? 'bg-white/[0.06] border-white/10'
                 : 'bg-white/[0.08] border-white/15'
             }`}>
-              <Search className="w-4 h-4 text-[#b8a898]" />
+              <Search className="w-4 h-4 text-[#b8a898]" aria-hidden="true" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder={placeholder || `Search ${label.toLowerCase()}...`}
+                aria-label={placeholder || `Search ${label.toLowerCase()}`}
+                aria-controls={listboxId}
                 className="flex-1 bg-transparent border-none outline-none text-[13px] text-[#e8dfd0] placeholder:text-[#b8a898]/50"
               />
               {searchQuery && (
                 <button
+                  type="button"
                   onClick={() => setSearchQuery('')}
-                  className="p-0.5 hover:bg-white/10 rounded transition-colors"
+                  aria-label="Clear search"
+                  className="p-0.5 hover:bg-white/10 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a]"
                 >
                   <X className="w-3 h-3 text-[#b8a898]" />
                 </button>
@@ -135,22 +214,34 @@ export function FilterDropdown({ label, options, value, onChange, placeholder }:
           </div>
 
           {/* Options List */}
-          <div className="max-h-[280px] overflow-y-auto custom-scrollbar">
+          <div
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="max-h-[280px] overflow-y-auto custom-scrollbar"
+          >
             {filteredOptions.length === 0 ? (
               <div className="px-4 py-8 text-center">
                 <p className="text-[13px] text-[#b8a898]">No options found.</p>
               </div>
             ) : (
               <div className="py-2">
-                {filteredOptions.map((option) => {
+                {filteredOptions.map((option, index) => {
                   // Convert "All Languages" -> "all", otherwise keep the option as-is
-                  const optionValue = option.toLowerCase().startsWith('all ') ? 'all' : option;
-                  
+                  const optionValue = toOptionValue(option);
+
                   return (
                     <button
                       key={option}
+                      ref={(element) => {
+                        optionRefs.current[index] = element;
+                      }}
+                      type="button"
+                      role="option"
+                      aria-selected={value === optionValue}
+                      tabIndex={-1}
                       onClick={() => handleSelect(optionValue)}
-                      className={`w-full px-4 py-2.5 text-left text-[13px] transition-colors ${
+                      className={`w-full px-4 py-2.5 text-left text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#c9983a] ${
                         value === optionValue
                           ? theme === 'dark'
                             ? 'bg-[#c9983a]/20 text-[#c9983a] font-semibold'

--- a/src/shared/components/GlassDropdown.test.tsx
+++ b/src/shared/components/GlassDropdown.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GlassDropdown } from './GlassDropdown';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+const OPTIONS = ['Open', 'Merged', 'Closed'] as const;
+type Option = (typeof OPTIONS)[number];
+
+function GlassHarness({
+  initialValue = 'Open',
+  onChange,
+}: {
+  initialValue?: Option;
+  onChange?: (value: Option) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<Option>(initialValue);
+  return (
+    <GlassDropdown<Option>
+      value={value}
+      options={[...OPTIONS]}
+      isOpen={open}
+      onToggle={() => setOpen((prev) => !prev)}
+      onClose={() => setOpen(false)}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe('GlassDropdown accessibility', () => {
+  it('exposes combobox aria attributes on the trigger', () => {
+    renderWithTheme(<GlassHarness />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-controls');
+  });
+
+  it('reflects the open state with aria-expanded and renders a listbox', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness />);
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(OPTIONS.length);
+  });
+
+  it('marks the selected option with aria-selected', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness initialValue="Merged" />);
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('option', { name: 'Merged' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('option', { name: 'Open' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('focuses the selected option when opened', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness initialValue="Merged" />);
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Merged' })).toHaveFocus();
+    });
+  });
+
+  it('navigates options with the arrow keys', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness initialValue="Open" />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Open' })).toHaveFocus());
+
+    const listbox = screen.getByRole('listbox');
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Merged' })).toHaveFocus());
+
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Open' })).toHaveFocus());
+
+    // ArrowUp from the first option wraps to the last.
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Closed' })).toHaveFocus());
+
+    // Home / End jump to the ends.
+    fireEvent.keyDown(listbox, { key: 'Home' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Open' })).toHaveFocus());
+    fireEvent.keyDown(listbox, { key: 'End' });
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Closed' })).toHaveFocus());
+  });
+
+  it('selects the active option with Enter and returns focus to the trigger', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness initialValue="Open" onChange={onChange} />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Open' })).toHaveFocus());
+
+    const listbox = screen.getByRole('listbox');
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(listbox, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('Merged');
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('selects an option on click', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness onChange={onChange} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('option', { name: 'Closed' }));
+
+    expect(onChange).toHaveBeenCalledWith('Closed');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness />);
+    const trigger = screen.getByRole('button');
+    await user.click(trigger);
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('opens with ArrowDown on the closed trigger', async () => {
+    renderWithTheme(<GlassHarness />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+  });
+
+  it('opens with Enter on the closed trigger', async () => {
+    renderWithTheme(<GlassHarness />);
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+  });
+
+  it('collapses the menu when Tab is pressed', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Tab' });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+});

--- a/src/shared/components/GlassDropdown.tsx
+++ b/src/shared/components/GlassDropdown.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 
@@ -10,66 +11,161 @@ interface GlassDropdownProps<T extends string> {
   onClose: () => void;
 }
 
-export function GlassDropdown<T extends string>({ 
-  value, 
-  onChange, 
-  options, 
-  isOpen, 
-  onToggle, 
-  onClose 
+/**
+ * Glassmorphic single-select dropdown.
+ *
+ * Accessibility contract:
+ * - The trigger is a `button` exposing `aria-haspopup="listbox"`,
+ *   `aria-expanded` (reflecting `isOpen`) and `aria-controls` (the menu id).
+ * - The menu is a `role="listbox"`; each option is a `role="option"` with
+ *   `aria-selected` reflecting the current `value`.
+ * - When opened, focus moves to the selected option (or the first one).
+ * - Keyboard support inside the menu: <kbd>Arrow Up</kbd>/<kbd>Arrow Down</kbd>
+ *   and <kbd>Home</kbd>/<kbd>End</kbd> move focus, <kbd>Enter</kbd>/<kbd>Space</kbd>
+ *   select, <kbd>Escape</kbd> (or <kbd>Tab</kbd>) closes. Closing via the
+ *   keyboard returns focus to the trigger.
+ * - <kbd>Arrow Down</kbd> on the closed trigger opens the menu.
+ */
+export function GlassDropdown<T extends string>({
+  value,
+  onChange,
+  options,
+  isOpen,
+  onToggle,
+  onClose,
 }: GlassDropdownProps<T>) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const menuId = useId();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // When the menu opens, start from the currently selected option (or the
+  // first one) and move focus to it.
+  useEffect(() => {
+    if (!isOpen) return;
+    const selectedIndex = options.indexOf(value);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [isOpen, options, value]);
+
+  // Keep DOM focus in sync with the active option while the menu is open.
+  useEffect(() => {
+    if (!isOpen) return;
+    optionRefs.current[activeIndex]?.focus();
+  }, [isOpen, activeIndex]);
 
   const handleSelect = (option: T) => {
     onChange(option);
     onClose();
+    // Return focus to the trigger after a selection.
+    buttonRef.current?.focus();
+  };
+
+  const closeAndRestoreFocus = () => {
+    onClose();
+    buttonRef.current?.focus();
+  };
+
+  const handleButtonKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (!isOpen && (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      onToggle();
+    }
+  };
+
+  const handleMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % options.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setActiveIndex((index) => (index - 1 + options.length) % options.length);
+        break;
+      case 'Home':
+        event.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        handleSelect(options[activeIndex]);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        closeAndRestoreFocus();
+        break;
+      case 'Tab':
+        // Allow focus to leave naturally, but collapse the menu.
+        onClose();
+        break;
+      default:
+        break;
+    }
   };
 
   return (
     <div className="relative">
       {/* Dropdown Button */}
-      <button 
-        className={`flex items-center gap-2 px-5 py-3 rounded-[14px] backdrop-blur-[25px] border transition-all ${
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        className={`flex items-center gap-2 px-5 py-3 rounded-[14px] backdrop-blur-[25px] border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[#c9983a] ${
           isDark
             ? 'bg-white/[0.08] border-white/15 hover:bg-white/[0.12] hover:border-[#e8c571]/30'
             : 'bg-white/[0.15] border-white/25 hover:bg-white/[0.2] hover:border-[#c9983a]/30'
         }`}
         onClick={onToggle}
+        onKeyDown={handleButtonKeyDown}
       >
-        <span className={`text-[14px] font-semibold ${
-          isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-        }`}>
+        <span className={`text-[14px] font-semibold ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
           {value}
         </span>
-        <ChevronDown className={`w-4 h-4 transition-transform ${
-          isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-        } ${isOpen ? 'rotate-180' : ''}`} />
+        <ChevronDown
+          className={`w-4 h-4 transition-transform ${isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'} ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+        />
       </button>
-      
+
       {/* Dropdown Menu */}
       {isOpen && (
         <>
           {/* Backdrop */}
-          <div 
-            className="fixed inset-0 z-40" 
-            onClick={onClose}
-          />
-          
+          <div className="fixed inset-0 z-40" onClick={onClose} aria-hidden="true" />
+
           {/* Menu */}
-          <div className={`absolute top-full right-0 mt-2 w-48 rounded-[16px] border z-50 overflow-hidden ${
-            isDark
-              ? 'bg-[#3a3228] border-white/30'
-              : 'bg-[#d4c5b0] border-white/40'
-          }`}>
+          <div
+            id={menuId}
+            role="listbox"
+            aria-label="Options"
+            onKeyDown={handleMenuKeyDown}
+            className={`absolute top-full right-0 mt-2 w-48 rounded-[16px] border z-50 overflow-hidden ${
+              isDark ? 'bg-[#3a3228] border-white/30' : 'bg-[#d4c5b0] border-white/40'
+            }`}
+          >
             <div className="py-2">
-              {options.map((option) => (
+              {options.map((option, index) => (
                 <button
                   key={option}
-                  className={`w-full px-5 py-2.5 text-left text-[13px] font-semibold transition-colors ${
-                    isDark
-                      ? 'text-[#e8dfd0] hover:bg-[#4a3e30]'
-                      : 'text-[#2d2820] hover:bg-[#c9b8a0]'
+                  ref={(element) => {
+                    optionRefs.current[index] = element;
+                  }}
+                  type="button"
+                  role="option"
+                  aria-selected={value === option}
+                  tabIndex={-1}
+                  className={`w-full px-5 py-2.5 text-left text-[13px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#c9983a] ${
+                    isDark ? 'text-[#e8dfd0] hover:bg-[#4a3e30]' : 'text-[#2d2820] hover:bg-[#c9b8a0]'
                   }`}
                   onClick={() => handleSelect(option)}
                 >

--- a/src/shared/components/SearchModal.test.tsx
+++ b/src/shared/components/SearchModal.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SearchModal } from './SearchModal';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+function SearchHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open search</button>
+      <SearchModal isOpen={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}
+
+describe('SearchModal accessibility', () => {
+  it('exposes role="dialog", aria-modal and a heading label', () => {
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    renderWithTheme(<SearchModal isOpen={false} onClose={() => {}} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('focuses the search input when opened', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchHarness />);
+    await user.click(screen.getByText('Open search'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search open source projects')).toHaveFocus();
+    });
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderWithTheme(<SearchModal isOpen onClose={onClose} />);
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={onClose} />);
+    await user.click(screen.getByRole('button', { name: 'Close search' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the query as the user types', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'rust');
+    expect(input).toHaveValue('rust');
+  });
+
+  it('populates the query when a suggestion is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} />);
+    const suggestion = 'Find the best GraphQL clients for TypeScript';
+    await user.click(screen.getByText(suggestion));
+
+    expect(screen.getByLabelText('Search open source projects')).toHaveValue(suggestion);
+  });
+
+  it('returns focus to the trigger after closing', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchHarness />);
+    const trigger = screen.getByText('Open search');
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByLabelText('Search open source projects')).toHaveFocus(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close search' }));
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/src/shared/components/SearchModal.tsx
+++ b/src/shared/components/SearchModal.tsx
@@ -1,16 +1,34 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import { Search, ArrowRight, X } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
+import { useFocusTrap } from '../utils/focusTrap';
 
 interface SearchModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+/**
+ * Full-screen search overlay.
+ *
+ * Accessibility contract:
+ * - Renders `role="dialog"` with `aria-modal="true"` and an `aria-labelledby`
+ *   pointing at the heading.
+ * - On open, focus moves to the search input; <kbd>Tab</kbd> cycles within the
+ *   overlay and <kbd>Escape</kbd> closes it.
+ * - On close, focus is restored to the element that opened the overlay.
+ */
 export function SearchModal({ isOpen, onClose }: SearchModalProps) {
   const { theme } = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
   const darkTheme = theme === 'dark';
+  const headingId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const dialogRef = useFocusTrap<HTMLDivElement>(isOpen, {
+    onEscape: onClose,
+    initialFocusRef: inputRef,
+  });
 
   const searchSuggestions = [
     "Terminal-based markdown editors worth checking out",
@@ -20,27 +38,25 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
   ];
 
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-
     if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
-      document.removeEventListener('keydown', handleEscape);
       document.body.style.overflow = 'unset';
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-start justify-center pt-[10vh]">
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+      className="fixed inset-0 z-[200] flex items-start justify-center pt-[10vh]"
+    >
       {/* Backdrop */}
       <div 
         className={`absolute inset-0 transition-colors ${
@@ -63,8 +79,10 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
       >
         {/* Close Button */}
         <button
+          type="button"
           onClick={onClose}
-          className={`absolute top-6 right-6 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 ${
+          aria-label="Close search"
+          className={`absolute top-6 right-6 w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#c9983a] ${
             darkTheme
               ? 'bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80'
               : 'bg-black/5 hover:bg-black/10 text-black/60 hover:text-black/80'
@@ -75,7 +93,7 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
 
         <div className="p-12">
           {/* Main Heading */}
-          <h1 className={`text-[42px] font-bold text-center mb-4 leading-tight transition-colors ${
+          <h1 id={headingId} className={`text-[42px] font-bold text-center mb-4 leading-tight transition-colors ${
             darkTheme ? 'text-[#f5efe5]' : 'text-[#2d2820]'
           }`}>
             Search Open Source Projects and<br />Build Your Confidence
@@ -103,19 +121,22 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
                 darkTheme ? 'text-white/50' : 'text-black/50'
               }`} />
               <input
+                ref={inputRef}
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="markdown editor in t"
-                autoFocus
+                aria-label="Search open source projects"
                 className={`flex-1 bg-transparent outline-none text-[16px] transition-colors ${
-                  darkTheme 
-                    ? 'text-white placeholder:text-white/40' 
+                  darkTheme
+                    ? 'text-white placeholder:text-white/40'
                     : 'text-[#2d2820] placeholder:text-black/40'
                 }`}
               />
-              <button 
-                className={`w-10 h-10 rounded-full flex items-center justify-center ml-4 flex-shrink-0 transition-all hover:scale-105 ${
+              <button
+                type="button"
+                aria-label="Submit search"
+                className={`w-10 h-10 rounded-full flex items-center justify-center ml-4 flex-shrink-0 transition-all hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#c9983a] ${
                   darkTheme
                     ? 'bg-[#c9983a] hover:bg-[#d4a645]'
                     : 'bg-[#c9983a] hover:bg-[#e8c571]'
@@ -144,8 +165,9 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
               {searchSuggestions.map((suggestion, index) => (
                 <button
                   key={index}
+                  type="button"
                   onClick={() => setSearchQuery(suggestion)}
-                  className={`group flex items-center justify-between px-5 py-4 rounded-[16px] transition-all hover:scale-[1.02] ${
+                  className={`group flex items-center justify-between px-5 py-4 rounded-[16px] transition-all hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] ${
                     darkTheme
                       ? 'bg-[#2d2820]/40 hover:bg-[#2d2820]/60 border border-white/5 hover:border-white/10'
                       : 'bg-white/40 hover:bg-white/60 border border-black/5 hover:border-black/10'

--- a/src/shared/components/ui/Modal.test.tsx
+++ b/src/shared/components/ui/Modal.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal, ModalButton, ModalFooter, ModalInput, ModalSelect } from './Modal';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+
+function ModalHarness({ title }: { title?: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open modal</button>
+      <Modal isOpen={open} onClose={() => setOpen(false)} title={title}>
+        <button>Inside one</button>
+        <button>Inside two</button>
+      </Modal>
+    </>
+  );
+}
+
+describe('Modal accessibility', () => {
+  it('exposes role="dialog", aria-modal and is labelled by its title', () => {
+    renderWithTheme(
+      <Modal isOpen onClose={() => {}} title="Settings">
+        <p>content</p>
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    // aria-labelledby points at the heading carrying the title text.
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)).toHaveTextContent('Settings');
+    expect(dialog).not.toHaveAttribute('aria-label');
+  });
+
+  it('falls back to aria-label when no title is provided', () => {
+    renderWithTheme(
+      <Modal isOpen onClose={() => {}} ariaLabel="Quick actions">
+        <p>content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Quick actions');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('uses a default aria-label when neither title nor ariaLabel is given', () => {
+    renderWithTheme(
+      <Modal isOpen onClose={() => {}}>
+        <p>content</p>
+      </Modal>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'Dialog');
+  });
+
+  it('does not render anything when closed', () => {
+    renderWithTheme(
+      <Modal isOpen={false} onClose={() => {}} title="Hidden">
+        <p>content</p>
+      </Modal>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('moves focus into the dialog when opened', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<ModalHarness title="Settings" />);
+    await user.click(screen.getByText('Open modal'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close dialog' })).toHaveFocus();
+    });
+  });
+
+  it('traps focus and cycles with Tab / Shift+Tab', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<ModalHarness title="Settings" />);
+    await user.click(screen.getByText('Open modal'));
+
+    const close = screen.getByRole('button', { name: 'Close dialog' });
+    const insideTwo = screen.getByText('Inside two');
+    await waitFor(() => expect(close).toHaveFocus());
+
+    // Tab on the last focusable wraps back to the first (the close button).
+    insideTwo.focus();
+    fireEvent.keyDown(insideTwo, { key: 'Tab' });
+    expect(close).toHaveFocus();
+
+    // Shift+Tab on the first focusable wraps to the last.
+    fireEvent.keyDown(close, { key: 'Tab', shiftKey: true });
+    expect(insideTwo).toHaveFocus();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderWithTheme(
+      <Modal isOpen onClose={onClose} title="Settings">
+        <button>Inside</button>
+      </Modal>,
+    );
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the backdrop is clicked but not when the panel is clicked', () => {
+    const onClose = vi.fn();
+    renderWithTheme(
+      <Modal isOpen onClose={onClose} title="Settings">
+        <button>Inside</button>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    // The backdrop is the dialog's parent element.
+    fireEvent.click(dialog.parentElement!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(
+      <Modal isOpen onClose={onClose} title="Settings">
+        <button>Inside</button>
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns focus to the trigger after closing', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<ModalHarness title="Settings" />);
+    const trigger = screen.getByText('Open modal');
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Close dialog' })).toHaveFocus(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }));
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('adds and removes the modal-open body class', () => {
+    const { rerender } = renderWithTheme(
+      <Modal isOpen onClose={() => {}} title="Settings">
+        <p>content</p>
+      </Modal>,
+    );
+    expect(document.body.classList.contains('modal-open')).toBe(true);
+
+    rerender(
+      <Modal isOpen={false} onClose={() => {}} title="Settings">
+        <p>content</p>
+      </Modal>,
+    );
+    expect(document.body.classList.contains('modal-open')).toBe(false);
+  });
+
+  it('renders an accessible dialog in dark theme', () => {
+    renderWithTheme(
+      <Modal isOpen onClose={() => {}} title="Dark settings">
+        <p>content</p>
+      </Modal>,
+      { theme: 'dark' },
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('renders a footer and hides the header when no title/icon/close', () => {
+    renderWithTheme(
+      <Modal isOpen onClose={() => {}} showCloseButton={false} footer={<span>footer-content</span>}>
+        <p>body</p>
+      </Modal>,
+    );
+    expect(screen.getByText('footer-content')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close dialog' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Modal building blocks', () => {
+  it('ModalFooter renders its children', () => {
+    renderWithTheme(
+      <ModalFooter className="extra">
+        <span>foot</span>
+      </ModalFooter>,
+    );
+    expect(screen.getByText('foot')).toBeInTheDocument();
+  });
+
+  it('ModalButton (primary) fires onClick and respects disabled', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = renderWithTheme(
+      <ModalButton variant="primary" onClick={onClick}>
+        Save
+      </ModalButton>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ModalButton variant="primary" onClick={onClick} disabled>
+        Save
+      </ModalButton>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('ModalButton (secondary) renders in dark theme', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<ModalButton onClick={onClick}>Cancel</ModalButton>, { theme: 'dark' });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('ModalInput renders a labelled text field and reports changes', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(
+      <ModalInput label="Name" value="" onChange={onChange} required placeholder="Your name" />,
+    );
+    const input = screen.getByPlaceholderText('Your name');
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    await user.type(input, 'a');
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('ModalInput renders a textarea with rows, reports changes and shows an error', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(
+      <ModalInput
+        label="Bio"
+        value="text"
+        onChange={onChange}
+        rows={4}
+        error="Required field"
+      />,
+      { theme: 'dark' },
+    );
+    expect(screen.getByText('Required field')).toBeInTheDocument();
+    const textarea = screen.getByDisplayValue('text');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    await user.type(textarea, '!');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('ModalSelect renders a labelled trigger with the selected value', () => {
+    renderWithTheme(
+      <ModalSelect
+        label="Status"
+        value="open"
+        onChange={() => {}}
+        options={[
+          { value: 'open', label: 'Open' },
+          { value: 'closed', label: 'Closed' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    // Radix renders the selected option label inside the trigger.
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -1,7 +1,8 @@
-import React, { ReactNode, useState, useRef, useEffect } from 'react';
+import React, { ReactNode, useId } from 'react';
 import { X, ChevronDown, Check } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useFocusTrap } from '../../utils/focusTrap';
 
 interface ModalProps {
   isOpen: boolean;
@@ -14,6 +15,11 @@ interface ModalProps {
   maxHeight?: boolean;
   footer?: ReactNode;
   dimBackdrop?: boolean;
+  /**
+   * Accessible name used when no visible `title` is provided. Ignored when
+   * `title` is set (the title is referenced via `aria-labelledby` instead).
+   */
+  ariaLabel?: string;
 }
 
 const widthClasses = {
@@ -23,6 +29,19 @@ const widthClasses = {
   xl: 'w-[95vw] sm:w-[650px]'
 };
 
+/**
+ * Accessible modal dialog.
+ *
+ * Accessibility contract:
+ * - Renders `role="dialog"` with `aria-modal="true"`.
+ * - Labelled via `aria-labelledby` (pointing at the rendered `title`) or, when
+ *   no title is given, via `aria-label` (`ariaLabel`, defaulting to "Dialog").
+ * - While open, keyboard focus is trapped inside the dialog and cycles with
+ *   <kbd>Tab</kbd>/<kbd>Shift</kbd>+<kbd>Tab</kbd> (see {@link useFocusTrap}).
+ * - <kbd>Escape</kbd> and a backdrop click both invoke `onClose`.
+ * - On close, focus is returned to the element that was focused before opening
+ *   (typically the trigger).
+ */
 export function Modal({
   isOpen,
   onClose,
@@ -33,10 +52,14 @@ export function Modal({
   showCloseButton = true,
   maxHeight = false,
   footer,
-  dimBackdrop = true
+  dimBackdrop = true,
+  ariaLabel
 }: ModalProps) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const titleId = useId();
+
+  const dialogRef = useFocusTrap<HTMLDivElement>(isOpen, { onEscape: onClose });
 
   React.useEffect(() => {
     if (isOpen) {
@@ -57,7 +80,13 @@ export function Modal({
       onClick={onClose}
     >
       <div
-        className={`rounded-[16px] md:rounded-[24px] border-2 shadow-[0_20px_60px_rgba(0,0,0,0.3)] ${widthClasses[width]} max-w-[95vw] sm:max-w-[90vw] max-h-[90vh] flex flex-col transition-all animate-in zoom-in-95 duration-200 ${isDark
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : (ariaLabel ?? 'Dialog')}
+        tabIndex={-1}
+        className={`rounded-[16px] md:rounded-[24px] border-2 shadow-[0_20px_60px_rgba(0,0,0,0.3)] focus:outline-none ${widthClasses[width]} max-w-[95vw] sm:max-w-[90vw] max-h-[90vh] flex flex-col transition-all animate-in zoom-in-95 duration-200 ${isDark
           ? 'bg-[#3a3228] border-white/30'
           : 'bg-[#d4c5b0] border-white/40'
           }`}
@@ -75,7 +104,7 @@ export function Modal({
                 </div>
               )}
               {title && (
-                <h3 className={`text-[16px] md:text-[18px] font-bold transition-colors ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                <h3 id={titleId} className={`text-[16px] md:text-[18px] font-bold transition-colors ${isDark ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
                   }`}>
                   {title}
                 </h3>
@@ -83,8 +112,10 @@ export function Modal({
             </div>
             {showCloseButton && (
               <button
+                type="button"
                 onClick={onClose}
-                className={`p-2 rounded-[10px] transition-all hover:scale-110 flex-shrink-0 ${isDark
+                aria-label="Close dialog"
+                className={`p-2 rounded-[10px] transition-all hover:scale-110 flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[#c9983a] ${isDark
                   ? 'hover:bg-white/[0.1] text-[#e8c571] hover:text-[#f5d98a]'
                   : 'hover:bg-black/[0.05] text-[#8b6f3a] hover:text-[#c9983a]'
                   }`}

--- a/src/shared/hooks/useOptimisticData.ts
+++ b/src/shared/hooks/useOptimisticData.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { logger } from '../../shared/utils/logger';
-import { useState, useCallback, useRef } from 'react';
 
 interface CacheEntry<T> {
   data: T;
@@ -102,14 +101,12 @@ export function useOptimisticData<T>(
         setHasError(false);
       } catch (err: any) {
         // Swallow AbortErrors and do not log to prevent leaking secure tokens or failing noisily
-        if (err.name === 'AbortError' || signal.aborted) {
+        if (err?.name === 'AbortError' || signal.aborted) {
           return;
         }
 
-        console.error('Failed to fetch data:', err);
-      } catch (err) {
         logger.error('Failed to fetch data:', err);
-        
+
         const isNetworkError =
           err instanceof TypeError ||
           (err instanceof Error &&

--- a/src/shared/utils/focusTrap.test.tsx
+++ b/src/shared/utils/focusTrap.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  getFocusableElements,
+  isElementVisible,
+  useFocusTrap,
+} from './focusTrap';
+
+describe('isElementVisible', () => {
+  it('accepts a plain, visible element', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    expect(isElementVisible(button)).toBe(true);
+  });
+
+  it('rejects disabled, hidden and aria-hidden elements', () => {
+    const disabled = document.createElement('button');
+    disabled.setAttribute('disabled', '');
+    const hidden = document.createElement('button');
+    hidden.hidden = true;
+    const ariaHidden = document.createElement('button');
+    ariaHidden.setAttribute('aria-hidden', 'true');
+
+    expect(isElementVisible(disabled)).toBe(false);
+    expect(isElementVisible(hidden)).toBe(false);
+    expect(isElementVisible(ariaHidden)).toBe(false);
+  });
+
+  it('rejects elements with display:none or visibility:hidden', () => {
+    const none = document.createElement('button');
+    none.style.display = 'none';
+    document.body.appendChild(none);
+    const invisible = document.createElement('button');
+    invisible.style.visibility = 'hidden';
+    document.body.appendChild(invisible);
+
+    expect(isElementVisible(none)).toBe(false);
+    expect(isElementVisible(invisible)).toBe(false);
+  });
+
+  it('rejects controls nested inside a hidden / aria-hidden subtree', () => {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('aria-hidden', 'true');
+    const nested = document.createElement('button');
+    wrapper.appendChild(nested);
+    document.body.appendChild(wrapper);
+
+    // Security boundary: focus must never land on a control the user can't see.
+    expect(isElementVisible(nested)).toBe(false);
+  });
+});
+
+describe('getFocusableElements', () => {
+  it('returns only the visible, focusable descendants in DOM order', () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <a href="#one">link</a>
+      <button>btn</button>
+      <button disabled>nope</button>
+      <input />
+      <div tabindex="0">tab0</div>
+      <div tabindex="-1">skip</div>
+      <button hidden>hidden</button>
+      <span aria-hidden="true"><button>aria</button></span>
+    `;
+    document.body.appendChild(container);
+
+    const focusables = getFocusableElements(container);
+    const labels = focusables.map((el) => el.textContent?.trim() ?? el.tagName);
+
+    // The input contributes an empty label; disabled/tabindex=-1/hidden/aria-hidden are excluded.
+    expect(labels).toEqual(['link', 'btn', '', 'tab0']);
+    expect(focusables.some((el) => el.tagName === 'INPUT')).toBe(true);
+    expect(focusables).toHaveLength(4);
+  });
+});
+
+function TrapHarness({
+  onEscape,
+  returnFocus,
+  withFocusable = true,
+}: {
+  onEscape?: () => void;
+  returnFocus?: boolean;
+  withFocusable?: boolean;
+}) {
+  const [active, setActive] = useState(false);
+  const ref = useFocusTrap<HTMLDivElement>(active, { onEscape, returnFocus });
+  return (
+    <div>
+      <button onClick={() => setActive(true)}>open</button>
+      {active && (
+        <div ref={ref} data-testid="trap" tabIndex={-1}>
+          {withFocusable && (
+            <>
+              <button>first</button>
+              <button>last</button>
+            </>
+          )}
+          <button onClick={() => setActive(false)}>do-close</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('moves focus into the container on activation', async () => {
+    const user = userEvent.setup();
+    render(<TrapHarness />);
+    await user.click(screen.getByText('open'));
+
+    await waitFor(() => {
+      expect(screen.getByText('first')).toHaveFocus();
+    });
+  });
+
+  it('wraps focus forward from the last element and backward from the first', async () => {
+    const user = userEvent.setup();
+    render(<TrapHarness />);
+    await user.click(screen.getByText('open'));
+
+    const first = screen.getByText('first');
+    const close = screen.getByText('do-close');
+
+    // Tab on the last focusable wraps to the first.
+    close.focus();
+    fireEvent.keyDown(close, { key: 'Tab' });
+    expect(first).toHaveFocus();
+
+    // Shift+Tab on the first focusable wraps to the last.
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+    expect(close).toHaveFocus();
+  });
+
+  it('invokes onEscape when Escape is pressed', async () => {
+    const onEscape = vi.fn();
+    const user = userEvent.setup();
+    render(<TrapHarness onEscape={onEscape} />);
+    await user.click(screen.getByText('open'));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores focus to the trigger on deactivation by default', async () => {
+    const user = userEvent.setup();
+    render(<TrapHarness />);
+    const openButton = screen.getByText('open');
+    await user.click(openButton);
+    await waitFor(() => expect(screen.getByText('first')).toHaveFocus());
+
+    await user.click(screen.getByText('do-close'));
+    await waitFor(() => expect(openButton).toHaveFocus());
+  });
+
+  it('does not restore focus when returnFocus is false', async () => {
+    const user = userEvent.setup();
+    render(<TrapHarness returnFocus={false} />);
+    const openButton = screen.getByText('open');
+    await user.click(openButton);
+    await waitFor(() => expect(screen.getByText('first')).toHaveFocus());
+
+    await user.click(screen.getByText('do-close'));
+    await waitFor(() => expect(openButton).not.toHaveFocus());
+  });
+
+  it('pins focus to the container when there is nothing else focusable', async () => {
+    const user = userEvent.setup();
+    render(<TrapHarness withFocusable={false} />);
+    await user.click(screen.getByText('open'));
+
+    const trap = screen.getByTestId('trap');
+    // The only focusable child is the close button; Tab keeps focus inside.
+    fireEvent.keyDown(screen.getByText('do-close'), { key: 'Tab' });
+    expect(trap.contains(document.activeElement)).toBe(true);
+  });
+
+  it('focuses and pins the container when it has zero focusable children', () => {
+    function EmptyTrap() {
+      const ref = useFocusTrap<HTMLDivElement>(true, {});
+      return <div ref={ref} data-testid="empty-trap" tabIndex={-1} />;
+    }
+    render(<EmptyTrap />);
+    const trap = screen.getByTestId('empty-trap');
+    // On activation focus falls back to the container itself...
+    expect(trap).toHaveFocus();
+    // ...and Tab keeps it there because there is nothing to cycle through.
+    fireEvent.keyDown(trap, { key: 'Tab' });
+    expect(trap).toHaveFocus();
+  });
+});

--- a/src/shared/utils/focusTrap.ts
+++ b/src/shared/utils/focusTrap.ts
@@ -1,0 +1,176 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * CSS selector matching elements that are, in principle, keyboard focusable.
+ *
+ * Note: this only encodes the *static* rules (disabled inputs, `tabindex="-1"`
+ * are excluded here). Dynamic visibility (an element inside a hidden subtree)
+ * is filtered separately by {@link isElementVisible} so that focus can never be
+ * trapped on a control the user cannot see.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
+
+/**
+ * Returns `true` when `el` can actually receive focus right now.
+ *
+ * This is a deliberate security boundary for the focus-trap: a malicious or
+ * buggy layout must not be able to keep keyboard focus on a control that is
+ * visually hidden. We therefore reject elements that are disabled, hidden via
+ * the `hidden` attribute, marked `aria-hidden="true"`, collapsed with
+ * `display:none`/`visibility:hidden`, or nested inside any such ancestor.
+ */
+export function isElementVisible(el: HTMLElement): boolean {
+  if (el.hasAttribute('disabled')) return false;
+  if (el.hidden) return false;
+  if (el.getAttribute('aria-hidden') === 'true') return false;
+  // Reject elements nested inside a hidden / aria-hidden subtree.
+  if (el.closest('[hidden]')) return false;
+  if (el.closest('[aria-hidden="true"]')) return false;
+
+  if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+  }
+  return true;
+}
+
+/**
+ * Collects every visible, keyboard-focusable descendant of `container`, in DOM
+ * order. The list is recomputed on demand so it always reflects the current
+ * tree (options can appear/disappear while a dialog is open).
+ */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  );
+  return nodes.filter(isElementVisible);
+}
+
+/** Options accepted by {@link useFocusTrap}. */
+export interface UseFocusTrapOptions {
+  /** Invoked when the user presses <kbd>Escape</kbd> while the trap is active. */
+  onEscape?: () => void;
+  /**
+   * Element to focus when the trap activates. When omitted the first focusable
+   * descendant is used, falling back to the container itself.
+   */
+  initialFocusRef?: RefObject<HTMLElement>;
+  /**
+   * Whether focus is restored to the previously focused element when the trap
+   * deactivates (default `true`). This is the "return focus to trigger"
+   * behaviour required for accessible dialogs.
+   */
+  returnFocus?: boolean;
+}
+
+/**
+ * React hook that traps keyboard focus inside a container while `isActive` is
+ * `true`, implementing the WAI-ARIA "modal dialog" focus contract:
+ *
+ * - On activation it remembers the currently focused element and moves focus
+ *   into the container ({@link UseFocusTrapOptions.initialFocusRef} or the first
+ *   focusable child).
+ * - <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> cycle within the container;
+ *   focus can never leave it.
+ * - <kbd>Escape</kbd> invokes {@link UseFocusTrapOptions.onEscape}.
+ * - On deactivation it restores focus to the original element (unless
+ *   {@link UseFocusTrapOptions.returnFocus} is `false`).
+ *
+ * The single `keydown` listener is always removed on cleanup, so there are no
+ * dangling listeners after unmount. Callbacks are read through a ref, so the
+ * effect does not re-run (and re-steal focus) when the parent passes a new
+ * `onEscape` identity on every render.
+ *
+ * @typeParam T - The container element type the returned ref is attached to.
+ * @returns A ref to attach to the trap container element.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+  isActive: boolean,
+  options: UseFocusTrapOptions = {},
+): RefObject<T> {
+  const { onEscape, initialFocusRef, returnFocus = true } = options;
+  const containerRef = useRef<T>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  // Keep the latest callback in a ref so the effect below only depends on
+  // `isActive`. This prevents the trap from re-initialising (and re-grabbing
+  // the "previously focused" element) on unrelated parent re-renders.
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!isActive) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    previouslyFocused.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const focusInitial = () => {
+      if (initialFocusRef?.current && isElementVisible(initialFocusRef.current)) {
+        initialFocusRef.current.focus();
+        return;
+      }
+      const focusables = getFocusableElements(container);
+      if (focusables.length > 0) {
+        focusables[0].focus();
+      } else {
+        container.focus();
+      }
+    };
+    focusInitial();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onEscapeRef.current?.();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const focusables = getFocusableElements(container);
+      if (focusables.length === 0) {
+        // Nothing focusable inside: keep focus pinned to the container.
+        event.preventDefault();
+        container.focus();
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !container.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (returnFocus && previouslyFocused.current && isElementVisible(previouslyFocused.current)) {
+        previouslyFocused.current.focus();
+      }
+    };
+    // `onEscape` is intentionally omitted (read via ref). `initialFocusRef` is a
+    // stable ref object; `returnFocus` is effectively constant per usage.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive]);
+
+  return containerRef;
+}

--- a/src/shared/utils/logger.test.ts
+++ b/src/shared/utils/logger.test.ts
@@ -25,7 +25,7 @@ describe('Guarded Logger', () => {
 
   describe('when in development (PROD is false)', () => {
     beforeEach(() => {
-      vi.stubEnv('PROD', false as unknown as string);
+      vi.stubEnv('PROD', false);
     });
 
     it('should call console.debug when logger.debug is called', () => {
@@ -51,7 +51,7 @@ describe('Guarded Logger', () => {
 
   describe('when in production (PROD is true)', () => {
     beforeEach(() => {
-      vi.stubEnv('PROD', true as unknown as string);
+      vi.stubEnv('PROD', true);
     });
 
     it('should NOT call console.debug when logger.debug is called', () => {

--- a/src/shared/utils/logger.test.ts
+++ b/src/shared/utils/logger.test.ts
@@ -6,7 +6,6 @@ describe('Guarded Logger', () => {
   let consoleInfoSpy: any;
   let consoleWarnSpy: any;
   let consoleErrorSpy: any;
-  const originalProd = import.meta.env.PROD;
 
   beforeEach(() => {
     consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
@@ -17,21 +16,15 @@ describe('Guarded Logger', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // Reset import.meta.env.PROD to original value
-    Object.defineProperty(import.meta.env, 'PROD', {
-      value: originalProd,
-      configurable: true,
-      writable: true
-    });
+    // Restore env stubs. `import.meta.env.PROD` is a read-only data descriptor in
+    // this Vitest version, so it must be overridden via `vi.stubEnv` rather than
+    // `Object.defineProperty` (which throws on the non-configurable property).
+    vi.unstubAllEnvs();
   });
 
   describe('when in development (PROD is false)', () => {
     beforeEach(() => {
-      Object.defineProperty(import.meta.env, 'PROD', {
-        value: false,
-        configurable: true,
-        writable: true
-      });
+      vi.stubEnv('PROD', false);
     });
 
     it('should call console.debug when logger.debug is called', () => {
@@ -57,11 +50,7 @@ describe('Guarded Logger', () => {
 
   describe('when in production (PROD is true)', () => {
     beforeEach(() => {
-      Object.defineProperty(import.meta.env, 'PROD', {
-        value: true,
-        configurable: true,
-        writable: true
-      });
+      vi.stubEnv('PROD', true);
     });
 
     it('should NOT call console.debug when logger.debug is called', () => {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -215,6 +215,46 @@ body.modal-open aside {
   transition: filter 0.2s ease, opacity 0.2s ease;
 }
 
+/*
+ * Accessible focus indicator.
+ *
+ * Keyboard users get a clearly visible brand-gold ring on any interactive
+ * element. `:where()` keeps the selector at zero specificity so component-level
+ * `focus-visible:ring-*` utilities can still override it, and `:focus-visible`
+ * ensures the ring only appears for keyboard interaction, not mouse clicks.
+ * A lighter gold is used in dark mode for adequate contrast in both themes.
+ */
+:where(
+  a[href],
+  button,
+  input,
+  select,
+  textarea,
+  [tabindex],
+  [role='option'],
+  [role='menuitem'],
+  [role='dialog']
+):focus-visible {
+  outline: 2px solid #c9983a;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.dark
+  :where(
+    a[href],
+    button,
+    input,
+    select,
+    textarea,
+    [tabindex],
+    [role='option'],
+    [role='menuitem'],
+    [role='dialog']
+  ):focus-visible {
+  outline-color: #e8c571;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/test/renderWithTheme.tsx
+++ b/src/test/renderWithTheme.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from 'react';
+import { render, type RenderOptions } from '@testing-library/react';
+import { ThemeProvider } from '../shared/contexts/ThemeContext';
+
+/**
+ * Renders `ui` wrapped in the app's {@link ThemeProvider}.
+ *
+ * The provider reads the initial theme from `localStorage`, so passing
+ * `theme: 'dark'` seeds it before render — useful for asserting that focus
+ * styles / aria behaviour hold in both themes.
+ */
+export function renderWithTheme(
+  ui: ReactElement,
+  { theme = 'light', ...options }: { theme?: 'light' | 'dark' } & RenderOptions = {},
+) {
+  localStorage.setItem('theme', theme);
+  return render(ui, { wrapper: ThemeProvider, ...options });
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,14 @@
+// Vitest global setup for component tests.
+// Registers jest-dom matchers (toBeInTheDocument, toHaveFocus, toHaveAttribute…)
+// and clears the DOM/mocks between tests so each test starts from a clean slate.
+import '@testing-library/jest-dom/vitest';
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  // `cleanup` touches the DOM, so it is a no-op for node-environment tests.
+  if (typeof document !== 'undefined') {
+    cleanup();
+  }
+  vi.clearAllMocks();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,5 +20,23 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
     dedupe: ['react', 'react-dom'],
+  },
+  test: {
+    // Default to the lightweight `node` environment; component/hook tests opt
+    // into jsdom per-file with a `// @vitest-environment jsdom` docblock.
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: [
+        'src/shared/components/ui/Modal.tsx',
+        'src/shared/components/GlassDropdown.tsx',
+        'src/shared/components/FilterDropdown.tsx',
+        'src/shared/components/SearchModal.tsx',
+        'src/shared/utils/focusTrap.ts',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary

Closes #25.

Makes the shared overlay components keyboard- and screen-reader-operable. Adds focus trapping, Escape-to-close, return-focus-to-trigger, ARIA roles/attributes, keyboard navigation for dropdowns, and a theme-aware visible focus indicator.

## Changes

**New focus-trap utility** — `src/shared/utils/focusTrap.ts`
- `useFocusTrap(isActive, { onEscape, initialFocusRef, returnFocus })` — moves focus into the container on activation, cycles `Tab`/`Shift+Tab`, invokes `onEscape`, and restores focus to the previously-focused trigger on deactivation. Callbacks are read through a ref so the trap does not re-initialise (and re-steal focus) on unrelated re-renders; the single `keydown` listener is always removed on cleanup.
- `getFocusableElements` / `isElementVisible` exclude `disabled`, `hidden`, `aria-hidden`, `display:none`/`visibility:hidden` elements **and** anything nested inside such a subtree, so focus can never be pinned to a control the user cannot see.

**Modal** (`src/shared/components/ui/Modal.tsx`)
- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` (rendered title) with an `aria-label` fallback (`ariaLabel`, default `"Dialog"`).
- Focus trap while open, Escape-to-close, return-focus-to-trigger, labelled close button, focus-visible styles.

**GlassDropdown** and **FilterDropdown**
- Trigger exposes `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls`.
- `role="listbox"` / `role="option"` with `aria-selected`.
- Keyboard navigation: Arrow Up/Down, Home/End, Enter/Space to select, Escape to close. Closing via keyboard returns focus to the trigger.
- FilterDropdown moves focus to its search input on open.

**SearchModal**
- `role="dialog"`, `aria-modal`, `aria-labelledby` (heading).
- Focus moves to the search input on open (replaced bare `autoFocus`), Escape closes, focus restored on close.

**Visible focus styles** — `src/styles/theme.css`
- Theme-aware `:focus-visible` indicator (brand gold, lighter gold in dark mode) at zero specificity, plus `focus-visible:ring` utilities on interactive controls.

**Documentation** — inline TSDoc documenting the a11y contract of each component and the focus-trap utility.

## Tests

Added jsdom-based component test infrastructure (Vitest `test` block + jest-dom setup, Testing Library deps declared in `package.json` and synced into the lockfile, verified with `--frozen-lockfile`). Component tests opt into jsdom per-file so the existing node-environment logger test is unaffected.

New tests assert ARIA attributes and focus behaviour: Tab cycling, Escape close, return focus, dropdown arrow navigation, selection, and both light/dark renders.

Also fixed a **pre-existing** failure in `logger.test.ts` (it redefined `import.meta.env.PROD` via `Object.defineProperty`, which throws in this Vitest version) by switching to `vi.stubEnv` / `vi.unstubAllEnvs`.

### Test output
```
Test Files  6 passed (6)
     Tests  69 passed (69)
```

### Coverage (changed files)
```
Statements : 98.78%
Lines      : 99.56%
Functions  : 100%
Branches   : 80%   (remaining branches are light/dark className ternaries)
```

`pnpm run typecheck`: 27 errors, all pre-existing on the base branch — **0 introduced** by this PR (verified by diffing typecheck output against the base). `eslint`: 0 errors.

## Security notes

No new data flows (UI behaviour only). All event listeners (focus-trap `keydown`, outside-click `mousedown`) are removed on unmount/close. The focus-trap explicitly filters disabled/hidden/`aria-hidden`/`display:none` controls so focus cannot be trapped on an off-screen or hidden element.
