### PR TITLE
feat(a11y): honor reduced motion in SkeletonLoader

### DIFF
--- a/src/shared/components/SkeletonLoader.test.tsx
+++ b/src/shared/components/SkeletonLoader.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { SkeletonLoader } from './SkeletonLoader';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+function mockReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('SkeletonLoader', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the shimmer layer for the default loading state', () => {
+    mockReducedMotion(false);
+    renderWithTheme(<SkeletonLoader />);
+
+    expect(screen.getByTestId('skeleton-shimmer')).toHaveClass('animate-shimmer');
+  });
+
+  it('renders a static shimmer layer when reduced motion is preferred', () => {
+    mockReducedMotion(true);
+    renderWithTheme(<SkeletonLoader />);
+
+    expect(screen.getByTestId('skeleton-shimmer')).not.toHaveClass('animate-shimmer');
+    expect(screen.getByTestId('skeleton-shimmer')).toHaveClass('translate-x-0');
+  });
+
+  it('keeps the shimmer layer in dark theme', () => {
+    mockReducedMotion(false);
+    renderWithTheme(<SkeletonLoader />, { theme: 'dark' });
+
+    expect(screen.getByTestId('skeleton-shimmer')).toHaveClass('via-white/[0.15]');
+  });
+});

--- a/src/shared/components/SkeletonLoader.tsx
+++ b/src/shared/components/SkeletonLoader.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { useTheme } from '../contexts/ThemeContext';
 
 interface SkeletonLoaderProps {
@@ -7,9 +9,36 @@ interface SkeletonLoaderProps {
   height?: string;
 }
 
+/**
+ * Tracks the user's reduced-motion preference so skeletons can render a static
+ * placeholder instead of relying only on CSS to stop the animation.
+ */
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
 export function SkeletonLoader({ className, variant = 'default', width, height }: SkeletonLoaderProps) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const baseClasses = `relative overflow-hidden ${
     variant === 'circle' 
@@ -27,9 +56,13 @@ export function SkeletonLoader({ className, variant = 'default', width, height }
     ? 'from-transparent via-white/[0.15] to-transparent'
     : 'from-transparent via-white/[0.25] to-transparent';
 
-  const style: React.CSSProperties = {};
+  const style: CSSProperties = {};
   if (width) style.width = width;
   if (height) style.height = height;
+
+  const motionClasses = prefersReducedMotion
+    ? 'translate-x-0'
+    : '-translate-x-full animate-shimmer';
 
   return (
     <div 
@@ -37,7 +70,8 @@ export function SkeletonLoader({ className, variant = 'default', width, height }
       style={style}
     >
       <div 
-        className={`absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r ${shimmerGradient}`}
+        className={`absolute inset-0 ${motionClasses} bg-gradient-to-r ${shimmerGradient}`}
+        data-testid="skeleton-shimmer"
       />
     </div>
   );

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -59,6 +59,13 @@
   animation: shimmer 2s infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer {
+    animation: none;
+    transform: translateX(0);
+  }
+}
+
 :root {
   --font-size: 16px;
   


### PR DESCRIPTION
## Summary
- honor `prefers-reduced-motion: reduce` in `SkeletonLoader`
- render a static shimmer layer for reduced-motion users while preserving the default animated experience
- add component coverage for both reduced and non-reduced motion states
- keep a CSS media-query fallback so the animation is disabled even if JS is unavailable

## Validation
- Added `src/shared/components/SkeletonLoader.test.tsx`
- Not run: `npm test -- SkeletonLoader.test.tsx`
- Not run: `npm run typecheck`
- Not run: `npm run build`

I could not complete runtime validation in this environment because the local Windows shell does not have `npm` available, and the provided remote Docker container is currently hanging on `docker exec`. The change is intentionally small and limited to the skeleton component, tests, and CSS fallback.

## Security notes
Presentation-only accessibility change; no user input, auth, network, or storage behavior is changed.

Fixes #96
