### PR TITLE
chore: add Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Keep root pnpm/npm dependencies current without opening too many PRs at once.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # This entry will start producing updates once GitHub Actions workflows exist.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/guidelines/Guidelines.md
+++ b/guidelines/Guidelines.md
@@ -1,3 +1,17 @@
+# Dependency Update Policy
+
+- Dependabot checks root npm/pnpm dependencies weekly on Monday at 09:00 UTC.
+- Production and development dependency updates are grouped separately to reduce
+  pull request noise while keeping review scopes clear.
+- GitHub Actions updates are configured for the same weekly window and will
+  start producing pull requests when workflow files are added under
+  `.github/workflows/`.
+- Do not auto-merge major dependency updates without a manual review and at
+  least the relevant typecheck, lint, test, or build command for the touched
+  package area.
+- Prefer small follow-up fixes over broad dependency sweeps when an update
+  exposes unrelated type or lint failures.
+
 **Add your own guidelines here**
 <!--
 


### PR DESCRIPTION
Closes #99

## Summary
- add `.github/dependabot.yml` with weekly npm dependency updates for the root project
- group production and development dependency updates separately and cap open update PRs to reduce review noise
- add a GitHub Actions ecosystem entry for future workflows and document the dependency update policy in `guidelines/Guidelines.md`

## Scope
- configuration and contributor docs only
- no app runtime, authentication, wallet, API, build output, lockfile, or dependency version changes

## Validation
- local structure check: confirmed `version: 2`, two update ecosystems, npm + github-actions entries, grouped production/development dependency rules, and no tab characters
- no runtime tests were run because this is a config/docs-only change