### PR TITLE
feat(blog): add clickable cards and slug-based article routing

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import { ProfilePage } from "../features/dashboard/pages/ProfilePage";
 import { DataPage } from "../features/dashboard/pages/DataPage";
 import { LeaderboardPage } from "../features/leaderboard/pages/LeaderboardPage";
 import { BlogPage } from "../features/blog/pages/BlogPage";
+import { BlogArticlePage } from "../features/blog/pages/BlogArticlePage";
 import { SettingsPage } from "../features/settings/pages/SettingsPage";
 import { AdminPage } from "../features/admin/pages/AdminPage";
 import {
@@ -73,6 +74,9 @@ export default function App() {
                 <Route path="projects/:projectId/issues/:issueId" element={<IssueDetailPageRoute />} />
                 <Route path="leaderboard" element={<LeaderboardPage />} />
                 <Route path="blog" element={<BlogPage />} />
+                {/* Deep link to an individual article. The `:slug` param is
+                    untrusted input — see BlogArticlePage for sanitize+lookup. */}
+                <Route path="blog/:slug" element={<BlogArticlePage />} />
                 <Route path="settings" element={<SettingsPage />} />
                 <Route path="admin" element={<RoleGuard allow={['admin']}><AdminPage /></RoleGuard>} />
                 <Route path="search" element={<SearchPageRoute />} />

--- a/src/features/blog/components/BlogPostCard.test.tsx
+++ b/src/features/blog/components/BlogPostCard.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route, useParams } from "react-router-dom";
+import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
+import { BlogPostCard } from "./BlogPostCard";
+import { BlogPost } from "../types";
+
+const post: BlogPost = {
+  id: 1,
+  slug: "future-of-decentralized-development",
+  title: "The Future of Decentralized Development",
+  excerpt: "Exploring how blockchain technology is transforming collaboration.",
+  date: "December 20, 2024",
+  readTime: "6 min read",
+  category: "Innovation",
+  icon: "🚀",
+};
+
+/**
+ * Render the card inside a router whose article route simply echoes the slug,
+ * so navigation can be asserted purely from rendered output.
+ */
+function renderCard(p: BlogPost = post) {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={["/dashboard/blog"]}>
+        <Routes>
+          <Route path="/dashboard/blog" element={<BlogPostCard post={p} />} />
+          <Route
+            path="/dashboard/blog/:slug"
+            element={<ArticleProbe />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+/** A stand-in article page that surfaces the matched slug for assertions. */
+function ArticleProbe() {
+  const { slug } = useParams<{ slug: string }>();
+  return <div data-testid="article">article:{slug}</div>;
+}
+
+describe("BlogPostCard", () => {
+  it("renders the post's title, excerpt and metadata", () => {
+    renderCard();
+    expect(
+      screen.getByText("The Future of Decentralized Development"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/blockchain technology is transforming/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("December 20, 2024")).toBeInTheDocument();
+    expect(screen.getByText("6 min read")).toBeInTheDocument();
+    expect(screen.getByText("Innovation")).toBeInTheDocument();
+  });
+
+  it("exposes the card as a single accessible link to the article deep link", () => {
+    renderCard();
+    const link = screen.getByRole("link", {
+      name: /read more: the future of decentralized development/i,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/dashboard/blog/future-of-decentralized-development",
+    );
+    // The "Read More" affordance must not be a second interactive control.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("navigates to the article when the card is clicked", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(
+      screen.getByRole("link", { name: /read more: the future/i }),
+    );
+
+    expect(screen.getByTestId("article")).toHaveTextContent(
+      "article:future-of-decentralized-development",
+    );
+  });
+
+  it("is keyboard-focusable and activates on Enter", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.tab();
+    const link = screen.getByRole("link", { name: /read more: the future/i });
+    expect(link).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByTestId("article")).toHaveTextContent(
+      "article:future-of-decentralized-development",
+    );
+  });
+
+  it("renders a visible focus ring for keyboard users", () => {
+    renderCard();
+    const link = screen.getByRole("link", { name: /read more: the future/i });
+    expect(link.className).toMatch(/focus-visible:ring-2/);
+  });
+
+  it("omits the category chip when the post has no category", () => {
+    const withoutCategory: BlogPost = { ...post, category: undefined };
+    renderCard(withoutCategory);
+    expect(screen.queryByText("Innovation")).not.toBeInTheDocument();
+    // Title still links correctly even without a category.
+    expect(
+      screen.getByRole("link", { name: /read more: the future/i }),
+    ).toHaveAttribute("href", "/dashboard/blog/future-of-decentralized-development");
+  });
+
+  it("renders correctly under the dark theme", () => {
+    localStorage.setItem("theme", "dark");
+    try {
+      renderCard();
+      expect(
+        screen.getByText("The Future of Decentralized Development"),
+      ).toBeInTheDocument();
+    } finally {
+      localStorage.clear();
+    }
+  });
+});

--- a/src/features/blog/components/BlogPostCard.tsx
+++ b/src/features/blog/components/BlogPostCard.tsx
@@ -1,4 +1,5 @@
 import { Calendar, Clock, ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { BlogPost } from '../types';
 
@@ -6,11 +7,24 @@ interface BlogPostCardProps {
   post: BlogPost;
 }
 
+/**
+ * A clickable preview card for a single blog post.
+ *
+ * The entire card is a React Router {@link Link} to the article's deep link
+ * (`/dashboard/blog/:slug`). Using a single anchor — rather than a nested
+ * button — keeps the markup accessible: the card is reachable by keyboard,
+ * activates on Enter, and exposes a visible focus ring. The "Read More"
+ * affordance is therefore a non-interactive `span`, not a second control.
+ */
 export function BlogPostCard({ post }: BlogPostCardProps) {
   const { theme } = useTheme();
 
   return (
-    <div className="backdrop-blur-[30px] bg-white/[0.15] rounded-[20px] border border-white/25 p-6 hover:bg-white/[0.2] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] transition-all cursor-pointer group">
+    <Link
+      to={`/dashboard/blog/${post.slug}`}
+      aria-label={`Read more: ${post.title}`}
+      className="block backdrop-blur-[30px] bg-white/[0.15] rounded-[20px] border border-white/25 p-6 hover:bg-white/[0.2] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] transition-all cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+    >
       <div className="w-16 h-16 rounded-[16px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] flex items-center justify-center shadow-lg text-3xl mb-4 border border-white/15 group-hover:scale-110 transition-transform duration-300">
         {post.icon}
       </div>
@@ -49,10 +63,10 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
         </span>
       </div>
 
-      <button className="text-[14px] font-semibold text-[#c9983a] hover:text-[#a67c2e] transition-colors flex items-center gap-2">
+      <span className="text-[14px] font-semibold text-[#c9983a] group-hover:text-[#a67c2e] transition-colors flex items-center gap-2">
         Read More
         <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-      </button>
-    </div>
+      </span>
+    </Link>
   );
 }

--- a/src/features/blog/data/blogPosts.ts
+++ b/src/features/blog/data/blogPosts.ts
@@ -2,8 +2,15 @@ import { BlogPost } from '../types';
 
 export const featuredPost: BlogPost = {
   id: 0,
+  slug: "bridging-the-gap-onlygrain-open-source",
   title: "Bridging the Gap: How OnlyGrain is Revolutionizing Open Source Contribution",
   excerpt: "Discover how OnlyGrain connects talented developers with groundbreaking Web3 projects across all blockchain ecosystems, creating a seamless bridge between innovation and execution.",
+  content:
+    "OnlyGrain connects talented open-source developers with innovative Web3 " +
+    "projects across every major blockchain ecosystem. By matching contributors " +
+    "to work that fits their skills and rewarding quality contributions " +
+    "transparently, we make meaningful collaboration accessible to everyone — " +
+    "from seasoned protocol engineers to first-time Web3 contributors.",
   date: "December 27, 2024",
   readTime: "8 min read",
   author: "OnlyGrain Team",
@@ -14,6 +21,7 @@ export const featuredPost: BlogPost = {
 export const recentPosts: BlogPost[] = [
   {
     id: 1,
+    slug: "future-of-decentralized-development",
     title: "The Future of Decentralized Development",
     excerpt: "Exploring how blockchain technology is transforming the way developers collaborate on open-source projects.",
     date: "December 20, 2024",
@@ -23,6 +31,7 @@ export const recentPosts: BlogPost[] = [
   },
   {
     id: 2,
+    slug: "cross-chain-collaboration",
     title: "Cross-Chain Collaboration: Breaking Down Barriers",
     excerpt: "How OnlyGrain enables developers to contribute to projects across multiple blockchain ecosystems seamlessly.",
     date: "December 15, 2024",
@@ -32,6 +41,7 @@ export const recentPosts: BlogPost[] = [
   },
   {
     id: 3,
+    slug: "incentivizing-quality-contributions",
     title: "Incentivizing Quality Contributions",
     excerpt: "Learn about our reward system that recognizes and compensates exceptional open-source contributions.",
     date: "December 10, 2024",
@@ -46,3 +56,18 @@ export const allBlogPosts: BlogPost[] = [
   featuredPost,
   ...recentPosts,
 ];
+
+/**
+ * Resolves a post from the *known* post set by its slug.
+ *
+ * Security: the caller is expected to pass a value that originates from the
+ * URL (untrusted input). Rather than rendering arbitrary route data, we only
+ * ever return a post that exists in {@link allBlogPosts}; an unknown or
+ * malformed slug yields `undefined` so the route can show a not-found state.
+ *
+ * @param slug - A sanitized, URL-safe slug (see `sanitizeSlug`).
+ * @returns The matching post, or `undefined` when no post owns that slug.
+ */
+export function getPostBySlug(slug: string): BlogPost | undefined {
+  return allBlogPosts.find((post) => post.slug === slug);
+}

--- a/src/features/blog/pages/BlogArticlePage.test.tsx
+++ b/src/features/blog/pages/BlogArticlePage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
+import { BlogArticlePage } from "./BlogArticlePage";
+import { allBlogPosts } from "../data/blogPosts";
+
+/** Render the article page at a given `/dashboard/blog/:slug` entry. */
+function renderAt(slug: string) {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={[`/dashboard/blog/${slug}`]}>
+        <Routes>
+          <Route path="/dashboard/blog" element={<div>blog index</div>} />
+          <Route path="/dashboard/blog/:slug" element={<BlogArticlePage />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe("BlogArticlePage", () => {
+  it("renders the matched post for a valid slug", () => {
+    const post = allBlogPosts[1];
+    renderAt(post.slug);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: post.title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(post.excerpt)).toBeInTheDocument();
+    expect(screen.getByText(post.date)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to blog/i }),
+    ).toHaveAttribute("href", "/dashboard/blog");
+  });
+
+  it("shows a not-found state for an unknown slug", () => {
+    renderAt("this-post-does-not-exist");
+
+    expect(screen.getByText(/article not found/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 1, name: /onlygrain/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to blog/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects a malformed/hostile slug instead of looking it up", () => {
+    // Path-traversal / markup style input must never resolve to a post.
+    renderAt(encodeURIComponent("../<script>alert(1)</script>"));
+
+    expect(screen.getByText(/article not found/i)).toBeInTheDocument();
+  });
+
+  it("renders author and full content when the post provides them", () => {
+    // The featured post carries an `author` and long-form `content`.
+    const featured = allBlogPosts.find((p) => p.isFeatured)!;
+    renderAt(featured.slug);
+
+    expect(screen.getByText(`By ${featured.author}`)).toBeInTheDocument();
+    expect(screen.getByText(featured.content!)).toBeInTheDocument();
+  });
+
+  it("renders the article and not-found states under the dark theme", () => {
+    localStorage.setItem("theme", "dark");
+    try {
+      const { unmount } = renderAt(allBlogPosts[1].slug);
+      expect(
+        screen.getByRole("heading", { level: 1, name: allBlogPosts[1].title }),
+      ).toBeInTheDocument();
+      unmount();
+
+      renderAt("nope-not-real");
+      expect(screen.getByText(/article not found/i)).toBeInTheDocument();
+    } finally {
+      localStorage.clear();
+    }
+  });
+});

--- a/src/features/blog/pages/BlogArticlePage.tsx
+++ b/src/features/blog/pages/BlogArticlePage.tsx
@@ -1,0 +1,133 @@
+import { useParams, Link } from 'react-router-dom';
+import { Calendar, Clock, ArrowLeft } from 'lucide-react';
+import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { getPostBySlug } from '../data/blogPosts';
+import { sanitizeSlug } from '../utils/slug';
+
+/**
+ * Renders a single blog article addressed by its slug
+ * (`/dashboard/blog/:slug`).
+ *
+ * Security: the `:slug` route param is untrusted. We {@link sanitizeSlug | sanitize}
+ * it and then resolve it against the known post set via
+ * {@link getPostBySlug} — arbitrary route data is never rendered. An invalid
+ * or unknown slug falls through to an in-context not-found state rather than a
+ * thrown error or a blank page.
+ */
+export function BlogArticlePage() {
+  const { theme } = useTheme();
+  const { slug } = useParams<{ slug: string }>();
+
+  const safeSlug = sanitizeSlug(slug);
+  const post = safeSlug ? getPostBySlug(safeSlug) : undefined;
+
+  if (!post) {
+    return (
+      <div className="space-y-6">
+        <div
+          className={`backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-10 text-center`}
+        >
+          <h2
+            className={`text-[28px] font-bold mb-3 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Article not found
+          </h2>
+          <p
+            className={`text-[16px] mb-6 transition-colors ${
+              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
+            }`}
+          >
+            We couldn't find the article you're looking for. It may have been
+            moved or removed.
+          </p>
+          <Link
+            to="/dashboard/blog"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[14px] font-semibold text-[14px] shadow-[0_6px_20px_rgba(162,121,44,0.35)] hover:shadow-[0_8px_24px_rgba(162,121,44,0.5)] transition-all border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Blog
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Link
+        to="/dashboard/blog"
+        className={`inline-flex items-center gap-2 text-[14px] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-md ${
+          theme === 'dark'
+            ? 'text-[#d4d4d4] hover:text-[#f5f5f5]'
+            : 'text-[#7a6b5a] hover:text-[#2d2820]'
+        }`}
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Back to Blog
+      </Link>
+
+      <article className="backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-10">
+        <div className="max-w-4xl mx-auto">
+          {/* Article Header */}
+          <header className="mb-8">
+            {post.category && (
+              <span className="inline-block px-3 py-1 mb-4 bg-[#c9983a]/20 border border-[#c9983a]/35 rounded-[8px] text-[11px] font-semibold text-[#8b6f3a]">
+                {post.category}
+              </span>
+            )}
+            <h1
+              className={`text-[36px] font-bold mb-4 leading-tight transition-colors ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
+              {post.title}
+            </h1>
+            <div
+              className={`flex flex-wrap items-center gap-4 text-[14px] transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
+              <span className="flex items-center gap-1.5">
+                <Calendar className="w-4 h-4" />
+                {post.date}
+              </span>
+              <span>•</span>
+              <span className="flex items-center gap-1.5">
+                <Clock className="w-4 h-4" />
+                {post.readTime}
+              </span>
+              {post.author && (
+                <>
+                  <span>•</span>
+                  <span>By {post.author}</span>
+                </>
+              )}
+            </div>
+          </header>
+
+          {/* Article Body */}
+          <div className="prose prose-lg max-w-none">
+            <p
+              className={`text-[18px] leading-relaxed mb-6 transition-colors ${
+                theme === 'dark' ? 'text-[#e5e5e5]' : 'text-[#4a4036]'
+              }`}
+            >
+              {post.excerpt}
+            </p>
+            {post.content && (
+              <p
+                className={`text-[16px] leading-relaxed transition-colors whitespace-pre-line ${
+                  theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
+                }`}
+              >
+                {post.content}
+              </p>
+            )}
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/src/features/blog/types/index.ts
+++ b/src/features/blog/types/index.ts
@@ -1,5 +1,14 @@
 export interface BlogPost {
   id: number;
+  /**
+   * URL-safe identifier used for deep-linking to an individual article at
+   * `/dashboard/blog/:slug`. Must be unique across posts and contain only
+   * lowercase alphanumerics separated by single hyphens (e.g.
+   * `future-of-decentralized-development`). Treated as untrusted when it
+   * arrives from the URL and is validated/looked up against the known post
+   * set before use.
+   */
+  slug: string;
   title: string;
   excerpt: string;
   content?: string; // Full content for individual post pages

--- a/src/features/blog/utils/slug.test.ts
+++ b/src/features/blog/utils/slug.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeSlug } from "./slug";
+
+describe("sanitizeSlug", () => {
+  it("accepts and lowercases a well-formed slug", () => {
+    expect(sanitizeSlug("Cross-Chain-Collaboration")).toBe(
+      "cross-chain-collaboration",
+    );
+    expect(sanitizeSlug("  future-of-dev  ")).toBe("future-of-dev");
+    expect(sanitizeSlug("post123")).toBe("post123");
+  });
+
+  it("returns null for empty or missing input", () => {
+    expect(sanitizeSlug(undefined)).toBeNull();
+    expect(sanitizeSlug("")).toBeNull();
+    expect(sanitizeSlug("   ")).toBeNull();
+  });
+
+  it.each([
+    "../etc/passwd",
+    "a/b",
+    "<script>",
+    "has space",
+    "-leading",
+    "trailing-",
+    "double--hyphen",
+    "under_score",
+    "emoji-🚀",
+  ])("rejects the unsafe slug %j", (input) => {
+    expect(sanitizeSlug(input)).toBeNull();
+  });
+});

--- a/src/features/blog/utils/slug.ts
+++ b/src/features/blog/utils/slug.ts
@@ -1,0 +1,29 @@
+/**
+ * URL slug helpers for the blog feature.
+ *
+ * The slug that React Router extracts from `/dashboard/blog/:slug` is
+ * **untrusted user input** — a visitor can type anything into the address bar.
+ * These helpers normalise and validate that value *before* it is used to look
+ * a post up, so the rest of the app never has to reason about hostile slugs.
+ */
+
+/**
+ * A safe slug: one or more lowercase alphanumeric groups joined by single
+ * hyphens (e.g. `cross-chain-collaboration`). No leading/trailing/double
+ * hyphens, no slashes, dots, or other path/markup characters.
+ */
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Normalise and validate a raw slug taken from the URL.
+ *
+ * @param raw - The value of the `:slug` route param (may be `undefined`).
+ * @returns The lowercased slug when it matches {@link SLUG_PATTERN}, otherwise
+ *          `null`. A `null` result signals the caller to render a not-found
+ *          state instead of attempting a lookup.
+ */
+export function sanitizeSlug(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const slug = raw.trim().toLowerCase();
+  return SLUG_PATTERN.test(slug) ? slug : null;
+}


### PR DESCRIPTION
Close #87 
---

## Summary
Blog post cards rendered with `cursor-pointer` styling and a "Read More" button but had **no click handler or link**, so clicking did nothing. There was also no way to deep-link to an individual article because posts had no stable identifier. This PR makes `BlogPostCard` fully clickable and introduces slug-based routing for individual articles, with an in-context not-found state for unknown slugs.
---
## Root cause
- `BlogPostCard` was a static `<div>` containing a decorative `<button>` — no `onClick`/`Link`, so the card suggested interaction it couldn't deliver.
- `blogPosts.ts` and the `BlogPost` type had no `slug` field, leaving no URL-safe key to route to `/blog/:slug`.
---
## Solution implemented
- Added a documented, required `slug` to the `BlogPost` type and to every post in the data file.
- Wrapped the **entire card** in a React Router `<Link>` to the article (single accessible control — no nested interactive elements). The old "Read More" button is now a non-interactive `<span>`.
- Added a `blog/:slug` route rendering a new `BlogArticlePage`.
- `BlogArticlePage` **sanitizes** the slug and resolves it against the **known post set**, rendering the matched article or a not-found state.
- Added a `sanitizeSlug()` utility plus a `getPostBySlug()` lookup helper.
---

## Key changes
| File | Change |
|------|--------|
| `src/features/blog/types/index.ts` | Add TSDoc'd `slug: string` to `BlogPost` |
| `src/features/blog/data/blogPosts.ts` | Add `slug` to every post, `content` to featured post, `getPostBySlug()` |
| `src/features/blog/utils/slug.ts` (new) | `sanitizeSlug()` — validate/normalize untrusted URL slugs |
| `src/features/blog/components/BlogPostCard.tsx` | Card is now a focusable `<Link>` with `aria-label` + focus ring |
| `src/features/blog/pages/BlogArticlePage.tsx` (new) | Sanitize → lookup → article or not-found |
| `src/app/App.tsx` | Register `blog/:slug` route |
| `*.test.*` (3 new files) | Cover navigation, keyboard, not-found, hostile slug, themes |
---

## 🔒 Security notes
The `:slug` route param is treated as **untrusted input**. `sanitizeSlug()` enforces a strict `^[a-z0-9]+(?:-[a-z0-9]+)*$` allow-list (rejecting path traversal `../`, slashes, and markup like `<script>`), and the article is resolved **only** from the known post set via `getPostBySlug()`. Arbitrary route data is never rendered; any non-matching slug falls through to the not-found state.

## Trade-offs / considerations
- **Route path:** Implemented as `/dashboard/blog/:slug` rather than the issue's literal `/blog/:slug`. The blog lives only under the authenticated dashboard layout, and this matches sibling detail routes (`/dashboard/projects/:projectId`, `/dashboard/ecosystems/:ecosystemId`). A top-level `/blog/:slug` would lose the layout/nav and have no entry point.
- **Scope:** Limited to `BlogPostCard` per the issue. The separate `FeaturedPost` component was left unchanged.
- **Article body:** The article page renders the post's excerpt + optional `content`; populated `content` on the featured post so the body is real rather than excerpt-only.
---

## Testing
```bash
npm install
npx vitest run src/features/blog          # 23 passed
npx vitest run --exclude='**/node_modules/**'   # 215 passed, no regressions
---
Coverage on changed files: 100% statements / functions / lines, 97.22% branches (≥95% target met).
Manual: /dashboard/blog → click any card → lands on the article; visit an unknown slug (e.g. /dashboard/blog/nope) → not-found state with a "Back to Blog" link; Tab to a card and press Enter → navigates.
Edge cases covered
✅ Valid slug renders the matched article (incl. author + full content)
✅ Unknown slug shows the not-found state
✅ Malformed/hostile slug (../<script>) is rejected, not looked up
✅ Card keyboard focus + Enter activation, visible focus ring
✅ Light and dark themes
---
Thank you very much, open for feedbcaks!!