### PR TITLE
refactor(forms): migrate AddRepositoryModal and ProfileTab to react-h…

### DIFF
--- a/src/features/maintainers/components/AddRepositoryModal.test.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { AddRepositoryModal } from './AddRepositoryModal'
+
+const mockCreateProject = vi.fn()
+const mockGetEcosystems = vi.fn()
+
+vi.mock('../../../shared/api/client', () => ({
+  createProject: (...args: unknown[]) => mockCreateProject(...args),
+  getEcosystems: (...args: unknown[]) => mockGetEcosystems(...args),
+}))
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetEcosystems.mockResolvedValue({
+    ecosystems: [
+      { name: 'Ethereum', slug: 'ethereum' },
+      { name: 'Starknet', slug: 'starknet' },
+    ],
+  })
+})
+
+describe('AddRepositoryModal', () => {
+  it('renders when isOpen is true', async () => {
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    expect(screen.getByText('Add a Repository')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+  })
+
+  it('does not render when isOpen is false', () => {
+    renderWithTheme(<AddRepositoryModal {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Add a Repository')).not.toBeInTheDocument()
+  })
+
+  it('shows repo name required error on mount with empty fields', async () => {
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+
+    expect(await screen.findByText('Repository name is required')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add repository/i })).toBeDisabled()
+    expect(mockCreateProject).not.toHaveBeenCalled()
+  })
+
+  it('shows repo name format error for missing slash', async () => {
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.clear(screen.getByPlaceholderText(/owner\/repo/i))
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'invalidname')
+
+    expect(await screen.findByText('Repository name must be in format: owner/repo')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add repository/i })).toBeDisabled()
+    expect(mockCreateProject).not.toHaveBeenCalled()
+  })
+
+  it('calls createProject on valid submit', async () => {
+    mockCreateProject.mockResolvedValue({ id: '1' })
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+    await user.click(screen.getByRole('button', { name: /add repository/i }))
+
+    await waitFor(() => {
+      expect(mockCreateProject).toHaveBeenCalledWith({
+        github_full_name: 'facebook/react',
+        ecosystem_name: 'Ethereum',
+        language: undefined,
+        tags: undefined,
+        category: undefined,
+      })
+    })
+  })
+
+  it('disables submit button while submitting', async () => {
+    mockCreateProject.mockImplementation(() => new Promise(() => {})) // never resolves
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+    await user.click(screen.getByRole('button', { name: /add repository/i }))
+
+    expect(await screen.findByText('Adding...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /adding/i })).toBeDisabled()
+  })
+
+  it('shows success message and calls onSuccess after valid submit', async () => {
+    mockCreateProject.mockResolvedValue({ id: '1' })
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+    renderWithTheme(
+      <AddRepositoryModal isOpen={true} onClose={onClose} onSuccess={onSuccess} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+    await user.click(screen.getByRole('button', { name: /add repository/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Repository added successfully!')).toBeInTheDocument()
+    })
+
+    // After 1.5s the modal should close
+    await waitFor(
+      () => {
+        expect(onSuccess).toHaveBeenCalled()
+        expect(onClose).toHaveBeenCalled()
+      },
+      { timeout: 2000 },
+    )
+  })
+})

--- a/src/features/maintainers/components/AddRepositoryModal.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import { X, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { createProject, getEcosystems } from '../../../shared/api/client';
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
+import { validateRepoName, validateRequired } from '../../../shared/utils/validation';
 
 interface AddRepositoryModalProps {
   isOpen: boolean;
@@ -10,15 +12,41 @@ interface AddRepositoryModalProps {
   onSuccess: () => void;
 }
 
+interface FormData {
+  githubFullName: string;
+  ecosystemName: string;
+  language: string;
+  tags: string;
+  category: string;
+}
+
 export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepositoryModalProps) {
   const { theme } = useTheme();
   const darkTheme = theme === 'dark';
 
-  const [githubFullName, setGithubFullName] = useState('');
-  const [ecosystemName, setEcosystemName] = useState('');
-  const [language, setLanguage] = useState('');
-  const [tags, setTags] = useState('');
-  const [category, setCategory] = useState('');
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    trigger,
+    formState: { errors, isValid },
+  } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues: {
+      githubFullName: '',
+      ecosystemName: '',
+      language: '',
+      tags: '',
+      category: '',
+    },
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      trigger();
+    }
+  }, [isOpen, trigger]);
 
   const [ecosystems, setEcosystems] = useState<Array<{ name: string; slug: string }>>([]);
   const [isLoadingEcosystems, setIsLoadingEcosystems] = useState(false);
@@ -46,53 +74,28 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const onSubmit = async (data: FormData) => {
     setError(null);
     setSuccess(false);
-
-    // Validation
-    if (!githubFullName.trim()) {
-      setError('Repository name is required (format: owner/repo)');
-      return;
-    }
-
-    if (!githubFullName.includes('/')) {
-      setError('Repository name must be in format: owner/repo');
-      return;
-    }
-
-    if (!ecosystemName) {
-      setError('Ecosystem is required');
-      return;
-    }
-
     setIsSubmitting(true);
 
     try {
-      const tagsArray = tags
+      const tagsArray = data.tags
         .split(',')
         .map(tag => tag.trim())
         .filter(tag => tag.length > 0);
 
       await createProject({
-        github_full_name: githubFullName.trim(),
-        ecosystem_name: ecosystemName,
-        language: language.trim() || undefined,
+        github_full_name: data.githubFullName.trim(),
+        ecosystem_name: data.ecosystemName,
+        language: data.language.trim() || undefined,
         tags: tagsArray.length > 0 ? tagsArray : undefined,
-        category: category.trim() || undefined,
+        category: data.category.trim() || undefined,
       });
 
       setSuccess(true);
-      
-      // Reset form
-      setGithubFullName('');
-      setEcosystemName('');
-      setLanguage('');
-      setTags('');
-      setCategory('');
+      reset();
 
-      // Close modal after 1.5 seconds and refresh projects
       setTimeout(() => {
         onSuccess();
         onClose();
@@ -109,11 +112,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
     if (!isSubmitting) {
       setError(null);
       setSuccess(false);
-      setGithubFullName('');
-      setEcosystemName('');
-      setLanguage('');
-      setTags('');
-      setCategory('');
+      reset();
       onClose();
     }
   };
@@ -157,7 +156,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
         </div>
 
         {/* Content */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-5">
           {/* Error Message */}
           {error && (
             <div className={`flex items-center gap-3 p-4 rounded-[12px] border-2 ${
@@ -191,22 +190,25 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             </label>
             <input
               type="text"
-              value={githubFullName}
-              onChange={(e) => setGithubFullName(e.target.value)}
+              {...register('githubFullName', { validate: validateRepoName })}
               placeholder="owner/repo (e.g., facebook/react)"
               disabled={isSubmitting}
               className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
                 darkTheme
                   ? 'bg-white/10 border-white/20 text-[#e8dfd0] placeholder:text-[#b8a898] focus:border-[#c9983a] focus:bg-white/15'
                   : 'bg-white/40 border-white/50 text-[#2d2820] placeholder:text-[#7a6b5a] focus:border-[#c9983a] focus:bg-white/60'
-              } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
-              required
+              } ${errors.githubFullName ? 'border-red-500/50' : ''} ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
             />
-            <p className={`mt-1.5 text-[12px] transition-colors ${
-              darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-            }`}>
-              Enter the full repository name in format: owner/repository
-            </p>
+            {errors.githubFullName && (
+              <p className="mt-1.5 text-[12px] text-red-500">{errors.githubFullName.message}</p>
+            )}
+            {!errors.githubFullName && (
+              <p className={`mt-1.5 text-[12px] transition-colors ${
+                darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+              }`}>
+                Enter the full repository name in format: owner/repository
+              </p>
+            )}
           </div>
 
           {/* Ecosystem */}
@@ -219,24 +221,32 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             {isLoadingEcosystems ? (
               <SkeletonLoader className="h-12 w-full rounded-[12px]" />
             ) : (
-              <select
-                value={ecosystemName}
-                onChange={(e) => setEcosystemName(e.target.value)}
-                disabled={isSubmitting || ecosystems.length === 0}
-                className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
-                  darkTheme
-                    ? 'bg-white/10 border-white/20 text-[#e8dfd0] focus:border-[#c9983a] focus:bg-white/15'
-                    : 'bg-white/40 border-white/50 text-[#2d2820] focus:border-[#c9983a] focus:bg-white/60'
-                } ${isSubmitting || ecosystems.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}`}
-                required
-              >
-                <option value="">Select an ecosystem</option>
-                {ecosystems.map((eco) => (
-                  <option key={eco.slug} value={eco.name}>
-                    {eco.name}
-                  </option>
-                ))}
-              </select>
+              <Controller
+                name="ecosystemName"
+                control={control}
+                rules={{ validate: (v) => validateRequired(v, 'Ecosystem') }}
+                render={({ field }) => (
+                  <select
+                    {...field}
+                    disabled={isSubmitting || ecosystems.length === 0}
+                    className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
+                      darkTheme
+                        ? 'bg-white/10 border-white/20 text-[#e8dfd0] focus:border-[#c9983a] focus:bg-white/15'
+                        : 'bg-white/40 border-white/50 text-[#2d2820] focus:border-[#c9983a] focus:bg-white/60'
+                    } ${errors.ecosystemName ? 'border-red-500/50' : ''} ${isSubmitting || ecosystems.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  >
+                    <option value="">Select an ecosystem</option>
+                    {ecosystems.map((eco) => (
+                      <option key={eco.slug} value={eco.name}>
+                        {eco.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+            )}
+            {errors.ecosystemName && (
+              <p className="mt-1.5 text-[12px] text-red-500">{errors.ecosystemName.message}</p>
             )}
           </div>
 
@@ -249,8 +259,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             </label>
             <input
               type="text"
-              value={language}
-              onChange={(e) => setLanguage(e.target.value)}
+              {...register('language')}
               placeholder="e.g., TypeScript, Go, Python"
               disabled={isSubmitting}
               className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
@@ -270,8 +279,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             </label>
             <input
               type="text"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
+              {...register('tags')}
               placeholder="Comma-separated: good first issue, help wanted"
               disabled={isSubmitting}
               className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
@@ -296,8 +304,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             </label>
             <input
               type="text"
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
+              {...register('category')}
               placeholder="e.g., Frontend, Backend, Full Stack"
               disabled={isSubmitting}
               className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
@@ -324,7 +331,7 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
             </button>
             <button
               type="submit"
-              disabled={isSubmitting || success}
+              disabled={isSubmitting || success || !isValid}
               className={`flex-1 px-5 py-3 rounded-[12px] border-2 font-semibold text-[14px] transition-all ${
                 darkTheme
                   ? 'bg-gradient-to-br from-[#c9983a]/40 to-[#d4af37]/30 border-[#c9983a]/70 text-[#fef5e7] hover:from-[#c9983a]/50 hover:to-[#d4af37]/40 shadow-[0_4px_16px_rgba(201,152,58,0.4)]'

--- a/src/features/settings/components/profile/ProfileTab.test.tsx
+++ b/src/features/settings/components/profile/ProfileTab.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { renderWithTheme } from '../../../../test/renderWithTheme'
+import { ProfileTab } from './ProfileTab'
+
+const mockGetCurrentUser = vi.fn()
+const mockUpdateProfile = vi.fn()
+const mockUpdateAvatar = vi.fn()
+const mockResyncGitHubProfile = vi.fn()
+
+vi.mock('../../../../shared/api/client', () => ({
+  getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+  updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
+  updateAvatar: (...args: unknown[]) => mockUpdateAvatar(...args),
+  resyncGitHubProfile: (...args: unknown[]) => mockResyncGitHubProfile(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const mockUser = {
+  id: 'user-1',
+  role: 'developer',
+  first_name: 'John',
+  last_name: 'Doe',
+  location: 'San Francisco',
+  website: 'https://example.com',
+  bio: 'A developer',
+  avatar_url: null,
+  telegram: '@johndoe',
+  linkedin: 'johndoe',
+  whatsapp: '+1234567890',
+  twitter: '@johndoe',
+  discord: 'johndoe#1234',
+  github: {
+    login: 'johndoe',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    location: 'San Francisco',
+    bio: 'A developer',
+    website: 'https://example.com',
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ProfileTab', () => {
+  it('renders heading and loads data', async () => {
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('John')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('Doe')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('San Francisco')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('https://example.com')).toBeInTheDocument()
+  })
+
+  it('shows website validation error on blur', async () => {
+    const user = userEvent.setup()
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('https://example.com')).toBeInTheDocument()
+    })
+
+    const websiteInput = screen.getByDisplayValue('https://example.com')
+    await user.clear(websiteInput)
+    await user.type(websiteInput, 'not-a-url')
+    await user.tab()
+
+    expect(await screen.findByText(/valid URL/i)).toBeInTheDocument()
+  })
+
+  it('disables submit button when form is not dirty', async () => {
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('John')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  })
+
+  it('disables submit button when form is invalid', async () => {
+    const user = userEvent.setup()
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('https://example.com')).toBeInTheDocument()
+    })
+
+    const websiteInput = screen.getByDisplayValue('https://example.com')
+    await user.clear(websiteInput)
+    await user.type(websiteInput, 'bad-url')
+    await user.tab()
+
+    expect(await screen.findByText(/valid URL/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  })
+
+  it('calls updateProfile and shows success toast on valid submit', async () => {
+    const user = userEvent.setup()
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    mockUpdateProfile.mockResolvedValue(undefined)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('John')).toBeInTheDocument()
+    })
+
+    const firstNameInput = screen.getByDisplayValue('John')
+    await user.clear(firstNameInput)
+    await user.type(firstNameInput, 'Jane')
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ first_name: 'Jane' }),
+      )
+    })
+    expect(toast.success).toHaveBeenCalledWith('Profile updated successfully!')
+  })
+
+  it('shows error toast when updateProfile fails', async () => {
+    const user = userEvent.setup()
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    mockUpdateProfile.mockRejectedValue(new Error('API error'))
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('John')).toBeInTheDocument()
+    })
+
+    const firstNameInput = screen.getByDisplayValue('John')
+    await user.clear(firstNameInput)
+    await user.type(firstNameInput, 'Jane')
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to update profile. Please try again.',
+      )
+    })
+  })
+})

--- a/src/features/settings/components/profile/ProfileTab.tsx
+++ b/src/features/settings/components/profile/ProfileTab.tsx
@@ -1,9 +1,11 @@
 import { logger } from '../../../../shared/utils/logger';
 import { useState, useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
 import { Github, User, Upload, Link as LinkIcon } from 'lucide-react';
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
 import { getCurrentUser, updateProfile, updateAvatar, resyncGitHubProfile } from '../../../../shared/api/client';
 import { toast } from 'sonner';
+import { validateUrl } from '../../../../shared/utils/validation';
 
 interface CurrentUser {
   id: string;
@@ -30,6 +32,19 @@ interface CurrentUser {
   };
 }
 
+interface ProfileFormData {
+  firstName: string;
+  lastName: string;
+  location: string;
+  website: string;
+  bio: string;
+  telegram: string;
+  linkedin: string;
+  whatsapp: string;
+  twitter: string;
+  discord: string;
+}
+
 export function ProfileTab() {
   const { theme } = useTheme();
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
@@ -38,42 +53,28 @@ export function ProfileTab() {
   const [isResyncing, setIsResyncing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Form state
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [location, setLocation] = useState('');
-  const [website, setWebsite] = useState('');
-  const [bio, setBio] = useState('');
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
-  const [telegram, setTelegram] = useState('');
-  const [linkedin, setLinkedin] = useState('');
-  const [whatsapp, setWhatsapp] = useState('');
-  const [twitter, setTwitter] = useState('');
-  const [discord, setDiscord] = useState('');
-  const [initialValues, setInitialValues] = useState({
-    firstName: '',
-    lastName: '',
-    location: '',
-    website: '',
-    bio: '',
-    telegram: '',
-    linkedin: '',
-    whatsapp: '',
-    twitter: '',
-    discord: '',
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty, isValid },
+  } = useForm<ProfileFormData>({
+    mode: 'onBlur',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      location: '',
+      website: '',
+      bio: '',
+      telegram: '',
+      linkedin: '',
+      whatsapp: '',
+      twitter: '',
+      discord: '',
+    },
   });
 
-  const isDirty =
-    firstName !== initialValues.firstName ||
-    lastName !== initialValues.lastName ||
-    location !== initialValues.location ||
-    website !== initialValues.website ||
-    bio !== initialValues.bio ||
-    telegram !== initialValues.telegram ||
-    linkedin !== initialValues.linkedin ||
-    whatsapp !== initialValues.whatsapp ||
-    twitter !== initialValues.twitter ||
-    discord !== initialValues.discord;
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   useEffect(() => {
     const fetchUser = async () => {
       setIsLoading(true);
@@ -81,8 +82,7 @@ export function ProfileTab() {
         const user = await getCurrentUser();
         setCurrentUser(user);
 
-        // Prefill form fields from database (preferred) or GitHub data
-        // Use database values first, then fallback to GitHub
+        // Derive first/last name from database or GitHub
         let fName = '';
         if (user.first_name) {
           fName = user.first_name;
@@ -92,7 +92,6 @@ export function ProfileTab() {
             fName = nameParts[0];
           }
         }
-        setFirstName(fName);
 
         let lName = '';
         if (user.last_name) {
@@ -103,7 +102,6 @@ export function ProfileTab() {
             lName = nameParts.slice(1).join(' ');
           }
         }
-        setLastName(lName);
 
         // Set avatar URL (database avatar_url takes precedence)
         if (user.avatar_url) {
@@ -112,30 +110,16 @@ export function ProfileTab() {
           setAvatarUrl(user.github.avatar_url);
         }
 
-        // Use database values if available, otherwise use GitHub
         const loc = user.location || user.github?.location || '';
         const web = user.website || user.github?.website || '';
         const b = user.bio || user.github?.bio || '';
-
-        setLocation(loc);
-        setWebsite(web);
-        setBio(b);
-
-        // Set social links from database
         const tel = user.telegram || '';
         const li = user.linkedin || '';
         const wa = user.whatsapp || '';
         const tw = user.twitter || '';
         const di = user.discord || '';
 
-        setTelegram(tel);
-        setLinkedin(li);
-        setWhatsapp(wa);
-        setTwitter(tw);
-        setDiscord(di);
-
-        // Set initial values for dirty check
-        setInitialValues({
+        reset({
           firstName: fName,
           lastName: lName,
           location: loc,
@@ -155,7 +139,7 @@ export function ProfileTab() {
       }
     };
     fetchUser();
-  }, []);
+  }, [reset]);
 
   const handleResync = async () => {
     setIsResyncing(true);
@@ -233,55 +217,52 @@ export function ProfileTab() {
     }
   };
 
-  const handleSave = async () => {
+  const onSubmit = async (data: ProfileFormData) => {
     setIsSaving(true);
     try {
       await updateProfile({
-        first_name: firstName || undefined,
-        last_name: lastName || undefined,
-        location: location || undefined,
-        website: website || undefined,
-        bio: bio || undefined,
-        telegram: telegram || undefined,
-        linkedin: linkedin || undefined,
-        whatsapp: whatsapp || undefined,
-        twitter: twitter || undefined,
-        discord: discord || undefined,
+        first_name: data.firstName || undefined,
+        last_name: data.lastName || undefined,
+        location: data.location || undefined,
+        website: data.website || undefined,
+        bio: data.bio || undefined,
+        telegram: data.telegram || undefined,
+        linkedin: data.linkedin || undefined,
+        whatsapp: data.whatsapp || undefined,
+        twitter: data.twitter || undefined,
+        discord: data.discord || undefined,
       });
       // Refetch user data to get updated profile
       const user = await getCurrentUser();
       setCurrentUser(user);
 
-      // Update form fields with saved data from database
-      setFirstName(user.first_name || '');
-      setLastName(user.last_name || '');
-      setLocation(user.location || user.github?.location || '');
-      setWebsite(user.website || user.github?.website || '');
-      setBio(user.bio || user.github?.bio || '');
-      setTelegram(user.telegram || '');
-      setLinkedin(user.linkedin || '');
-      setWhatsapp(user.whatsapp || '');
-      setTwitter(user.twitter || '');
-      setDiscord(user.discord || '');
+      const loc = user.location || user.github?.location || '';
+      const web = user.website || user.github?.website || '';
+      const b = user.bio || user.github?.bio || '';
+      const tel = user.telegram || '';
+      const li = user.linkedin || '';
+      const wa = user.whatsapp || '';
+      const tw = user.twitter || '';
+      const di = user.discord || '';
+
+      reset({
+        firstName: user.first_name || '',
+        lastName: user.last_name || '',
+        location: loc,
+        website: web,
+        bio: b,
+        telegram: tel,
+        linkedin: li,
+        whatsapp: wa,
+        twitter: tw,
+        discord: di,
+      });
+
       if (user.avatar_url) {
         setAvatarUrl(user.avatar_url);
       } else if (user.github?.avatar_url) {
         setAvatarUrl(user.github.avatar_url);
       }
-
-      // Update initial values after successful save
-      setInitialValues({
-        firstName: user.first_name || '',
-        lastName: user.last_name || '',
-        location: user.location || user.github?.location || '',
-        website: user.website || user.github?.website || '',
-        bio: user.bio || user.github?.bio || '',
-        telegram: user.telegram || '',
-        linkedin: user.linkedin || '',
-        whatsapp: user.whatsapp || '',
-        twitter: user.twitter || '',
-        discord: user.discord || '',
-      });
 
       toast.success('Profile updated successfully!');
     } catch (error) {
@@ -419,8 +400,7 @@ export function ProfileTab() {
             <input
               type="text"
               placeholder="Enter your first name"
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
+              {...register('firstName')}
               className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                 ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]'
@@ -435,8 +415,7 @@ export function ProfileTab() {
             <input
               type="text"
               placeholder="Enter your last name"
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
+              {...register('lastName')}
               className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                 ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]'
@@ -451,8 +430,7 @@ export function ProfileTab() {
             <input
               type="text"
               placeholder="Enter your location"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
+              {...register('location')}
               className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                 ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]'
@@ -467,13 +445,15 @@ export function ProfileTab() {
             <input
               type="text"
               placeholder="Enter your website"
-              value={website}
-              onChange={(e) => setWebsite(e.target.value)}
+              {...register('website', { validate: validateUrl })}
               className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                 ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]'
-                }`}
+                } ${errors.website ? 'border-red-500/50' : ''}`}
             />
+            {errors.website && (
+              <p className="mt-1.5 text-[12px] text-red-500">{errors.website.message}</p>
+            )}
           </div>
         </div>
 
@@ -484,8 +464,7 @@ export function ProfileTab() {
           <textarea
             placeholder="Enter your bio"
             rows={4}
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
+            {...register('bio')}
             className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] resize-none ${theme === 'dark'
               ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
               : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]'
@@ -514,8 +493,7 @@ export function ProfileTab() {
             <div className="relative">
               <input
                 type="text"
-                value={telegram}
-                onChange={(e) => setTelegram(e.target.value)}
+                {...register('telegram')}
                 placeholder="Enter your telegram handle"
                 className={`w-full px-4 py-3 pr-10 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                   ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
@@ -534,8 +512,7 @@ export function ProfileTab() {
             <div className="relative">
               <input
                 type="text"
-                value={linkedin}
-                onChange={(e) => setLinkedin(e.target.value)}
+                {...register('linkedin')}
                 placeholder="Enter your linkedin handle"
                 className={`w-full px-4 py-3 pr-10 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                   ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
@@ -554,8 +531,7 @@ export function ProfileTab() {
             <div className="relative">
               <input
                 type="text"
-                value={whatsapp}
-                onChange={(e) => setWhatsapp(e.target.value)}
+                {...register('whatsapp')}
                 placeholder="Enter your whatsApp handle"
                 className={`w-full px-4 py-3 pr-10 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                   ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
@@ -574,8 +550,7 @@ export function ProfileTab() {
             <div className="relative">
               <input
                 type="text"
-                value={twitter}
-                onChange={(e) => setTwitter(e.target.value)}
+                {...register('twitter')}
                 placeholder="Enter your twitter handle"
                 className={`w-full px-4 py-3 pr-10 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                   ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
@@ -594,8 +569,7 @@ export function ProfileTab() {
             <div className="relative">
               <input
                 type="text"
-                value={discord}
-                onChange={(e) => setDiscord(e.target.value)}
+                {...register('discord')}
                 placeholder="Enter your discord handle"
                 className={`w-full px-4 py-3 pr-10 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
                   ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#b8a898]'
@@ -612,8 +586,8 @@ export function ProfileTab() {
       {/* Save Button */}
       <div className="flex justify-end">
         <button
-          onClick={handleSave}
-          disabled={isSaving || !isDirty}
+          onClick={handleSubmit(onSubmit)}
+          disabled={isSaving || !isDirty || !isValid}
           className={`px-8 py-3 rounded-[16px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[15px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed`}
         >
           {isSaving ? 'Saving...' : 'Save'}

--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { validateRepoName, validateUrl, validateEmail, validateRequired } from './validation'
+
+describe('validateRepoName', () => {
+  it('accepts valid owner/repo format', () => {
+    expect(validateRepoName('facebook/react')).toBe(true)
+  })
+
+  it('accepts names with hyphens', () => {
+    expect(validateRepoName('my-org/my-repo')).toBe(true)
+  })
+
+  it('accepts names with dots', () => {
+    expect(validateRepoName('org/repo.name')).toBe(true)
+  })
+
+  it('accepts names with underscores', () => {
+    expect(validateRepoName('my_org/my_repo')).toBe(true)
+  })
+
+  it('rejects empty string', () => {
+    expect(validateRepoName('')).toBe('Repository name is required')
+  })
+
+  it('rejects whitespace-only string', () => {
+    expect(validateRepoName('   ')).toBe('Repository name is required')
+  })
+
+  it('rejects missing slash', () => {
+    const result = validateRepoName('just-a-name')
+    expect(result).toBe('Repository name must be in format: owner/repo')
+  })
+
+  it('rejects trailing slash', () => {
+    const result = validateRepoName('owner/')
+    expect(result).toBe('Repository name must be in format: owner/repo')
+  })
+
+  it('rejects leading slash', () => {
+    const result = validateRepoName('/repo')
+    expect(result).toBe('Repository name must be in format: owner/repo')
+  })
+
+  it('rejects special characters', () => {
+    const result = validateRepoName('own er/repo')
+    expect(result).toContain('invalid characters')
+  })
+
+  it('rejects uppercase characters', () => {
+    // lowercase & alphanumeric are fine; test special chars
+    expect(validateRepoName('owner/repo!')).toContain('invalid characters')
+  })
+})
+
+describe('validateUrl', () => {
+  it('accepts empty string (optional field)', () => {
+    expect(validateUrl('')).toBe(true)
+  })
+
+  it('accepts whitespace-only as empty', () => {
+    expect(validateUrl('   ')).toBe(true)
+  })
+
+  it('accepts valid https URL', () => {
+    expect(validateUrl('https://example.com')).toBe(true)
+  })
+
+  it('accepts valid http URL', () => {
+    expect(validateUrl('http://example.com')).toBe(true)
+  })
+
+  it('accepts URL with path', () => {
+    expect(validateUrl('https://example.com/path/to/page')).toBe(true)
+  })
+
+  it('rejects plain text', () => {
+    const result = validateUrl('not-a-url')
+    expect(result).toContain('valid URL')
+  })
+
+  it('rejects ftp protocol', () => {
+    const result = validateUrl('ftp://example.com')
+    expect(result).toContain('http')
+  })
+
+  it('rejects missing hostname', () => {
+    const result = validateUrl('https://')
+    expect(result).toContain('valid URL')
+  })
+
+  it('rejects hostname without dot', () => {
+    const result = validateUrl('https://localhost')
+    // localhost has no dot but is technically valid; our rule catches it
+    expect(result).toBe('URL must have a valid hostname')
+  })
+})
+
+describe('validateEmail', () => {
+  it('accepts empty string (optional field)', () => {
+    expect(validateEmail('')).toBe(true)
+  })
+
+  it('accepts whitespace-only as empty', () => {
+    expect(validateEmail('   ')).toBe(true)
+  })
+
+  it('accepts valid email', () => {
+    expect(validateEmail('user@example.com')).toBe(true)
+  })
+
+  it('accepts email with dots and plus in local part', () => {
+    expect(validateEmail('user.name+tag@example.co.uk')).toBe(true)
+  })
+
+  it('rejects missing TLD', () => {
+    expect(validateEmail('user@example')).toContain('valid email')
+  })
+
+  it('rejects missing local part', () => {
+    expect(validateEmail('@example.com')).toContain('valid email')
+  })
+
+  it('rejects double @', () => {
+    expect(validateEmail('user@@example.com')).toContain('valid email')
+  })
+
+  it('rejects spaces in email', () => {
+    expect(validateEmail('user @example.com')).toContain('valid email')
+  })
+
+  it('rejects missing domain name', () => {
+    expect(validateEmail('user@.com')).toContain('valid email')
+  })
+
+  it('rejects trailing dot after TLD', () => {
+    expect(validateEmail('user@example.')).toContain('valid email')
+  })
+})
+
+describe('validateRequired', () => {
+  it('accepts non-empty value', () => {
+    expect(validateRequired('hello', 'Field')).toBe(true)
+  })
+
+  it('rejects empty string', () => {
+    expect(validateRequired('', 'Field')).toBe('Field is required')
+  })
+
+  it('rejects whitespace-only', () => {
+    expect(validateRequired('   ', 'Field')).toBe('Field is required')
+  })
+
+  it('uses custom field name in message', () => {
+    expect(validateRequired('', 'Ecosystem')).toBe('Ecosystem is required')
+  })
+})

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -1,0 +1,79 @@
+/**
+ * Validates that a GitHub repository name matches "owner/repo" format.
+ * Accepts alphanumeric characters, hyphens, underscores, and dots in both segments.
+ *
+ * @param value - The repository full name to validate.
+ * @returns `true` if valid, or an error message string if invalid.
+ */
+export function validateRepoName(value: string): string | true {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return 'Repository name is required'
+  }
+  if (!trimmed.includes('/')) {
+    return 'Repository name must be in format: owner/repo'
+  }
+  if (trimmed.startsWith('/') || trimmed.endsWith('/')) {
+    return 'Repository name must be in format: owner/repo'
+  }
+  if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(trimmed)) {
+    return 'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.'
+  }
+  return true
+}
+
+/**
+ * Validates a URL string. Accepts empty values (optional field).
+ * Must start with http:// or https:// and have a valid hostname.
+ *
+ * @param value - The URL to validate.
+ * @returns `true` if valid or empty, or an error message string if invalid.
+ */
+export function validateUrl(value: string): string | true {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return true
+  }
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return 'URL must start with http:// or https://'
+    }
+    if (!url.hostname.includes('.')) {
+      return 'URL must have a valid hostname'
+    }
+    return true
+  } catch {
+    return 'Please enter a valid URL starting with http:// or https://'
+  }
+}
+
+/**
+ * Validates an email address. Accepts empty values (optional field).
+ * Must have a local part, @ symbol, domain, and TLD with no spaces.
+ *
+ * @param value - The email address to validate.
+ * @returns `true` if valid or empty, or an error message string if invalid.
+ */
+export function validateEmail(value: string): string | true {
+  const trimmed = value.trim()
+  if (!trimmed) return true
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    return 'Please enter a valid email address'
+  }
+  return true
+}
+
+/**
+ * Validates that a value is non-empty after trimming.
+ *
+ * @param value - The value to check.
+ * @param fieldName - Display name for the field in the error message.
+ * @returns `true` if non-empty, or an error message string if empty.
+ */
+export function validateRequired(value: string, fieldName: string): string | true {
+  if (!value.trim()) {
+    return `${fieldName} is required`
+  }
+  return true
+}


### PR DESCRIPTION
# Pull Request: Refactor Forms to React-Hook-Form

## What changed
Migrated `AddRepositoryModal` and `ProfileTab` from manual `useState` blocks and ad-hoc imperative checks to `react-hook-form`.

* **Added:** Centralized validation helpers (`src/shared/utils/validation.ts`) with robust regex for owner/repo slugs and website URL parsing.
* **Added:** Comprehensive unit tests for the new validation logic and form behaviors.
* **Refactored:** Replaced scattered form states with `useForm` registration to surface clean, per-field inline error messages and manage form submission state natively.

## Why
The previous implementation relied on manual validation strings and loose checks (e.g., `.includes('/')`), which resulted in poor error UX and allowed malformed input to reach the API. Transitioning to `react-hook-form` enforces consistent schema validation, improves UX with field-level feedback, and ensures input is client-side validated and trimmed before submission.

## Checklist
- [x] Both forms use `react-hook-form` with per-field error display
- [x] owner/repo and URL fields are validated by schema
- [x] Submit is disabled while invalid/submitting
- [x] Existing API submit + toast behaviour preserved
- [x] Tests cover valid and each invalid path