### PR TITLE
fix(leaderboard): guard against missing avatar in ContributorsPodium

### DIFF
--- a/src/features/leaderboard/components/ContributorsPodium.test.tsx
+++ b/src/features/leaderboard/components/ContributorsPodium.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ContributorsPodium } from './ContributorsPodium';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+import { LeaderData } from '../types/index';
+
+function makeEntry(overrides: Partial<LeaderData> & { rank: number; username: string }): LeaderData {
+  return {
+    score: 100,
+    trend: 'up',
+    trendValue: 0,
+    avatar: 'https://example.com/avatar.png',
+    ...overrides,
+  };
+}
+
+const defaultTop3: LeaderData[] = [
+  makeEntry({ rank: 1, username: 'Alice', avatar: 'https://example.com/alice.png' }),
+  makeEntry({ rank: 2, username: 'Bob',   avatar: 'https://example.com/bob.png' }),
+  makeEntry({ rank: 3, username: 'Carol', avatar: 'https://example.com/carol.png' }),
+];
+
+describe('ContributorsPodium – avatar null guard', () => {
+  it('renders without crashing when all avatars are valid URLs', () => {
+    renderWithTheme(<ContributorsPodium topThree={defaultTop3} isLoaded actualCount={3} />);
+    expect(screen.getAllByRole('img')).toHaveLength(3);
+  });
+
+  it('does not crash when 1st-place avatar is null', () => {
+    const top3 = [
+      makeEntry({ rank: 1, username: 'Alice', avatar: null as unknown as string }),
+      makeEntry({ rank: 2, username: 'Bob' }),
+      makeEntry({ rank: 3, username: 'Carol' }),
+    ];
+    expect(() =>
+      renderWithTheme(<ContributorsPodium topThree={top3} isLoaded actualCount={3} />),
+    ).not.toThrow();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('does not crash when 2nd-place avatar is undefined', () => {
+    const top3 = [
+      makeEntry({ rank: 1, username: 'Alice' }),
+      makeEntry({ rank: 2, username: 'Bob', avatar: undefined as unknown as string }),
+      makeEntry({ rank: 3, username: 'Carol' }),
+    ];
+    expect(() =>
+      renderWithTheme(<ContributorsPodium topThree={top3} isLoaded actualCount={3} />),
+    ).not.toThrow();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('does not crash when 3rd-place avatar is null', () => {
+    const top3 = [
+      makeEntry({ rank: 1, username: 'Alice' }),
+      makeEntry({ rank: 2, username: 'Bob' }),
+      makeEntry({ rank: 3, username: 'Carol', avatar: null as unknown as string }),
+    ];
+    expect(() =>
+      renderWithTheme(<ContributorsPodium topThree={top3} isLoaded actualCount={3} />),
+    ).not.toThrow();
+    expect(screen.getByText('C')).toBeInTheDocument();
+  });
+
+  it('renders emoji avatar when avatar is a non-http string', () => {
+    const top3 = [
+      makeEntry({ rank: 1, username: 'Alice', avatar: '🏆' }),
+      makeEntry({ rank: 2, username: 'Bob' }),
+      makeEntry({ rank: 3, username: 'Carol' }),
+    ];
+    renderWithTheme(<ContributorsPodium topThree={top3} isLoaded actualCount={3} />);
+    expect(screen.getByText('🏆')).toBeInTheDocument();
+  });
+
+  it('renders all three positions with missing avatars without crashing', () => {
+    const top3 = [
+      makeEntry({ rank: 1, username: 'Alice', avatar: null as unknown as string }),
+      makeEntry({ rank: 2, username: 'Bob',   avatar: null as unknown as string }),
+      makeEntry({ rank: 3, username: 'Carol', avatar: null as unknown as string }),
+    ];
+    expect(() =>
+      renderWithTheme(<ContributorsPodium topThree={top3} isLoaded actualCount={3} />),
+    ).not.toThrow();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+  });
+});

--- a/src/features/leaderboard/components/ContributorsPodium.tsx
+++ b/src/features/leaderboard/components/ContributorsPodium.tsx
@@ -26,10 +26,11 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
         <div className="backdrop-blur-[30px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] border-2 border-white/40 rounded-[18px] p-6 w-[150px] shadow-[0_6px_24px_rgba(0,0,0,0.1)] mb-3 hover:shadow-[0_8px_28px_rgba(0,0,0,0.15)] hover:scale-105 transition-all duration-300 group">
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#c9983a]/80 to-[#a67c2e]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl group-hover:rotate-12 transition-transform duration-300 overflow-hidden">
-              {topThree[1].avatar.startsWith('http') ? (
+              {/** Use optional chaining so a null/undefined avatar never throws on startsWith */}
+              {topThree[1].avatar?.startsWith('http') ? (
                 <img src={topThree[1].avatar} alt={topThree[1].username} className="w-full h-full object-cover" />
               ) : (
-                topThree[1].avatar
+                topThree[1].avatar || topThree[1].username.charAt(0).toUpperCase()
               )}
             </div>
             <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -96,10 +97,11 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
           
           <div className="relative">
             <div className="relative w-20 h-20 rounded-full bg-gradient-to-br from-[#c9983a] to-[#a67c2e] flex items-center justify-center mx-auto mb-3 border-2 border-[#d4af37] shadow-xl text-3xl group-hover:rotate-[360deg] transition-transform duration-700 overflow-hidden">
-              {topThree[0].avatar.startsWith('http') ? (
+              {/** Use optional chaining so a null/undefined avatar never throws on startsWith */}
+              {topThree[0].avatar?.startsWith('http') ? (
                 <img src={topThree[0].avatar} alt={topThree[0].username} className="w-full h-full object-cover" />
               ) : (
-                topThree[0].avatar
+                topThree[0].avatar || topThree[0].username.charAt(0).toUpperCase()
               )}
               {/* Crown on top */}
               <Crown className="absolute -top-6 left-1/2 -translate-x-1/2 w-6 h-6 text-[#d4af37] animate-float" />
@@ -131,10 +133,11 @@ export function ContributorsPodium({ topThree, isLoaded, actualCount }: Contribu
         <div className="backdrop-blur-[30px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] border-2 border-white/40 rounded-[18px] p-6 w-[150px] shadow-[0_6px_24px_rgba(0,0,0,0.1)] mb-3 hover:shadow-[0_8px_28px_rgba(0,0,0,0.15)] hover:scale-105 transition-all duration-300 group">
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#b89968]/80 to-[#9a7d4f]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl group-hover:rotate-12 transition-transform duration-300 overflow-hidden">
-              {topThree[2].avatar.startsWith('http') ? (
+              {/** Use optional chaining so a null/undefined avatar never throws on startsWith */}
+              {topThree[2].avatar?.startsWith('http') ? (
                 <img src={topThree[2].avatar} alt={topThree[2].username} className="w-full h-full object-cover" />
               ) : (
-                topThree[2].avatar
+                topThree[2].avatar || topThree[2].username.charAt(0).toUpperCase()
               )}
             </div>
             <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#b89968] opacity-0 group-hover:opacity-100 transition-opacity" />


### PR DESCRIPTION
## Overview
Add null/undefined guard before every `.startsWith('http')` call on `avatar` in `ContributorsPodium.tsx`. A missing avatar previously threw "Cannot read properties of null (reading 'startsWith')" and crashed the entire leaderboard podium.

## Related Issue
Closes #84

## Changes
- `src/features/leaderboard/components/ContributorsPodium.tsx`: replaced `avatar.startsWith('http')` with `avatar?.startsWith('http')` in all three podium positions (1st, 2nd, 3rd place). Fallback displays the first letter of the username when avatar is null/undefined/empty
- `src/features/leaderboard/components/ContributorsPodium.test.tsx`: 6 tests added covering valid URL avatars, null avatar on each position, emoji avatar, and all three positions missing at once

## Verification Results
All 6 tests pass:
- ✅ renders without crashing when all avatars are valid URLs
- ✅ does not crash when 1st-place avatar is null
- ✅ does not crash when 2nd-place avatar is undefined
- ✅ does not crash when 3rd-place avatar is null
- ✅ renders emoji avatar when avatar is a non-http string
- ✅ renders all three positions with missing avatars without crashing

## How to Test
```bash