### PR TITLE
fix: respect prefers-reduced-motion in FallingPetals animation

### DIFF
--- a/src/features/leaderboard/components/FallingPetals.tsx
+++ b/src/features/leaderboard/components/FallingPetals.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Petal } from '../types';
 
 interface FallingPetalsProps {
@@ -5,6 +6,18 @@ interface FallingPetalsProps {
 }
 
 export function FallingPetals({ petals }: FallingPetalsProps) {
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  if (reducedMotion) return null;
+
   return (
     <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none z-10 overflow-hidden">
       {petals.map((petal) => (
@@ -18,7 +31,6 @@ export function FallingPetals({ petals }: FallingPetalsProps) {
             transform: `scale(${petal.size})`,
           }}
         >
-          {/* Golden Flower Petal */}
           <svg
             width="24"
             height="24"

--- a/src/features/leaderboard/components/LeaderboardStyles.tsx
+++ b/src/features/leaderboard/components/LeaderboardStyles.tsx
@@ -171,6 +171,13 @@ export function LeaderboardStyles() {
         animation: falling linear infinite;
       }
       
+      @media (prefers-reduced-motion: reduce) {
+        .falling-petal {
+          animation: none;
+          display: none;
+        }
+      }
+      
       @keyframes ray-rotate {
         0%, 100% { transform: rotate(0deg); }
         50% { transform: rotate(360deg); }


### PR DESCRIPTION
Adds a reduced-motion check to the FallingPetals component so it renders nothing when the user has `prefers-reduced-motion: reduce` enabled.\n\nCloses #47