### PR TITLE
fix(ui): use stable keys for IssueCard tags

### DIFF
--- a/src/shared/components/ui/IssueCard.test.tsx
+++ b/src/shared/components/ui/IssueCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { IssueCard } from './IssueCard';
+
+function renderIssueCard(tags: string[]) {
+  return render(
+    <ThemeProvider>
+      <IssueCard
+        id="issue-93"
+        number="#93"
+        title="Replace array-index keys"
+        tags={tags}
+        showTags
+      />
+    </ThemeProvider>
+  );
+}
+
+describe('IssueCard tags', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders reordered tags without losing their displayed labels', () => {
+    const { rerender } = renderIssueCard(['frontend', 'bug', 'good first issue']);
+
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+    expect(screen.getByText('bug')).toBeInTheDocument();
+    expect(screen.getByText('good first issue')).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider>
+        <IssueCard
+          id="issue-93"
+          number="#93"
+          title="Replace array-index keys"
+          tags={['good first issue', 'frontend', 'bug']}
+          showTags
+        />
+      </ThemeProvider>
+    );
+
+    const card = screen.getByRole('button', { name: /replace array-index keys/i });
+    const labels = within(card).getAllByText(/frontend|bug|good first issue/);
+
+    expect(labels.map((label) => label.textContent)).toEqual([
+      'good first issue',
+      'frontend',
+      'bug',
+    ]);
+  });
+
+  it('uses unique stable keys for duplicate normalized tags', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    renderIssueCard(['frontend', 'Frontend', 'front end']);
+
+    const consoleMessages = consoleError.mock.calls.flat().join('\n');
+
+    expect(screen.getAllByText(/front/i)).toHaveLength(3);
+    expect(consoleMessages).not.toContain('Encountered two children with the same key');
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/shared/components/ui/IssueCard.tsx
+++ b/src/shared/components/ui/IssueCard.tsx
@@ -27,6 +27,23 @@ export interface IssueCardProps {
   primaryTag?: string; // For the main tag (e.g., "good first issue", "bug")
 }
 
+/**
+ * Creates stable keys from tag content while keeping duplicate labels unique.
+ */
+function createTagKeyFactory() {
+  const seenTags = new Map<string, number>();
+
+  return (tag: string) => {
+    const normalizedTag = tag.trim().toLowerCase().replace(/\s+/g, '-');
+    const tagKey = normalizedTag || 'untagged';
+    const seenCount = seenTags.get(tagKey) ?? 0;
+
+    seenTags.set(tagKey, seenCount + 1);
+
+    return seenCount === 0 ? tagKey : `${tagKey}-${seenCount + 1}`;
+  };
+}
+
 export function IssueCard({
   id,
   number,
@@ -103,6 +120,8 @@ export function IssueCard({
       </div>
     );
   }
+
+  const getTagKey = createTagKeyFactory();
 
   // Default Issue Card Variant
   return (
@@ -184,9 +203,9 @@ export function IssueCard({
       {/* Optional Tags */}
       {showTags && tags.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-3">
-          {tags.map((tag, idx) => (
+          {tags.map((tag) => (
             <span
-              key={idx}
+              key={getTagKey(tag)}
               className={`px-2 py-1 rounded-[6px] text-[10px] font-bold backdrop-blur-[20px] border border-white/25 transition-colors ${
                 isDark ? 'bg-white/[0.08] text-[#d4d4d4]' : 'bg-white/[0.08] text-[#4a3f2f]'
               }`}


### PR DESCRIPTION
Closes #93

## Summary
- replace IssueCard tag array-index keys with normalized tag-value keys
- keep duplicate normalized labels unique with deterministic suffixes
- add React Testing Library coverage for reordered tags and duplicate tag labels

## Scope
- changes are limited to `src/shared/components/ui/IssueCard.tsx` and `src/shared/components/ui/IssueCard.test.tsx`
- no API, wallet, auth, storage, or routing behavior is changed
- rendering-only fix; no security-sensitive behavior is introduced

## Validation
- static local check confirmed `key={idx}` is removed and the new stable tag-key factory is present
- static local check confirmed tests cover reordered tags and duplicate normalized tags
- repository test commands were not run on this desktop because the local environment does not have the project toolchain available
