### PR TITLE
fix: add aria-current to dashboard nav links for accessibility

### DIFF
--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -285,6 +285,7 @@ export function DashboardLayout() {
                   <Link
                     key={item.id}
                     to={item.path}
+                    aria-current={isActive ? "page" : undefined}
                     className={`group w-full flex items-center rounded-[12px] transition-all duration-300 ${
                       isSidebarCollapsed
                         ? "justify-center px-0 h-[49px]"


### PR DESCRIPTION
Adds `aria-current="page"` to the active dashboard navigation link in `DashboardLayout.tsx`. Ensures screen readers can identify the current page.\n\nCloses #49