### PR TITLE
feat(settings): persist payout project mappings on save

### DIFF
--- a/src/features/settings/components/payout/PayoutTab.test.tsx
+++ b/src/features/settings/components/payout/PayoutTab.test.tsx
@@ -1,0 +1,371 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PayoutTab } from './PayoutTab';
+import { ThemeProvider } from '../../../../shared/contexts/ThemeContext';
+import { BillingProfilesProvider } from '../../contexts/BillingProfilesContext';
+import type { ReactNode } from 'react';
+
+// ── Hoisted mock factories ────────────────────────────────────────────────────
+const {
+  mockGetProjectsContributed,
+  mockGetPayoutMappings,
+  mockSavePayoutMappings,
+} = vi.hoisted(() => ({
+  mockGetProjectsContributed: vi.fn(),
+  mockGetPayoutMappings: vi.fn(),
+  mockSavePayoutMappings: vi.fn(),
+}));
+
+vi.mock('../../../../shared/api/client', () => ({
+  getProjectsContributed: mockGetProjectsContributed,
+  getPayoutMappings: mockGetPayoutMappings,
+  savePayoutMappings: mockSavePayoutMappings,
+}));
+
+// Capture toast calls without rendering the Toaster DOM node
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+  Toaster: () => null,
+}));
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+const PROJECT_A = {
+  id: 'proj-1',
+  github_full_name: 'org/alpha',
+  status: 'active',
+  ecosystem_name: 'Stellar',
+  language: undefined,
+  owner_avatar_url: undefined,
+};
+
+const PROJECT_B = {
+  id: 'proj-2',
+  github_full_name: 'org/beta',
+  status: 'active',
+  ecosystem_name: undefined,
+  language: 'TypeScript',
+  owner_avatar_url: undefined,
+};
+
+const VERIFIED_PROFILE = { id: 1, name: 'My Wallet', status: 'verified' as const, type: 'individual' as const };
+const UNVERIFIED_PROFILE = { id: 2, name: 'Pending', status: 'missing-verification' as const, type: 'individual' as const };
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+function renderPayoutTab(
+  initialProfiles: typeof VERIFIED_PROFILE[] = [],
+) {
+  // Seed localStorage so BillingProfilesProvider picks up these profiles
+  localStorage.setItem('billing_profiles', JSON.stringify(initialProfiles));
+
+  return render(
+    <ThemeProvider>
+      <BillingProfilesProvider>
+        <PayoutTab />
+      </BillingProfilesProvider>
+    </ThemeProvider>,
+  );
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+
+  // Default: no persisted mappings, no projects
+  mockGetProjectsContributed.mockResolvedValue([]);
+  mockGetPayoutMappings.mockResolvedValue([]);
+  mockSavePayoutMappings.mockResolvedValue({ ok: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('PayoutTab – loading state', () => {
+  it('shows skeleton loaders while data is fetching', () => {
+    // Never resolve so we stay in loading state
+    mockGetProjectsContributed.mockReturnValue(new Promise(() => {}));
+    mockGetPayoutMappings.mockReturnValue(new Promise(() => {}));
+
+    renderPayoutTab();
+
+    // SkeletonLoader elements are rendered (they have an animated class)
+    const skeletons = document.querySelectorAll('[class*="animate"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+describe('PayoutTab – empty state', () => {
+  it('renders the empty-state message when no projects are returned', async () => {
+    mockGetProjectsContributed.mockResolvedValue([]);
+
+    renderPayoutTab();
+
+    await waitFor(() =>
+      expect(screen.getByText('No projects found')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('PayoutTab – error state', () => {
+  it('shows an error banner when the projects fetch fails', async () => {
+    mockGetProjectsContributed.mockRejectedValue(new Error('Network error'));
+
+    renderPayoutTab();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/failed to load projects/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('PayoutTab – projects list', () => {
+  it('renders project names after a successful fetch', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A, PROJECT_B]);
+
+    renderPayoutTab();
+
+    await waitFor(() => expect(screen.getByText('alpha')).toBeInTheDocument());
+    expect(screen.getByText('beta')).toBeInTheDocument();
+  });
+
+  it('shows "No verified billing profiles" text when all profiles are unverified', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([UNVERIFIED_PROFILE as never]);
+
+    await waitFor(() =>
+      expect(screen.getAllByText('No verified billing profiles')).toHaveLength(1),
+    );
+  });
+
+  it('renders a select for each project when verified profiles exist', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A, PROJECT_B]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => {
+      const selects = screen.getAllByRole('combobox');
+      expect(selects).toHaveLength(2);
+    });
+  });
+
+  it('pre-selects the persisted billing profile for each project', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+    mockGetPayoutMappings.mockResolvedValue([
+      { project_id: 'proj-1', billing_profile_id: 1 },
+    ]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => {
+      const select = screen.getByRole('combobox') as HTMLSelectElement;
+      expect(select.value).toBe('1');
+    });
+  });
+});
+
+describe('PayoutTab – save button state', () => {
+  it('save button is disabled when mappings have not changed', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument());
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('save button becomes enabled after a mapping change', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, '1');
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+});
+
+describe('PayoutTab – successful save', () => {
+  it('calls savePayoutMappings with the current mappings', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(mockSavePayoutMappings).toHaveBeenCalledWith([
+        { project_id: 'proj-1', billing_profile_id: 1 },
+      ]),
+    );
+  });
+
+  it('shows a success toast and disables the button after saving', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Payout preferences saved'));
+
+    // After save, form is no longer dirty — button re-disables
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('re-enables the save button if the user makes another change after a successful save', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    // First save
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
+
+    // Modify again
+    await user.selectOptions(screen.getByRole('combobox'), '');
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+});
+
+describe('PayoutTab – failed save', () => {
+  it('shows an error toast when savePayoutMappings rejects', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+    mockSavePayoutMappings.mockRejectedValue(new Error('Server error'));
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith('Server error'),
+    );
+  });
+
+  it('leaves the form dirty after a failed save so the user can retry', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+    mockSavePayoutMappings.mockRejectedValue(new Error('Server error'));
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+
+    // Button should still be enabled so the user can retry
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+
+  it('shows a generic message when the error has no message property', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+    mockSavePayoutMappings.mockRejectedValue('plain string error');
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith('Failed to save payout preferences'),
+    );
+  });
+});
+
+describe('PayoutTab – save button during pending request', () => {
+  it('shows "Saving…" text and disables the button while the request is in flight', async () => {
+    const user = userEvent.setup();
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+
+    let resolveSave!: () => void;
+    mockSavePayoutMappings.mockReturnValue(
+      new Promise<{ ok: boolean }>((resolve) => {
+        resolveSave = () => resolve({ ok: true });
+      }),
+    );
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await user.selectOptions(screen.getByRole('combobox'), '1');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    // While in-flight the label changes and the button is disabled
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled(),
+    );
+
+    resolveSave();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('PayoutTab – getPayoutMappings failure', () => {
+  it('gracefully continues rendering even when getPayoutMappings fails', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A]);
+    mockGetPayoutMappings.mockRejectedValue(new Error('403 Forbidden'));
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => expect(screen.getByText('alpha')).toBeInTheDocument());
+    // All selects start unselected
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('');
+  });
+});
+
+describe('PayoutTab – persisted state survives reload', () => {
+  it('seeds the selects from getPayoutMappings on mount', async () => {
+    mockGetProjectsContributed.mockResolvedValue([PROJECT_A, PROJECT_B]);
+    mockGetPayoutMappings.mockResolvedValue([
+      { project_id: 'proj-1', billing_profile_id: 1 },
+    ]);
+
+    renderPayoutTab([VERIFIED_PROFILE]);
+
+    await waitFor(() => {
+      const selects = screen.getAllByRole('combobox') as HTMLSelectElement[];
+      expect(selects[0].value).toBe('1');
+      expect(selects[1].value).toBe('');
+    });
+  });
+});

--- a/src/features/settings/components/payout/PayoutTab.tsx
+++ b/src/features/settings/components/payout/PayoutTab.tsx
@@ -1,9 +1,14 @@
 import { logger } from '../../../../shared/utils/logger';
 import { useState, useEffect } from 'react';
 import { Info } from 'lucide-react';
+import { toast } from 'sonner';
 import { SkeletonLoader } from '../shared/SkeletonLoader';
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
-import { getProjectsContributed } from '../../../../shared/api/client';
+import {
+  getProjectsContributed,
+  getPayoutMappings,
+  savePayoutMappings,
+} from '../../../../shared/api/client';
 import { useBillingProfiles } from '../../contexts/BillingProfilesContext';
 import { LanguageIcon } from '../../../../shared/components/LanguageIcon';
 
@@ -11,6 +16,7 @@ export function PayoutTab() {
   const { theme } = useTheme();
   const { profiles } = useBillingProfiles();
   const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
   const [projects, setProjects] = useState<Array<{
     id: string;
     github_full_name: string;
@@ -20,24 +26,36 @@ export function PayoutTab() {
     owner_avatar_url?: string;
   }>>([]);
   const [projectMappings, setProjectMappings] = useState<Record<string, number | null>>({});
-const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [savedMappings, setSavedMappings] = useState<Record<string, number | null>>({});
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isDirty = JSON.stringify(projectMappings) !== JSON.stringify(savedMappings);
 
   useEffect(() => {
-    const fetchProjects = async () => {
+    const fetchData = async () => {
       try {
         setIsLoading(true);
-        const response = await getProjectsContributed();
-        setProjects(response || []);
+        const [projectsData, persistedMappings] = await Promise.all([
+          getProjectsContributed(),
+          getPayoutMappings().catch(() => []),
+        ]);
+        setProjects(projectsData || []);
+
+        const mappingsRecord = Object.fromEntries(
+          persistedMappings.map((m) => [m.project_id, m.billing_profile_id]),
+        );
+        setProjectMappings(mappingsRecord);
+        setSavedMappings(mappingsRecord);
       } catch (error) {
         logger.error('Failed to fetch projects:', error);
-        setErrorMessage("Failed to load projects. Please try again later.");
+        setErrorMessage('Failed to load projects. Please try again later.');
         setProjects([]);
       } finally {
         setIsLoading(false);
       }
     };
 
-    fetchProjects();
+    fetchData();
   }, []);
 
   const handleProfileChange = (projectId: string, profileId: string) => {
@@ -47,9 +65,28 @@ const [errorMessage, setErrorMessage] = useState<string | null>(null);
     }));
   };
 
-  const handleSave = () => {
-    // TODO: Implement save to backend
-    logger.debug('Saving payout preferences:', projectMappings);
+  /**
+   * Persists the current project-to-billing-profile mappings to the backend.
+   * Shows a success or error toast and resets the dirty state on success.
+   */
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const mappings = Object.entries(projectMappings).map(([project_id, billing_profile_id]) => ({
+        project_id,
+        billing_profile_id,
+      }));
+      await savePayoutMappings(mappings);
+      setSavedMappings({ ...projectMappings });
+      toast.success('Payout preferences saved');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to save payout preferences';
+      logger.error('Failed to save payout preferences:', error);
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const getProjectInitial = (fullName: string) => {
@@ -68,11 +105,11 @@ const [errorMessage, setErrorMessage] = useState<string | null>(null);
   return (
     <div className="space-y-6">
       {errorMessage && (
-              <div className="bg-red-500/10 border border-red-500/50 text-red-500 p-3 rounded-lg mb-4">
-                      {errorMessage}
-                            </div>
-                                )}
-      
+        <div className="bg-red-500/10 border border-red-500/50 text-red-500 p-3 rounded-lg mb-4">
+          {errorMessage}
+        </div>
+      )}
+
       <div className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
         theme === 'dark'
           ? 'bg-[#2d2820]/[0.4] border-white/10'
@@ -254,9 +291,10 @@ const [errorMessage, setErrorMessage] = useState<string | null>(null);
         <div className="flex justify-end">
           <button
             onClick={handleSave}
-            className="px-8 py-3 rounded-[16px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[15px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all border border-white/10"
+            disabled={isSaving || !isDirty}
+            className="px-8 py-3 rounded-[16px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[15px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Save
+            {isSaving ? 'Saving...' : 'Save'}
           </button>
         </div>
       )}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -766,6 +766,32 @@ export const getKYCStatus = () =>
 export const getBillingProfiles = () =>
   apiRequest<BillingProfile[]>("/billing/profiles", { requiresAuth: true });
 
+/** A single project-to-billing-profile assignment. */
+export type PayoutMappingEntry = {
+  project_id: string;
+  billing_profile_id: number | null;
+};
+
+/**
+ * Fetches the authenticated user's persisted payout mappings.
+ * Returns an empty array when none have been saved yet.
+ */
+export const getPayoutMappings = () =>
+  apiRequest<PayoutMappingEntry[]>("/profile/payout-mappings", {
+    requiresAuth: true,
+  });
+
+/**
+ * Persists project-to-billing-profile payout mappings for the authenticated user.
+ * Requires a valid session; omitting auth is blocked at the API layer.
+ */
+export const savePayoutMappings = (mappings: PayoutMappingEntry[]) =>
+  apiRequest<{ ok: boolean }>("/profile/payout-mappings", {
+    requiresAuth: true,
+    method: "PUT",
+    body: JSON.stringify({ mappings }),
+  });
+
 export const getBlogPosts = () =>
   apiRequest<BlogPost[]>("/blog/posts", { requiresAuth: false });
 


### PR DESCRIPTION
## Summary

- **Replaced TODO stub** in `PayoutTab.tsx` — `handleSave` now calls an authenticated `PUT /profile/payout-mappings` API instead of only logging to the console
- **Added two API client functions** in `client.ts`: `getPayoutMappings()` (loads persisted state on mount) and `savePayoutMappings()` (persists on save), both with `requiresAuth: true`
- **Dirty tracking** — Save button is disabled when mappings match the last-saved state and re-enables after any change; shows "Saving…" and is disabled while the request is in flight
- **Toast feedback** — success toast on save, error toast with server message on failure; form stays dirty after error so the user can retry

## Test plan

- [ ] 18 Vitest tests pass (`npm run test`)
- [ ] Loading state shows skeletons
- [ ] Empty-projects state renders correctly with no Save button
- [ ] Network error on projects fetch shows error banner
- [ ] Persisted mappings pre-populate selects on mount
- [ ] Save disabled when form is clean; enabled after change
- [ ] Save shows "Saving…" / disabled during request
- [ ] Success path: toast shown, button re-disables (form is now clean)
- [ ] Failure path: error toast shown, button stays enabled (retry possible)
- [ ] `getPayoutMappings` failure falls back gracefully (empty mappings, page still usable)

## Security notes

Both `getPayoutMappings` and `savePayoutMappings` use `requiresAuth: true`, so the `Authorization: Bearer <token>` header is always attached. The endpoints are unreachable without a valid session.

## Test output

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  11:42:48
   Duration  4.01s
```

Closes #73
