### PR TITLE
fix: add keyboard and screen-reader support to toggle and filter controls

### DIFF
--- a/src/features/leaderboard/components/FiltersSection.tsx
+++ b/src/features/leaderboard/components/FiltersSection.tsx
@@ -1,5 +1,5 @@
 import { logger } from '../../../shared/utils/logger';
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { ChevronDown } from "lucide-react";
 import { useTheme } from "../../../shared/contexts/ThemeContext";
 import { getEcosystems } from "../../../shared/api/client";
@@ -99,11 +99,17 @@ export function FiltersSection({
         {/* Filter Dropdown Button */}
         <div className="relative z-[100]">
           <button
+            aria-haspopup="listbox"
+            aria-expanded={showFilterDropdown}
             onClick={() => {
               setShowFilterDropdown(!showFilterDropdown);
-              // Close ecosystem dropdown if it's open
               if (showDropdown) {
                 onToggleDropdown();
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape' && showFilterDropdown) {
+                setShowFilterDropdown(false);
               }
             }}
             className={`flex items-center gap-2 px-4 py-2.5 rounded-[12px] backdrop-blur-[30px] border hover:scale-105 transition-all duration-300 ${
@@ -126,12 +132,18 @@ export function FiltersSection({
             />
           </button>
           {showFilterDropdown && (
-            <div className={`absolute right-0 mt-2 w-[220px] border-2 border-white/30 rounded-[12px] shadow-[0_8px_32px_rgba(0,0,0,0.15)] overflow-hidden z-[100] animate-dropdown-in ${
-              theme === "dark" ? "bg-[#2d2820]/95" : "bg-white/95"
-            }`}>
+            <div
+              role="listbox"
+              aria-label="Filter options"
+              className={`absolute right-0 mt-2 w-[220px] border-2 border-white/30 rounded-[12px] shadow-[0_8px_32px_rgba(0,0,0,0.15)] overflow-hidden z-[100] animate-dropdown-in ${
+                theme === "dark" ? "bg-[#2d2820]/95" : "bg-white/95"
+              }`}
+            >
               {filterOptions.map((option) => (
                 <button
                   key={option.value}
+                  role="option"
+                  aria-selected={activeFilter === option.value}
                   onClick={() => {
                     onFilterChange(option.value);
                     setShowFilterDropdown(false);
@@ -152,11 +164,17 @@ export function FiltersSection({
         {/* Ecosystem Dropdown Button */}
         <div className="relative z-[100]">
           <button
+            aria-haspopup="listbox"
+            aria-expanded={showDropdown}
             onClick={() => {
               onToggleDropdown();
-              // Close filter dropdown if it's open
               if (showFilterDropdown) {
                 setShowFilterDropdown(false);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape' && showDropdown) {
+                onToggleDropdown();
               }
             }}
             className={`flex items-center gap-2 px-4 py-2.5 rounded-[12px] backdrop-blur-[30px] border hover:scale-105 transition-all duration-300 ${
@@ -179,9 +197,13 @@ export function FiltersSection({
             />
           </button>
           {showDropdown && (
-            <div className={`absolute right-0 mt-2 w-[200px] border-2 border-white/30 rounded-[12px] shadow-[0_8px_32px_rgba(0,0,0,0.15)] overflow-hidden z-[100] animate-dropdown-in ${
-              theme === "dark" ? "bg-[#2d2820]/95" : "bg-white/95"
-            }`}>
+            <div
+              role="listbox"
+              aria-label="Ecosystems"
+              className={`absolute right-0 mt-2 w-[200px] border-2 border-white/30 rounded-[12px] shadow-[0_8px_32px_rgba(0,0,0,0.15)] overflow-hidden z-[100] animate-dropdown-in ${
+                theme === "dark" ? "bg-[#2d2820]/95" : "bg-white/95"
+              }`}
+            >
               {loading ? (
                 <div className="px-4 py-3 flex justify-center">
                   <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
@@ -190,6 +212,8 @@ export function FiltersSection({
                 ecosystemOptions.map((eco, index) => (
                   <button
                     key={eco.value}
+                    role="option"
+                    aria-selected={selectedEcosystem.value === eco.value}
                     onClick={() => {
                       onEcosystemChange({ label: eco.label, value: eco.value });
                       onToggleDropdown();

--- a/src/features/leaderboard/components/LeaderboardTypeToggle.tsx
+++ b/src/features/leaderboard/components/LeaderboardTypeToggle.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Users, FolderGit2 } from 'lucide-react';
 import { LeaderboardType } from '../types';
 
@@ -7,34 +8,56 @@ interface LeaderboardTypeToggleProps {
   isLoaded: boolean;
 }
 
+const TYPES: { key: LeaderboardType; icon: typeof Users; label: string }[] = [
+  { key: 'contributors', icon: Users, label: 'Contributors' },
+  { key: 'projects', icon: FolderGit2, label: 'Projects' },
+];
+
 export function LeaderboardTypeToggle({ leaderboardType, onToggle, isLoaded }: LeaderboardTypeToggleProps) {
+  const onKeyDown = useCallback((e: React.KeyboardEvent, current: LeaderboardType) => {
+    let next: LeaderboardType | null = null;
+    if (e.key === 'ArrowLeft') {
+      next = current === 'contributors' ? 'projects' : 'contributors';
+    } else if (e.key === 'ArrowRight') {
+      next = current === 'projects' ? 'contributors' : 'projects';
+    }
+    if (next) {
+      e.preventDefault();
+      onToggle(next);
+    }
+  }, [onToggle]);
+
   return (
     <div className={`sticky top-6 z-[200] flex justify-center transition-all duration-1000 ${
       isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'
     }`}>
-      <div className="backdrop-blur-[40px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] rounded-[20px] border-2 border-white/30 shadow-[0_12px_48px_rgba(0,0,0,0.15)] p-2 flex gap-2">
-        <button
-          onClick={() => onToggle('contributors')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-[14px] font-bold text-[15px] transition-all duration-300 ${
-            leaderboardType === 'contributors'
-              ? 'bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white shadow-[0_6px_20px_rgba(201,152,58,0.4)] scale-105 border-2 border-white/20'
-              : 'text-[#6b5d4d] hover:bg-white/[0.15] hover:scale-105'
-          }`}
-        >
-          <Users className="w-5 h-5" />
-          Contributors
-        </button>
-        <button
-          onClick={() => onToggle('projects')}
-          className={`flex items-center gap-2 px-6 py-3 rounded-[14px] font-bold text-[15px] transition-all duration-300 ${
-            leaderboardType === 'projects'
-              ? 'bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white shadow-[0_6px_20px_rgba(201,152,58,0.4)] scale-105 border-2 border-white/20'
-              : 'text-[#6b5d4d] hover:bg-white/[0.15] hover:scale-105'
-          }`}
-        >
-          <FolderGit2 className="w-5 h-5" />
-          Projects
-        </button>
+      <div
+        role="tablist"
+        aria-label="Leaderboard type"
+        className="backdrop-blur-[40px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] rounded-[20px] border-2 border-white/30 shadow-[0_12px_48px_rgba(0,0,0,0.15)] p-2 flex gap-2"
+      >
+        {TYPES.map(({ key, icon: Icon, label }) => {
+          const isActive = leaderboardType === key;
+          return (
+            <button
+              key={key}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`leaderboard-panel-${key}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => onToggle(key)}
+              onKeyDown={(e) => onKeyDown(e, key)}
+              className={`flex items-center gap-2 px-6 py-3 rounded-[14px] font-bold text-[15px] transition-all duration-300 ${
+                isActive
+                  ? 'bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white shadow-[0_6px_20px_rgba(201,152,58,0.4)] scale-105 border-2 border-white/20'
+                  : 'text-[#6b5d4d] hover:bg-white/[0.15] hover:scale-105'
+              }`}
+            >
+              <Icon className="w-5 h-5" />
+              {label}
+            </button>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds proper ARIA roles, states, and keyboard navigation to:\n- LeaderboardTypeToggle: `role=tablist/tab`, `aria-selected`, arrow key navigation\n- FiltersSection: `aria-haspopup`/ `aria-expanded`, `role=listbox/option`, Escape to close\n\nCloses #63