### PR TITLE
fix(ui): normalize DatePicker calendar dates locally

### DIFF
--- a/src/shared/components/ui/DatePicker.test.tsx
+++ b/src/shared/components/ui/DatePicker.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import {
+  DatePicker,
+  formatDatePickerValue,
+  parseDatePickerValue,
+} from './DatePicker';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+
+describe('DatePicker date normalization', () => {
+  it('parses YYYY-MM-DD as a local calendar day at noon', () => {
+    const parsed = parseDatePickerValue('2026-03-10');
+
+    expect(parsed).toBeInstanceOf(Date);
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(2);
+    expect(parsed?.getDate()).toBe(10);
+    expect(parsed?.getHours()).toBe(12);
+  });
+
+  it('round-trips selected local dates without converting through UTC', () => {
+    const selected = new Date(2026, 10, 2, 23, 30);
+
+    expect(formatDatePickerValue(selected)).toBe('2026-11-02');
+  });
+
+  it('renders the provided date without shifting the displayed day', () => {
+    renderWithTheme(
+      <DatePicker value="2026-03-10" onChange={vi.fn()} placeholder="Pick a date" />,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Mar 10, 2026');
+  });
+
+  it('falls back to the placeholder for invalid dates', () => {
+    renderWithTheme(
+      <DatePicker value="2026-02-31" onChange={vi.fn()} placeholder="Pick a date" />,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Pick a date');
+  });
+});

--- a/src/shared/components/ui/DatePicker.tsx
+++ b/src/shared/components/ui/DatePicker.tsx
@@ -18,6 +18,37 @@ interface DatePickerProps {
   error?: string | null; // ADDED: Error message support
 }
 
+const LOCAL_CALENDAR_HOUR = 12;
+
+/**
+ * DatePicker treats `YYYY-MM-DD` as a local calendar day. Using local noon
+ * avoids UTC-midnight and DST boundaries shifting the rendered date.
+ */
+export function parseDatePickerValue(value: string) {
+  if (!value) return undefined;
+
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return undefined;
+
+  const parsedDate = new Date(year, month - 1, day, LOCAL_CALENDAR_HOUR);
+  if (
+    parsedDate.getFullYear() !== year ||
+    parsedDate.getMonth() !== month - 1 ||
+    parsedDate.getDate() !== day
+  ) {
+    return undefined;
+  }
+
+  return parsedDate;
+}
+
+/**
+ * Formats a selected local calendar day without converting it through UTC.
+ */
+export function formatDatePickerValue(date: Date) {
+  return format(date, "yyyy-MM-dd");
+}
+
 export function DatePicker({
   label,
   value,
@@ -33,24 +64,16 @@ export function DatePicker({
   // ADDED: Check if there's an error
   const isError = !!error;
 
-  // Parse the date value (YYYY-MM-DD format)
-  // Parse as UTC to avoid timezone issues
+  // Parse and format on the same local-calendar basis to avoid off-by-one days.
   const date = React.useMemo(() => {
-    if (!value) return undefined;
-    try {
-      const [year, month, day] = value.split('-').map(Number);
-      if (isNaN(year) || isNaN(month) || isNaN(day)) return undefined;
-      return new Date(Date.UTC(year, month - 1, day));
-    } catch {
-      return undefined;
-    }
+    return parseDatePickerValue(value);
   }, [value]);
 
   // Handle date selection
   const handleSelect = (selectedDate: Date | undefined) => {
     if (selectedDate) {
       // Format as YYYY-MM-DD
-      const formattedDate = format(selectedDate, "yyyy-MM-dd");
+      const formattedDate = formatDatePickerValue(selectedDate);
       onChange(formattedDate);
       setOpen(false);
     }


### PR DESCRIPTION
## Summary
- parse `YYYY-MM-DD` values as local calendar days instead of UTC midnight
- use local noon to avoid DST/offset boundary shifts before formatting with date-fns
- add DatePicker coverage for parsing, round-tripping, displayed dates, and invalid dates

## Validation
- Added `src/shared/components/ui/DatePicker.test.tsx`
- Not run: `npm test -- DatePicker.test.tsx`
- Not run: `npm run typecheck`
- Not run: `npm run build`

I could not complete runtime validation in this environment because the local Windows shell does not have `npm` available, and the provided remote Docker container is currently hanging on `docker exec`. The change is limited to DatePicker date normalization and tests.

## Security notes
Rendering/date-normalization only; no auth, storage, network, or user data handling changes.

Fixes #91
