### PR TITLE
feat(profile): add error and retry states to activity/contributions

### DIFF
--- a/src/features/dashboard/pages/ProfilePage.test.tsx
+++ b/src/features/dashboard/pages/ProfilePage.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * @file ProfilePage.test.tsx
+ * @description Tests for ProfilePage focused on the activity and contributions
+ *  (contributed-projects) sections:
+ *   - Loading skeletons remain in place while requests are in flight
+ *   - Empty states ("No contributions yet" / "No projects contributed yet")
+ *   - Error states with a working Retry that re-invokes the failed API call
+ *   - Public-profile (other user) view: error/retry parity + no leakage of the
+ *     authenticated user's own data into the public view (security)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+
+// ---------------------------------------------------------------------------
+// Mock API client — declared BEFORE vi.mock() factory so they are in scope
+// ---------------------------------------------------------------------------
+const mockGetUserProfile = vi.fn()
+const mockGetPublicProfile = vi.fn()
+const mockGetProjectsContributed = vi.fn()
+const mockGetProjectsLed = vi.fn()
+const mockGetProfileCalendar = vi.fn()
+const mockGetProfileActivity = vi.fn()
+
+vi.mock('../../../shared/api/client', () => ({
+  getUserProfile: (...a: unknown[]) => mockGetUserProfile(...a),
+  getPublicProfile: (...a: unknown[]) => mockGetPublicProfile(...a),
+  getProjectsContributed: (...a: unknown[]) => mockGetProjectsContributed(...a),
+  getProjectsLed: (...a: unknown[]) => mockGetProjectsLed(...a),
+  getProfileCalendar: (...a: unknown[]) => mockGetProfileCalendar(...a),
+  getProfileActivity: (...a: unknown[]) => mockGetProfileActivity(...a),
+}))
+
+// Authenticated user — distinct login so we can assert it never leaks into the
+// public-profile view.
+vi.mock('../../../shared/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { github: { login: 'owner-self', avatar_url: 'https://example.com/self.png' } },
+  }),
+}))
+
+// recharts renders nothing meaningful in jsdom (0×0 container); stub it out to
+// keep the tests fast and free of width/height warnings.
+vi.mock('recharts', () => ({
+  PieChart: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Pie: () => null,
+  Cell: () => null,
+  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Tooltip: () => null,
+}))
+
+// ---------------------------------------------------------------------------
+// Component under test (import AFTER mocks)
+// ---------------------------------------------------------------------------
+import { ProfilePage } from './ProfilePage'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+function makeProfile(overrides: Record<string, unknown> = {}) {
+  return {
+    contributions_count: 5,
+    languages: [{ language: 'TypeScript', contribution_count: 4 }],
+    ecosystems: [{ ecosystem_name: 'Stellar', contribution_count: 3 }],
+    projects_contributed_to_count: 1,
+    projects_led_count: 0,
+    rewards_count: 0,
+    rank: { position: 1, tier: 'gold', tier_name: 'Gold', tier_color: '#c9983a' },
+    ...overrides,
+  }
+}
+
+function makeActivity() {
+  return {
+    activities: [
+      {
+        type: 'pull_request',
+        id: 'pr-1',
+        number: 42,
+        title: 'Fix the flaky test',
+        url: 'https://github.com/org/repo/pull/42',
+        state: 'open',
+        date: '2026-06-01T00:00:00Z',
+        month_year: 'June 2026',
+        project_name: 'repo',
+        project_id: 'proj-1',
+      },
+    ],
+    total: 1,
+    limit: 100,
+    offset: 0,
+  }
+}
+
+function makeContributedProjects() {
+  return [
+    {
+      id: 'proj-1',
+      github_full_name: 'org/cool-repo',
+      status: 'active',
+      ecosystem_name: 'Stellar',
+      language: 'TypeScript',
+      owner_avatar_url: undefined,
+    },
+  ]
+}
+
+function renderPage(props: Partial<React.ComponentProps<typeof ProfilePage>> = {}) {
+  return render(
+    <ThemeProvider>
+      <ProfilePage {...props} />
+    </ThemeProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGetUserProfile.mockReset().mockResolvedValue(makeProfile())
+  mockGetPublicProfile.mockReset()
+  mockGetProjectsContributed.mockReset().mockResolvedValue(makeContributedProjects())
+  mockGetProjectsLed.mockReset().mockResolvedValue([])
+  mockGetProfileCalendar.mockReset().mockResolvedValue({ calendar: [] })
+  mockGetProfileActivity.mockReset().mockResolvedValue(makeActivity())
+})
+
+// ===========================================================================
+// Activity section
+// ===========================================================================
+describe('ProfilePage — contribution activity', () => {
+  it('renders activity items on success', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Fix the flaky test')).toBeInTheDocument())
+    expect(mockGetProfileActivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the empty state when there is no activity', async () => {
+    mockGetProfileActivity.mockResolvedValue({ activities: [], total: 0, limit: 100, offset: 0 })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('No contributions yet')).toBeInTheDocument())
+  })
+
+  it('shows an error + retry state when the activity request fails', async () => {
+    mockGetProfileActivity.mockRejectedValue(new Error('network'))
+    renderPage()
+    await waitFor(() => expect(screen.getByText("Couldn't load activity")).toBeInTheDocument())
+    // Error state is announced and does NOT collapse to the empty state.
+    expect(screen.queryByText('No contributions yet')).not.toBeInTheDocument()
+    expect(screen.getByText("Couldn't load activity").closest('[role="alert"]')).toBeInTheDocument()
+  })
+
+  it('recovers when Retry succeeds after an activity failure', async () => {
+    mockGetProfileActivity.mockRejectedValueOnce(new Error('network'))
+    renderPage()
+    const errorPanel = await screen.findByText("Couldn't load activity")
+    const retry = errorPanel.closest('[role="alert"]')!.querySelector('button')!
+
+    mockGetProfileActivity.mockResolvedValue(makeActivity())
+    await userEvent.click(retry)
+
+    await waitFor(() => expect(screen.getByText('Fix the flaky test')).toBeInTheDocument())
+    expect(screen.queryByText("Couldn't load activity")).not.toBeInTheDocument()
+    expect(mockGetProfileActivity).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ===========================================================================
+// Contributed-projects section
+// ===========================================================================
+describe('ProfilePage — contributed projects', () => {
+  it('renders contributed projects on success', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('cool-repo')).toBeInTheDocument())
+    expect(mockGetProjectsContributed).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the empty state when no projects are returned', async () => {
+    mockGetProjectsContributed.mockResolvedValue([])
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText('No projects contributed yet')).toBeInTheDocument()
+    )
+  })
+
+  it('shows an error + retry state when the projects request fails', async () => {
+    mockGetProjectsContributed.mockRejectedValue(new Error('boom'))
+    renderPage()
+    await waitFor(() => expect(screen.getByText("Couldn't load projects")).toBeInTheDocument())
+    expect(screen.queryByText('No projects contributed yet')).not.toBeInTheDocument()
+  })
+
+  it('recovers when Retry succeeds after a projects failure', async () => {
+    mockGetProjectsContributed.mockRejectedValueOnce(new Error('boom'))
+    renderPage()
+    const errorPanel = await screen.findByText("Couldn't load projects")
+    const retry = errorPanel.closest('[role="alert"]')!.querySelector('button')!
+
+    mockGetProjectsContributed.mockResolvedValue(makeContributedProjects())
+    await userEvent.click(retry)
+
+    await waitFor(() => expect(screen.getByText('cool-repo')).toBeInTheDocument())
+    expect(screen.queryByText("Couldn't load projects")).not.toBeInTheDocument()
+    expect(mockGetProjectsContributed).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ===========================================================================
+// Public-profile (other user) view
+// ===========================================================================
+describe('ProfilePage — public profile view', () => {
+  beforeEach(() => {
+    mockGetPublicProfile.mockResolvedValue(
+      makeProfile({ login: 'other-user', avatar_url: 'https://example.com/other.png' })
+    )
+  })
+
+  it('fetches activity/contributions for the viewed login, not the signed-in user', async () => {
+    renderPage({ viewingUserLogin: 'other-user' })
+    await waitFor(() => expect(screen.getByText('Fix the flaky test')).toBeInTheDocument())
+
+    expect(mockGetPublicProfile).toHaveBeenCalled()
+    expect(mockGetUserProfile).not.toHaveBeenCalled()
+    expect(mockGetProfileActivity).toHaveBeenCalledWith(100, 0, undefined, 'other-user')
+    expect(mockGetProjectsContributed).toHaveBeenCalledWith(undefined, 'other-user')
+  })
+
+  it('does not leak the authenticated user into the public view (security)', async () => {
+    renderPage({ viewingUserLogin: 'other-user' })
+    await waitFor(() => expect(screen.getByText('other-user')).toBeInTheDocument())
+    expect(screen.queryByText('owner-self')).not.toBeInTheDocument()
+  })
+
+  it('shows error + retry for activity on the public view and recovers', async () => {
+    mockGetProfileActivity.mockRejectedValueOnce(new Error('network'))
+    renderPage({ viewingUserLogin: 'other-user' })
+
+    const errorPanel = await screen.findByText("Couldn't load activity")
+    const retry = errorPanel.closest('[role="alert"]')!.querySelector('button')!
+
+    mockGetProfileActivity.mockResolvedValue(makeActivity())
+    await userEvent.click(retry)
+
+    await waitFor(() => expect(screen.getByText('Fix the flaky test')).toBeInTheDocument())
+    // Retry must re-query the same public login, never the signed-in user.
+    expect(mockGetProfileActivity).toHaveBeenLastCalledWith(100, 0, undefined, 'other-user')
+  })
+})

--- a/src/features/dashboard/pages/ProfilePage.tsx
+++ b/src/features/dashboard/pages/ProfilePage.tsx
@@ -1,12 +1,59 @@
 import { logger } from '../../../shared/utils/logger';
-import { useState, useEffect, useRef } from 'react';
-import { Search, Award, GitPullRequest, FolderGit2, Trophy, Github, Code, Globe, Sparkles, Star, Users, GitFork, DollarSign, GitMerge, Calendar, ChevronRight, Circle, Eye, Crown, Link, ArrowLeft, Medal, Shield, LucideIcon } from 'lucide-react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, Award, GitPullRequest, FolderGit2, Trophy, Github, Code, Globe, Sparkles, Star, Users, GitFork, DollarSign, GitMerge, Calendar, ChevronRight, Circle, Eye, Crown, Link, ArrowLeft, Medal, Shield, AlertCircle, RefreshCw, LucideIcon } from 'lucide-react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { useAuth } from '../../../shared/contexts/AuthContext';
 import { getUserProfile, getProjectsContributed, getProjectsLed, getProfileCalendar, getProfileActivity, getPublicProfile } from '../../../shared/api/client';
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
 import { LanguageIcon } from '../../../shared/components/LanguageIcon';
+
+/**
+ * Inline error panel with a retry affordance, rendered when a profile section's
+ * API call (activity or contributed projects) fails.
+ *
+ * @remarks
+ * Kept visually consistent with each section's empty state and theme-aware.
+ * Exposes `role="alert"` so assistive tech announces the failure, and renders no
+ * user data — safe for the public-profile (other user) view.
+ *
+ * @param theme - Active UI theme (`'dark'` or `'light'`).
+ * @param message - Short, section-specific failure headline.
+ * @param onRetry - Handler that re-invokes the failed fetch for the current view.
+ * @param className - Optional extra classes (e.g. grid column spans).
+ */
+function SectionError({
+  theme,
+  message,
+  onRetry,
+  className = '',
+}: {
+  theme: string;
+  message: string;
+  onRetry: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={`text-center py-8 ${className} ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+    >
+      <AlertCircle className={`w-12 h-12 mx-auto mb-3 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}`} />
+      <p className="text-[14px] font-medium mb-1">{message}</p>
+      <p className={`text-[12px] mb-4 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}`}>
+        Something went wrong while loading this section.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-[12px] bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border-2 border-[#c9983a]/50 text-[#c9983a] text-[13px] font-semibold hover:scale-105 hover:shadow-[0_4px_12px_rgba(201,152,58,0.4)] transition-all duration-300"
+      >
+        <RefreshCw className="w-4 h-4" />
+        Retry
+      </button>
+    </div>
+  );
+}
 
 interface ProfileData {
   contributions_count: number;
@@ -76,6 +123,10 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
   const [isLoadingCalendar, setIsLoadingCalendar] = useState(true);
   const [isLoadingActivity, setIsLoadingActivity] = useState(true);
+  // Error flags for the API-backed activity/contributions sections, used to show
+  // a retry affordance instead of a misleading empty state when a request fails.
+  const [projectsError, setProjectsError] = useState(false);
+  const [activityError, setActivityError] = useState(false);
   const [_selectedMonth, _setSelectedMonth] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedMonths, setExpandedMonths] = useState<{ [key: string]: boolean }>({});
@@ -132,36 +183,52 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
     fetchProfile();
   }, [viewingUserId, viewingUserLogin]);
 
+  /**
+   * Fetch the contributed-projects list for the currently viewed user (or self).
+   *
+   * @remarks
+   * State handling: shows the skeleton and clears any prior error while the
+   * request is in flight; on failure it sets {@link projectsError} so the section
+   * renders a retry button rather than a misleading "no projects" empty state.
+   * Stale responses (the viewed user changed mid-request) are dropped via
+   * {@link isSameView}. Reads the current view from `viewingRef`, so the same
+   * function serves both the initial load and the retry button for own and
+   * public-profile views alike.
+   */
+  const fetchProjects = useCallback(async () => {
+    const { viewingUserId: requestedUserId, viewingUserLogin: requestedLogin } = viewingRef.current;
+    setIsLoadingProjects(true);
+    setProjectsError(false);
+    try {
+      const data = await getProjectsContributed(requestedUserId || undefined, requestedLogin || undefined);
+      if (!isSameView(requestedUserId, requestedLogin)) return;
+      const contributedProjects = data.map((p: any) => ({
+        id: p.id,
+        github_full_name: p.github_full_name,
+        status: p.status,
+        ecosystem_name: p.ecosystem_name,
+        language: p.language,
+        owner_avatar_url: p.owner_avatar_url,
+        stars_count: 0,
+        forks_count: 0,
+        contributors_count: 0,
+      }));
+      setProjects(contributedProjects);
+    } catch (error) {
+      if (isSameView(requestedUserId, requestedLogin)) {
+        logger.error('Failed to fetch projects:', error);
+        setProjectsError(true);
+      }
+    } finally {
+      if (isSameView(requestedUserId, requestedLogin)) setIsLoadingProjects(false);
+    }
+  }, []);
+
   // Fetch user's contributed projects (for viewed user or self)
   useEffect(() => {
-    const requestedUserId = viewingUserId;
-    const requestedLogin = viewingUserLogin;
-    if (requestedUserId || requestedLogin) setProjects([]);
-    const fetchProjects = async () => {
-      setIsLoadingProjects(true);
-      try {
-        const data = await getProjectsContributed(requestedUserId || undefined, requestedLogin || undefined);
-        if (!isSameView(requestedUserId, requestedLogin)) return;
-        const contributedProjects = data.map((p: any) => ({
-          id: p.id,
-          github_full_name: p.github_full_name,
-          status: p.status,
-          ecosystem_name: p.ecosystem_name,
-          language: p.language,
-          owner_avatar_url: p.owner_avatar_url,
-          stars_count: 0,
-          forks_count: 0,
-          contributors_count: 0,
-        }));
-        setProjects(contributedProjects);
-      } catch (error) {
-        if (isSameView(requestedUserId, requestedLogin)) logger.error('Failed to fetch projects:', error);
-      } finally {
-        if (isSameView(requestedUserId, requestedLogin)) setIsLoadingProjects(false);
-      }
-    };
+    if (viewingUserId || viewingUserLogin) setProjects([]);
     fetchProjects();
-  }, [viewingUserId, viewingUserLogin]);
+  }, [viewingUserId, viewingUserLogin, fetchProjects]);
 
   // Fetch projects led (for viewed user or self)
   useEffect(() => {
@@ -213,34 +280,48 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
     fetchCalendar();
   }, [viewingUserId, viewingUserLogin]);
 
-  // Fetch contribution activity
-  useEffect(() => {
-    const requestedUserId = viewingUserId;
-    const requestedLogin = viewingUserLogin;
-    if (requestedUserId || requestedLogin) setContributionActivity([]);
-    const fetchActivity = async () => {
-      setIsLoadingActivity(true);
-      try {
-        const data = await getProfileActivity(100, 0, requestedUserId || undefined, requestedLogin || undefined);
-        if (!isSameView(requestedUserId, requestedLogin)) return;
-        setContributionActivity(data.activities || []);
-        const monthsSet = new Set<string>();
-        data.activities?.forEach((activity: any) => {
-          if (activity.month_year) monthsSet.add(activity.month_year);
-        });
-        const monthsObj: { [key: string]: boolean } = {};
-        Array.from(monthsSet).forEach((month, idx) => {
-          monthsObj[month] = idx === 0;
-        });
-        setExpandedMonths(monthsObj);
-      } catch (error) {
-        if (isSameView(requestedUserId, requestedLogin)) logger.error('Failed to fetch activity:', error);
-      } finally {
-        if (isSameView(requestedUserId, requestedLogin)) setIsLoadingActivity(false);
+  /**
+   * Fetch contribution activity for the currently viewed user (or self).
+   *
+   * @remarks
+   * State handling mirrors {@link fetchProjects}: skeleton while loading, an
+   * explicit {@link activityError} flag on failure (so the section shows a retry
+   * button instead of the "No contributions yet" empty state), and stale-response
+   * guarding via {@link isSameView}. Memoised so the retry button can re-invoke
+   * it; reads the current view from `viewingRef`.
+   */
+  const fetchActivity = useCallback(async () => {
+    const { viewingUserId: requestedUserId, viewingUserLogin: requestedLogin } = viewingRef.current;
+    setIsLoadingActivity(true);
+    setActivityError(false);
+    try {
+      const data = await getProfileActivity(100, 0, requestedUserId || undefined, requestedLogin || undefined);
+      if (!isSameView(requestedUserId, requestedLogin)) return;
+      setContributionActivity(data.activities || []);
+      const monthsSet = new Set<string>();
+      data.activities?.forEach((activity: any) => {
+        if (activity.month_year) monthsSet.add(activity.month_year);
+      });
+      const monthsObj: { [key: string]: boolean } = {};
+      Array.from(monthsSet).forEach((month, idx) => {
+        monthsObj[month] = idx === 0;
+      });
+      setExpandedMonths(monthsObj);
+    } catch (error) {
+      if (isSameView(requestedUserId, requestedLogin)) {
+        logger.error('Failed to fetch activity:', error);
+        setActivityError(true);
       }
-    };
+    } finally {
+      if (isSameView(requestedUserId, requestedLogin)) setIsLoadingActivity(false);
+    }
+  }, []);
+
+  // Fetch contribution activity (for viewed user or self)
+  useEffect(() => {
+    if (viewingUserId || viewingUserLogin) setContributionActivity([]);
     fetchActivity();
-  }, [viewingUserId, viewingUserLogin]);
+  }, [viewingUserId, viewingUserLogin, fetchActivity]);
 
   const toggleMonth = (month: string) => {
     setExpandedMonths(prev => ({
@@ -904,6 +985,13 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
                 </div>
               </div>
             ))
+          ) : projectsError ? (
+            <SectionError
+              theme={theme}
+              message="Couldn't load projects"
+              onRetry={fetchProjects}
+              className="col-span-3"
+            />
           ) : (showAllProjects ? projects : projects.slice(0, 3)).length > 0 ? (
             (showAllProjects ? projects : projects.slice(0, 3)).map((project, idx) => {
               const projectName = project.github_full_name.split('/')[1] || project.github_full_name;
@@ -1421,6 +1509,13 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
               </div>
             ))}
           </div>
+        ) : activityError ? (
+          <SectionError
+            theme={theme}
+            message="Couldn't load activity"
+            onRetry={fetchActivity}
+            className="py-12"
+          />
         ) : Object.keys(contributionsByMonth).length === 0 ? (
           <div className={`text-center py-12 ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
             <Calendar className="w-16 h-16 mx-auto mb-4 opacity-50" />


### PR DESCRIPTION
feat(profile): add error and retry states to activity/contributions

closes #61

## What
ProfilePage consumes getProfileActivity and getProjectsContributed. The page
already had loading skeletons and empty states, but a failed request only
logged to the console, leaving the activity and contributions panels blank and
making a working profile look broken.

This PR adds explicit error states with retry to both sections, while keeping
the existing skeletons and empty states intact.

## Changes
- Extract the contributed-projects and activity fetches into memoized
  `fetchProjects` / `fetchActivity` callbacks that read the current view from
  `viewingRef`, so the same function powers both the initial load and a retry.
- Add `projectsError` / `activityError` state: set when the request fails,
  cleared at the start of every attempt.
- Add a reusable, theme-aware `SectionError` panel (`role="alert"` + a Retry
  button) rendered before the empty-state branch in each section, so failures no
  longer collapse into a misleading "nothing here" message.
- Preserve loading skeletons and the "No contributions yet" /
  "No projects contributed yet" empty states.
- Stale-response guarding (`isSameView`) is retained, so retries and view
  switches never apply outdated results.

## Public-profile handling
Both fetches read the viewed user from `viewingRef`, so the empty, error, and
retry paths behave identically for own-profile and public-profile (other user)
views. Retry re-queries the same viewed login, never the signed-in user.

## Security
The error/empty UI renders no user data, and the public-profile view continues
to use only public profile fields — no own-only/private data is exposed. A test
asserts the authenticated user's login never leaks into another user's view.

## Tests
Added src/features/dashboard/pages/ProfilePage.test.tsx (11 tests):
- Activity: success, empty state, error state, retry recovers.
- Contributed projects: success, empty state, error state, retry recovers.
- Public profile: correct login passed to the activity/contributions APIs,
  error + retry parity, and no leak of the signed-in user into the public view.

Test output (target file):
  Test Files  1 passed (1)
       Tests  11 passed (11)
