### PR TITLE
refactor(billing): replace native alert with themed toast error

### DIFF
--- a/src/features/settings/components/billing/BillingTab.test.tsx
+++ b/src/features/settings/components/billing/BillingTab.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BillingTab } from './BillingTab';
+import { toast } from 'sonner';
+
+// Mock contexts and hooks
+vi.mock('../../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+// We'll mock the hook to control the profiles state
+const mockProfiles = [
+  { id: 1, name: 'John Doe', type: 'individual', status: 'verified' }
+];
+
+const mockAddProfile = vi.fn();
+
+vi.mock('../../contexts/BillingProfilesContext', () => ({
+  useBillingProfiles: () => ({
+    profiles: mockProfiles,
+    setProfiles: vi.fn(),
+    addProfile: mockAddProfile,
+    updateProfile: vi.fn(),
+  }),
+}));
+
+// Mock the API client
+vi.mock('../../../../shared/api/client', () => ({
+  getBillingProfiles: vi.fn().mockResolvedValue([]),
+  getKYCStatus: vi.fn().mockResolvedValue({ status: 'verified' }),
+  startKYCVerification: vi.fn().mockResolvedValue({ url: 'https://example.com' }),
+}));
+
+describe('BillingTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_USE_MOCK_DATA', 'true');
+  });
+
+  it('shows an error toast when trying to create a duplicate individual profile', async () => {
+    render(<BillingTab />);
+    
+    // Open modal
+    const newProfileBtn = await screen.findByText('New Profile');
+    fireEvent.click(newProfileBtn);
+    
+    // Fill in a valid name
+    const nameInput = screen.getByRole('textbox');
+    fireEvent.change(nameInput, { target: { value: 'Jane Doe' } });
+    
+    // Try to create
+    const createBtn = screen.getByRole('button', { name: 'Create' });
+    fireEvent.click(createBtn);
+    
+    // Toast should be called
+    expect(toast.error).toHaveBeenCalledWith('An individual billing profile already exists. You can only create one individual profile.');
+    
+    // addProfile should not have been called
+    expect(mockAddProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -1,6 +1,7 @@
 import { logger } from '../../../../shared/utils/logger';
 import { useState, useEffect, useRef } from 'react';
 import { Plus, X, Loader2, AlertCircle, Info, ChevronDown, MessageSquare } from 'lucide-react';
+import { toast } from 'sonner';
 import { BillingProfile, BillingProfileType, BillingProfileStatus, ProfileDetailTabType, PaymentMethod, Invoice } from '../../types';
 import { getBillingProfiles } from "../../../../shared/api/client";
 import { sampleInvoices } from '../../data/invoicesData';
@@ -149,7 +150,12 @@ export function BillingTab() {
     if (profileType === 'individual') {
       const existingIndividual = profiles.find(p => p.type === 'individual');
       if (existingIndividual) {
-        alert('An individual billing profile already exists. You can only create one individual profile.');
+        /**
+         * Error Path: Block duplicate individual profiles.
+         * Uses sonner toast instead of native alert to ensure screen readers announce
+         * the error properly without blocking the main thread, maintaining visual consistency.
+         */
+        toast.error('An individual billing profile already exists. You can only create one individual profile.');
         return;
       }
     }
@@ -855,7 +861,6 @@ export function BillingTab() {
                 </button>
                 <button
                   onClick={handleCreateProfile}
-                  disabled={profileType === 'individual' && profiles.some(p => p.type === 'individual')}
                   className="flex-1 px-6 py-3 rounded-[12px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[14px] shadow-[0_4px_16px_rgba(162,121,44,0.3)] hover:shadow-[0_6px_20px_rgba(162,121,44,0.4)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Create


### PR DESCRIPTION

 Closes #77 


## Description
This PR replaces a jarring native `alert()` call inside `BillingTab` with an accessible, themed Toast notification. Previously, the main thread was blocked when a user tried to create a duplicate individual profile. Additionally, the `Create` button is no longer explicitly disabled when a duplicate profile exists, ensuring that the Toast triggers and screen readers correctly announce the error when interacted with.

## Changes Made
- Imported and utilized `toast` from `sonner` inside `src/features/settings/components/billing/BillingTab.tsx`.
- Removed native `alert()` from `handleCreateProfile`.
- Enabled the duplicate check to visibly run to ensure the toast error gets announced by screen readers through Toast's live regions.
- Wrote tests mocking `useBillingProfiles`, environment variables, and `toast` to strictly assert proper behavior.

## Security notes
None; UI consistency only.

## Test Output
```text
> @figma/my-make-file@0.0.1 test
> vitest run src/features/settings/components/billing/BillingTab.test.tsx

 RUN  v4.1.9 /Users/0xblackadam/Downloads/Grainlify-Frontend

 ✓ src/features/settings/components/billing/BillingTab.test.tsx (1 test) 54ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
      
 
 