### PR TITLE
fix(leaderboard): guard missing podium avatars

### DIFF
--- a/src/features/leaderboard/components/ContributorsPodium.test.tsx
+++ b/src/features/leaderboard/components/ContributorsPodium.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext';
+import type { LeaderData } from '../types';
+import { ContributorsPodium } from './ContributorsPodium';
+
+function createLeader(overrides: Partial<LeaderData>): LeaderData {
+  return {
+    rank: 1,
+    username: 'Contributor',
+    avatar: 'AB',
+    score: 100,
+    trend: 'same',
+    trendValue: 0,
+    ...overrides,
+  };
+}
+
+function renderPodium(topThree: LeaderData[]) {
+  return render(
+    <ThemeProvider>
+      <ContributorsPodium topThree={topThree} isLoaded actualCount={3} />
+    </ThemeProvider>
+  );
+}
+
+describe('ContributorsPodium avatars', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders fallback initials when podium avatars are missing', () => {
+    const leaders = [
+      createLeader({ rank: 1, username: 'Ada Lovelace', avatar: null as unknown as string }),
+      createLeader({ rank: 2, username: 'Grace Hopper', avatar: undefined as unknown as string }),
+      createLeader({ rank: 3, username: 'Linus Torvalds', avatar: '' }),
+    ];
+
+    expect(() => renderPodium(leaders)).not.toThrow();
+    expect(screen.getByText('AL')).toBeInTheDocument();
+    expect(screen.getByText('GH')).toBeInTheDocument();
+    expect(screen.getByText('LT')).toBeInTheDocument();
+  });
+
+  it('keeps valid URL avatars as images and non-URL avatars as labels', () => {
+    const leaders = [
+      createLeader({
+        rank: 1,
+        username: 'Url Avatar',
+        avatar: 'https://example.com/avatar.png',
+      }),
+      createLeader({ rank: 2, username: 'Initial Avatar', avatar: 'IA' }),
+      createLeader({ rank: 3, username: 'Letter Avatar', avatar: 'LA' }),
+    ];
+
+    renderPodium(leaders);
+
+    expect(screen.getByAltText('Url Avatar')).toHaveAttribute(
+      'src',
+      'https://example.com/avatar.png'
+    );
+    expect(screen.getByText('IA')).toBeInTheDocument();
+    expect(screen.getByText('LA')).toBeInTheDocument();
+  });
+});

--- a/src/features/leaderboard/components/ContributorsPodium.tsx
+++ b/src/features/leaderboard/components/ContributorsPodium.tsx
@@ -1,11 +1,42 @@
 import { Medal, Trophy, Crown, Sparkles } from 'lucide-react';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { LeaderData } from '../types';
+import type { LeaderData } from '../types';
 
 interface ContributorsPodiumProps {
   topThree: LeaderData[];
   isLoaded: boolean;
   actualCount?: number; // Number of actual contributors (not padded)
+}
+
+/**
+ * Falls back to readable initials when leaderboard data omits an avatar value.
+ */
+function getAvatarFallback(username: string) {
+  const initials = username
+    .trim()
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return initials || '?';
+}
+
+function renderAvatar(contributor: LeaderData) {
+  const avatar = typeof contributor.avatar === 'string' ? contributor.avatar.trim() : '';
+
+  if (avatar.startsWith('http')) {
+    return (
+      <img
+        src={avatar}
+        alt={contributor.username}
+        className="w-full h-full object-cover"
+      />
+    );
+  }
+
+  return avatar || getAvatarFallback(contributor.username);
 }
 
 export function ContributorsPodium({ topThree, isLoaded, actualCount }: ContributorsPodiumProps) {
@@ -26,11 +57,7 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
         <div className="backdrop-blur-[30px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] border-2 border-white/40 rounded-[18px] p-6 w-[150px] shadow-[0_6px_24px_rgba(0,0,0,0.1)] mb-3 hover:shadow-[0_8px_28px_rgba(0,0,0,0.15)] hover:scale-105 transition-all duration-300 group">
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#c9983a]/80 to-[#a67c2e]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl group-hover:rotate-12 transition-transform duration-300 overflow-hidden">
-              {topThree[1].avatar.startsWith('http') ? (
-                <img src={topThree[1].avatar} alt={topThree[1].username} className="w-full h-full object-cover" />
-              ) : (
-                topThree[1].avatar
-              )}
+              {renderAvatar(topThree[1])}
             </div>
             <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 transition-opacity" />
           </div>
@@ -96,11 +123,7 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
           
           <div className="relative">
             <div className="relative w-20 h-20 rounded-full bg-gradient-to-br from-[#c9983a] to-[#a67c2e] flex items-center justify-center mx-auto mb-3 border-2 border-[#d4af37] shadow-xl text-3xl group-hover:rotate-[360deg] transition-transform duration-700 overflow-hidden">
-              {topThree[0].avatar.startsWith('http') ? (
-                <img src={topThree[0].avatar} alt={topThree[0].username} className="w-full h-full object-cover" />
-              ) : (
-                topThree[0].avatar
-              )}
+              {renderAvatar(topThree[0])}
               {/* Crown on top */}
               <Crown className="absolute -top-6 left-1/2 -translate-x-1/2 w-6 h-6 text-[#d4af37] animate-float" />
             </div>
@@ -131,11 +154,7 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
         <div className="backdrop-blur-[30px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] border-2 border-white/40 rounded-[18px] p-6 w-[150px] shadow-[0_6px_24px_rgba(0,0,0,0.1)] mb-3 hover:shadow-[0_8px_28px_rgba(0,0,0,0.15)] hover:scale-105 transition-all duration-300 group">
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#b89968]/80 to-[#9a7d4f]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl group-hover:rotate-12 transition-transform duration-300 overflow-hidden">
-              {topThree[2].avatar.startsWith('http') ? (
-                <img src={topThree[2].avatar} alt={topThree[2].username} className="w-full h-full object-cover" />
-              ) : (
-                topThree[2].avatar
-              )}
+              {renderAvatar(topThree[2])}
             </div>
             <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#b89968] opacity-0 group-hover:opacity-100 transition-opacity" />
           </div>


### PR DESCRIPTION
Closes #84

## Summary
- guard ContributorsPodium avatar rendering before checking URL prefixes
- render readable initials when a podium avatar is missing or empty
- add coverage for null, undefined, empty, non-URL, and valid URL avatar cases

## Scope
- changes are limited to `src/features/leaderboard/components/ContributorsPodium.tsx` and `src/features/leaderboard/components/ContributorsPodium.test.tsx`
- no API, ranking, scoring, wallet, auth, or routing behavior is changed
- defensive rendering only; no security-sensitive behavior is introduced

## Validation
- static local check confirmed direct `topThree[n].avatar.startsWith` calls were removed
- static local check confirmed tests cover missing and valid URL avatar cases
- repository test commands were not run on this desktop because the local environment does not have the project toolchain available
