### PR TITLE
fix(billing): validate wallet address format before saving payment method

### DIFF
--- a/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PaymentMethodsTab, validateWalletAddress } from './PaymentMethodsTab';
+import { renderWithTheme } from '../../../../test/renderWithTheme';
+import type { PaymentMethod } from '../../types';
+
+function createValidAddress(prefix: 'G' | 'M' | 'C'): string {
+  const length = prefix === 'M' ? 69 : 56;
+  return prefix + 'A'.repeat(length - 1);
+}
+
+const VALID_G = createValidAddress('G');
+const VALID_M = createValidAddress('M');
+const VALID_C = createValidAddress('C');
+
+function setup(initial: PaymentMethod[] = []) {
+  const onAddPaymentMethod = vi.fn();
+  const onRemovePaymentMethod = vi.fn();
+  const onSetDefault = vi.fn();
+
+  const result = renderWithTheme(
+    <PaymentMethodsTab
+      paymentMethods={initial}
+      onAddPaymentMethod={onAddPaymentMethod}
+      onRemovePaymentMethod={onRemovePaymentMethod}
+      onSetDefault={onSetDefault}
+    />,
+  );
+
+  return { onAddPaymentMethod, onRemovePaymentMethod, onSetDefault, ...result };
+}
+
+async function openModal() {
+  const user = userEvent.setup();
+  // The header "Add Wallet" button is the first one in DOM order
+  const buttons = screen.getAllByRole('button', { name: /add wallet/i });
+  await user.click(buttons[0]);
+}
+
+async function typeAddress(address: string) {
+  const user = userEvent.setup();
+  const input = screen.getByPlaceholderText(/enter your.*wallet address/i);
+  await user.type(input, address);
+  return input;
+}
+
+async function submit() {
+  const user = userEvent.setup();
+  await user.click(getSubmitButton());
+}
+
+function getInput() {
+  return screen.getByPlaceholderText(/enter your.*wallet address/i);
+}
+
+function getSubmitButton() {
+  const buttons = screen.getAllByRole('button', { name: /add wallet/i });
+  // The modal submit button is the last "Add Wallet" button in DOM order
+  return buttons[buttons.length - 1];
+}
+
+describe('validateWalletAddress', () => {
+  it('returns null for empty input', () => {
+    expect(validateWalletAddress('')).toBeNull();
+    expect(validateWalletAddress('   ')).toBeNull();
+  });
+
+  it('returns null for a valid G address (56 chars)', () => {
+    expect(validateWalletAddress(VALID_G)).toBeNull();
+  });
+
+  it('returns null for a valid M address (69 chars)', () => {
+    expect(validateWalletAddress(VALID_M)).toBeNull();
+  });
+
+  it('returns null for a valid C address (56 chars)', () => {
+    expect(validateWalletAddress(VALID_C)).toBeNull();
+  });
+
+  it('returns null for a valid address with surrounding whitespace', () => {
+    expect(validateWalletAddress(`  ${VALID_G}  `)).toBeNull();
+  });
+
+  it('rejects an address with wrong prefix', () => {
+    const error = validateWalletAddress('X' + 'A'.repeat(55));
+    expect(error).toMatch(/start with G, M, or C/i);
+  });
+
+  it('rejects an address that is too short', () => {
+    const error = validateWalletAddress('G' + 'A'.repeat(50));
+    expect(error).toMatch(/exactly 56 characters/i);
+  });
+
+  it('rejects a G address that is too long', () => {
+    const error = validateWalletAddress('G' + 'A'.repeat(60));
+    expect(error).toMatch(/exactly 56 characters/i);
+  });
+
+  it('rejects an M address with wrong length', () => {
+    const error = validateWalletAddress('M' + 'A'.repeat(55));
+    expect(error).toMatch(/exactly 69 characters/i);
+  });
+
+  it('rejects addresses with lowercase characters', () => {
+    const error = validateWalletAddress('g' + 'A'.repeat(55));
+    expect(error).toMatch(/start with G, M, or C/i);
+  });
+
+  it('rejects addresses with special characters', () => {
+    const error = validateWalletAddress('G' + 'A'.repeat(54) + '!');
+    expect(error).toMatch(/invalid characters/i);
+  });
+
+  it('rejects addresses with digits 0 and 1', () => {
+    const error = validateWalletAddress('G' + 'A'.repeat(54) + '0');
+    expect(error).toMatch(/invalid characters/i);
+  });
+});
+
+describe('PaymentMethodsTab - wallet address validation', () => {
+  it('opens the modal when Add Wallet is clicked', async () => {
+    setup();
+    await openModal();
+    expect(screen.getByText('Add Payment Method')).toBeInTheDocument();
+  });
+
+  it('disables the submit button when input is empty', async () => {
+    setup();
+    await openModal();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('disables the submit button after validation fails', async () => {
+    setup();
+    await openModal();
+    await typeAddress('invalid');
+    await submit();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('calls onAddPaymentMethod with a valid address', async () => {
+    const { onAddPaymentMethod } = setup();
+    await openModal();
+    await typeAddress(VALID_G);
+    await submit();
+    expect(onAddPaymentMethod).toHaveBeenCalledTimes(1);
+    expect(onAddPaymentMethod).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: VALID_G }),
+    );
+  });
+
+  it('trims whitespace before validation and uses trimmed address', async () => {
+    const { onAddPaymentMethod } = setup();
+    await openModal();
+    const input = getInput();
+    const user = userEvent.setup();
+    await user.type(input, `  ${VALID_G}  `);
+    await submit();
+    expect(onAddPaymentMethod).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: VALID_G }),
+    );
+  });
+
+  it('shows an error and does not call onAddPaymentMethod for invalid addresses', async () => {
+    const { onAddPaymentMethod } = setup();
+    await openModal();
+    await typeAddress('BAD');
+    await submit();
+    expect(onAddPaymentMethod).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('clears the error when the user starts typing after a failed submission', async () => {
+    setup();
+    await openModal();
+    await typeAddress('BAD');
+    await submit();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    const input = getInput();
+    const user = userEvent.setup();
+    await user.type(input, 'X');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('resets the error when the modal is closed via close button', async () => {
+    setup();
+    await openModal();
+    await typeAddress('BAD');
+    await submit();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    await openModal();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('resets the error when the modal is closed via Cancel button', async () => {
+    setup();
+    await openModal();
+    await typeAddress('BAD');
+    await submit();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    await openModal();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('PaymentMethodsTab - accessibility', () => {
+  it('sets aria-invalid on the input when validation fails', async () => {
+    setup();
+    await openModal();
+    const input = getInput();
+    expect(input).not.toHaveAttribute('aria-invalid');
+
+    await typeAddress('BAD');
+    await submit();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('sets aria-describedby pointing to the error message', async () => {
+    setup();
+    await openModal();
+    const input = getInput();
+    await typeAddress('BAD');
+    await submit();
+
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBe('wallet-address-error');
+    const errorEl = document.getElementById('wallet-address-error');
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveTextContent(/start with G, M, or C/i);
+  });
+
+  it('renders the error with role="alert"', async () => {
+    setup();
+    await openModal();
+    await typeAddress('BAD');
+    await submit();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/src/features/settings/components/billing/PaymentMethodsTab.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.tsx
@@ -4,6 +4,39 @@ import { Plus, Trash2, Wallet, Copy, CheckCircle2, Star, X } from 'lucide-react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
 import { PaymentMethod, EcosystemType, CryptoType } from '../../types';
 
+/**
+ * Validates a Stellar wallet address format.
+ *
+ * Stellar addresses are base32-encoded using characters A-Z and 2-7:
+ * - Ed25519 public keys: 56 characters, starting with 'G'
+ * - Muxed accounts: 69 characters, starting with 'M'
+ * - Contract accounts: 56 characters, starting with 'C'
+ *
+ * @param address - Raw wallet address input (will be trimmed before validation)
+ * @returns An error message string if invalid, or `null` if the address is valid
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function validateWalletAddress(address: string): string | null {
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+
+  const prefix = trimmed[0];
+  if (!['G', 'M', 'C'].includes(prefix)) {
+    return 'Wallet address must start with G, M, or C';
+  }
+
+  const expectedLength = prefix === 'M' ? 69 : 56;
+  if (trimmed.length !== expectedLength) {
+    return `Wallet address must be exactly ${expectedLength} characters`;
+  }
+
+  if (!/^[A-Z2-7]+$/.test(trimmed)) {
+    return 'Wallet address contains invalid characters (only A-Z and 2-7 allowed)';
+  }
+
+  return null;
+}
+
 interface PaymentMethodsTabProps {
   paymentMethods: PaymentMethod[];
   onAddPaymentMethod: (method: PaymentMethod) => void;
@@ -22,25 +55,36 @@ export function PaymentMethodsTab({
   const selectedEcosystem: EcosystemType = 'stellar';
   const [selectedCrypto, setSelectedCrypto] = useState<CryptoType>('usdc');
   const [walletAddress, setWalletAddress] = useState('');
+  const [walletAddressError, setWalletAddressError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<number | null>(null);
 
   const getAvailableCryptos = (): CryptoType[] => ['usdc', 'usdt', 'xlm'];
 
   const handleAddPaymentMethod = () => {
-    if (!walletAddress.trim()) return;
+    const trimmed = walletAddress.trim();
+    if (!trimmed) return;
+
+    const error = validateWalletAddress(trimmed);
+    if (error) {
+      setWalletAddressError(error);
+      return;
+    }
+
+    setWalletAddressError(null);
 
     const newMethod: PaymentMethod = {
       id: Date.now(),
       ecosystem: selectedEcosystem,
       cryptoType: selectedCrypto,
-      walletAddress: walletAddress,
-      isDefault: paymentMethods.length === 0, // First one is default
+      walletAddress: trimmed,
+      isDefault: paymentMethods.length === 0,
       createdAt: new Date().toISOString(),
     };
 
     onAddPaymentMethod(newMethod);
     setShowAddModal(false);
     setWalletAddress('');
+    setWalletAddressError(null);
     setSelectedCrypto('usdc');
   };
 
@@ -218,7 +262,10 @@ export function PaymentMethodsTab({
                 theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
               }`}>Add Payment Method</h3>
               <button 
-                onClick={() => setShowAddModal(false)} 
+                onClick={() => {
+                  setShowAddModal(false);
+                  setWalletAddressError(null);
+                }}
                 className={`w-8 h-8 rounded-[10px] backdrop-blur-[20px] border flex items-center justify-center transition-all ${
                   theme === 'dark'
                     ? 'bg-white/[0.1] hover:bg-white/[0.15] border-white/20'
@@ -272,14 +319,24 @@ export function PaymentMethodsTab({
                 <input
                   type="text"
                   value={walletAddress}
-                  onChange={(e) => setWalletAddress(e.target.value)}
+                  onChange={(e) => {
+                    setWalletAddress(e.target.value);
+                    if (walletAddressError) setWalletAddressError(null);
+                  }}
                   placeholder={`Enter your ${getCryptoLabel(selectedCrypto)} wallet address`}
                   className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] font-mono transition-all ${
                     theme === 'dark'
                       ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50 focus:border-[#c9983a]/40'
                       : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50 focus:bg-white/[0.2] focus:border-[#c9983a]/40'
                   }`}
+                  aria-invalid={walletAddressError ? true : undefined}
+                  aria-describedby={walletAddressError ? 'wallet-address-error' : undefined}
                 />
+                {walletAddressError && (
+                  <p id="wallet-address-error" role="alert" className="text-[12px] mt-1 text-red-500">
+                    {walletAddressError}
+                  </p>
+                )}
                 <p className={`text-[12px] mt-2 transition-colors ${
                   theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
                 }`}>
@@ -290,7 +347,10 @@ export function PaymentMethodsTab({
 
             <div className="flex items-center gap-3 mt-6">
               <button
-                onClick={() => setShowAddModal(false)}
+                onClick={() => {
+                  setShowAddModal(false);
+                  setWalletAddressError(null);
+                }}
                 className={`flex-1 px-6 py-3 rounded-[12px] backdrop-blur-[30px] border font-medium text-[14px] transition-all ${
                   theme === 'dark'
                     ? 'bg-white/[0.08] border-white/20 text-[#d4c5b0] hover:bg-white/[0.12]'
@@ -301,7 +361,7 @@ export function PaymentMethodsTab({
               </button>
               <button
                 onClick={handleAddPaymentMethod}
-                disabled={!walletAddress.trim()}
+                disabled={!walletAddress.trim() || !!walletAddressError}
                 className="flex-1 px-6 py-3 rounded-[12px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[14px] shadow-[0_4px_16px_rgba(162,121,44,0.3)] hover:shadow-[0_6px_20px_rgba(162,121,44,0.4)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Add Wallet


### PR DESCRIPTION
Closes #76 

## Description

Added client-side wallet address format validation in `PaymentMethodsTab` before submitting a new payment method.

### Changes

**`src/features/settings/components/billing/PaymentMethodsTab.tsx`**

- **Exported `validateWalletAddress` function** with TSDoc — validates Stellar wallet addresses:
  - Prefix must be `G`, `M`, or `C`
  - Length: 56 chars for `G`/`C` (Ed25519/Contract), 69 chars for `M` (Muxed)
  - Character set: `A-Z` and `2-7` (base32)
  - Input is trimmed and normalized before validation
- **Added `walletAddressError` state** to track validation errors inline
- **Updated `handleAddPaymentMethod`** — validates before submitting, blocks on invalid input, uses trimmed address in the saved method
- **Inline error UI** with `role="alert"` for assistive tech announcement
- **Accessibility attributes** — `aria-invalid` and `aria-describedby` wired to the input when an error is present
- **Button disabled logic** — "Add Wallet" disabled when error exists (in addition to existing empty-input check)
- **Error resets** on modal close and when user starts typing after a failed submission

**`src/features/settings/components/billing/PaymentMethodsTab.test.tsx`** (new, 24 tests)

- 12 unit tests for `validateWalletAddress` covering: empty input, valid G/M/C formats, whitespace trimming, wrong prefix, too short, too long, lowercase, special characters, invalid digits
- 9 component tests for UI behavior: modal open, disabled states, valid submission, whitespace trimming, error display, error clearing, error reset on close
- 3 accessibility tests: `aria-invalid`, `aria-describedby` linking to error, `role="alert"`

### Acceptance criteria met

- [x] Malformed addresses rejected with inline error
- [x] Error announced to assistive tech (`role="alert"`, `aria-describedby`)
- [x] Whitespace trimmed/normalized before validation
- [x] Valid addresses still save
- [x] Tests cover valid and several invalid cases

### Security notes

Client-side validation is defense-in-depth; the server must still validate independently. Invalid data is blocked before submission — only trimmed, validated addresses reach the `onAddPaymentMethod` callback.


### Screenshots:

<img width="1491" height="658" alt="image" src="https://github.com/user-attachments/assets/9ed7392a-372f-4e25-a056-182285c110c1" />

<img width="1491" height="658" alt="image" src="https://github.com/user-attachments/assets/6fe70580-2efb-4085-8d1c-da10c42a5a5f" />
