### PR TITLE
feat(leaderboard): add empty and error states to contributor/projec

### DIFF
--- a/src/features/leaderboard/components/ContributorsTable.test.tsx
+++ b/src/features/leaderboard/components/ContributorsTable.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { ContributorsTable } from './ContributorsTable'
+import { LeaderData } from '../types'
+
+const contributors: LeaderData[] = [
+  {
+    rank: 1,
+    username: 'octocat',
+    avatar: '',
+    user_id: 'uid-1',
+    score: 100,
+    trend: 'up',
+    trendValue: 2,
+    contributions: 12,
+    ecosystems: ['Web3'],
+  },
+]
+
+function renderTable(props: Partial<React.ComponentProps<typeof ContributorsTable>> = {}) {
+  return render(
+    <ThemeProvider>
+      <ContributorsTable data={contributors} activeFilter="overall" isLoaded {...props} />
+    </ThemeProvider>
+  )
+}
+
+describe('ContributorsTable states', () => {
+  it('renders a row per contributor when data is present', () => {
+    renderTable()
+    expect(screen.getByText('octocat')).toBeInTheDocument()
+    // No empty/error live regions while data is shown.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders an accessible empty state for zero rows', () => {
+    renderTable({ data: [] })
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText(/no contributors yet/i)).toBeInTheDocument()
+    // No retry button is offered for an empty (non-error) result.
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it('renders an error state with an assertive live region and retry', async () => {
+    const onRetry = vi.fn()
+    renderTable({ data: [], error: "We couldn't load contributors. Please try again.", onRetry })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+    expect(screen.getByText(/please try again/i)).toBeInTheDocument()
+    // Error copy stays generic and exposes no internals.
+    expect(alert.textContent).not.toMatch(/stack|http|status\s*\d|\bat\s+\w+\.\w+/i)
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers the error state over rows even when data exists', () => {
+    renderTable({ error: "We couldn't load contributors. Please try again." })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByText('octocat')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/leaderboard/components/ContributorsTable.tsx
+++ b/src/features/leaderboard/components/ContributorsTable.tsx
@@ -1,68 +1,77 @@
-import { TrendingUp, TrendingDown, Minus, Award } from "lucide-react";
-import { useTheme } from "../../../shared/contexts/ThemeContext";
-import { LeaderData, FilterType } from "../types";
-import { getAvatarGradient } from "../data/leaderboardData";
+import { TrendingUp, TrendingDown, Minus, Award } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { LeaderData, FilterType } from '../types'
+import { getAvatarGradient } from '../data/leaderboardData'
+import { LeaderboardTableState } from './LeaderboardTableState'
 
 interface ContributorsTableProps {
-  data: LeaderData[];
-  activeFilter: FilterType;
-  isLoaded: boolean;
-  onUserClick?: (username: string, userId?: string) => void;
+  data: LeaderData[]
+  activeFilter: FilterType
+  isLoaded: boolean
+  onUserClick?: (username: string, userId?: string) => void
+  /**
+   * Generic, user-facing error message. When set, the table renders an error
+   * state with a retry action instead of rows. Must not expose internals.
+   */
+  error?: string | null
+  /** Retry handler wired to the data source; enables the error-state button. */
+  onRetry?: () => void
 }
 
-const getTrendIcon = (trend: "up" | "down" | "same") => {
-  if (trend === "up") return <TrendingUp className="w-4 h-4 text-green-600" />;
-  if (trend === "down")
-    return <TrendingDown className="w-4 h-4 text-red-600" />;
-  return <Minus className="w-4 h-4 text-[#7a6b5a]" />;
-};
+const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
+  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
+  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
+  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
+}
 
 export function ContributorsTable({
   data,
   activeFilter,
   isLoaded,
   onUserClick,
+  error,
+  onRetry,
 }: ContributorsTableProps) {
-  const { theme } = useTheme();
+  const { theme } = useTheme()
 
   const handleRowClick = (leader: LeaderData) => {
     if (onUserClick) {
-      onUserClick(leader.username, leader.user_id);
+      onUserClick(leader.username, leader.user_id)
     }
-  };
+  }
 
   return (
     <div
       className={`backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden transition-all duration-700 delay-1000 ${
-        isLoaded ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
+        isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
       }`}
     >
       {/* Table Header */}
       <div className="grid grid-cols-12 gap-4 px-8 py-4 border-b border-white/10 backdrop-blur-[30px] bg-white/[0.08]">
         <div
           className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-            theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
           }`}
         >
           Rank
         </div>
         <div
           className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-            theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
           }`}
         >
           Trend
         </div>
         <div
           className={`col-span-6 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-            theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
           }`}
         >
           Contributor
         </div>
         <div
           className={`col-span-2 text-[12px] font-bold uppercase tracking-wider text-right flex items-center justify-end gap-1 transition-colors ${
-            theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
           }`}
         >
           Score
@@ -71,125 +80,133 @@ export function ContributorsTable({
         <div className="col-span-2"></div>
       </div>
 
-      {/* Table Rows */}
-      <div className="divide-y divide-white/10">
-        {data.map((leader, index) => (
-          <div
-            key={leader.rank}
-            onClick={() => handleRowClick(leader)}
-            className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
-            style={{
-              animation: isLoaded
-                ? `slideInLeft 0.5s ease-out ${1.1 + index * 0.1}s both`
-                : "none",
-            }}
-          >
-            {/* Rank */}
-            <div className="col-span-1 flex items-center">
-              <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 group-hover:shadow-md transition-all duration-300">
-                <span
-                  className={`text-[15px] font-bold transition-colors ${
-                    theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                  }`}
-                >
-                  {leader.rank}
-                </span>
-              </div>
-            </div>
-
-            {/* Trend */}
-            <div className="col-span-1 flex items-center">
-              <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 transition-all duration-300">
-                {getTrendIcon(leader.trend)}
-              </div>
-            </div>
-
-            {/* Contributor */}
-            <div className="col-span-6 flex items-center gap-3">
-              <div
-                className={`relative w-12 h-12 rounded-full bg-gradient-to-br ${getAvatarGradient(index)} flex items-center justify-center text-white font-bold text-[18px] shadow-md border-2 border-white/25 group-hover:scale-125 group-hover:shadow-lg group-hover:rotate-12 transition-all duration-300 overflow-hidden`}
-              >
-                {leader.avatar &&
-                (leader.avatar.startsWith("http") ||
-                  leader.avatar.startsWith("https")) ? (
-                  <img
-                    src={leader.avatar}
-                    alt={leader.username}
-                    className="w-full h-full object-cover"
-                    onError={(e) => {
-                      // Fallback to GitHub avatar if image fails to load
-                      const target = e.target as HTMLImageElement;
-                      target.src = `https://github.com/${leader.username}.png?size=200`;
-                    }}
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center">
-                    {leader.username.substring(0, 2).toUpperCase()}
-                  </div>
-                )}
-                {/* Glow ring on hover */}
-                <div className="absolute inset-0 rounded-full border-2 border-[#c9983a]/0 group-hover:border-[#c9983a]/50 transition-all duration-300 animate-ping-on-hover" />
-              </div>
-              <div>
-                <div
-                  className={`text-[15px] font-bold group-hover:text-[#c9983a] transition-colors duration-300 ${
-                    theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                  }`}
-                >
-                  {leader.username}
-                </div>
-                {activeFilter === "contributions" && leader.contributions && (
-                  <div
-                    className={`text-[12px] transition-colors ${
-                      theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+      {/* Table Rows — or an empty / error state in their place. */}
+      {error || data.length === 0 ? (
+        <LeaderboardTableState
+          error={error}
+          onRetry={onRetry}
+          emptyTitle="No contributors yet"
+          emptyHint="Be the first to contribute and climb the leaderboard."
+        />
+      ) : (
+        <div className="divide-y divide-white/10">
+          {data.map((leader, index) => (
+            <div
+              key={leader.rank}
+              onClick={() => handleRowClick(leader)}
+              className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
+              style={{
+                animation: isLoaded
+                  ? `slideInLeft 0.5s ease-out ${1.1 + index * 0.1}s both`
+                  : 'none',
+              }}
+            >
+              {/* Rank */}
+              <div className="col-span-1 flex items-center">
+                <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 group-hover:shadow-md transition-all duration-300">
+                  <span
+                    className={`text-[15px] font-bold transition-colors ${
+                      theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
                     }`}
                   >
-                    {leader.contributions} contributions
-                  </div>
-                )}
-                {activeFilter === "ecosystems" && leader.ecosystems && (
-                  <div className="flex gap-1.5 mt-1">
-                    {leader.ecosystems.map((eco, idx) => (
-                      <span
-                        key={idx}
-                        className="px-2 py-0.5 bg-[#c9983a]/20 border border-[#c9983a]/30 rounded-[6px] text-[10px] font-semibold text-[#8b6f3a] hover:bg-[#c9983a]/30 transition-colors"
-                      >
-                        {eco}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Score */}
-            <div className="col-span-2 flex items-center justify-end">
-              <div className="relative px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/15 border border-[#c9983a]/40 shadow-sm group-hover:shadow-lg group-hover:border-[#c9983a]/70 group-hover:from-[#c9983a]/35 group-hover:to-[#d4af37]/25 group-hover:scale-110 transition-all duration-300">
-                <div
-                  className={`text-[17px] font-black transition-colors ${
-                    theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                  }`}
-                >
-                  {leader.score}
+                    {leader.rank}
+                  </span>
                 </div>
               </div>
-            </div>
 
-            {/* Action */}
-            <div className="col-span-2 flex items-center justify-end opacity-0 group-hover:opacity-100 transition-all duration-300">
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRowClick(leader);
-                }}
-                className="px-4 py-2 rounded-[10px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white text-[12px] font-semibold shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300 border border-white/10"
-              >
-                View Profile
-              </button>
+              {/* Trend */}
+              <div className="col-span-1 flex items-center">
+                <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 transition-all duration-300">
+                  {getTrendIcon(leader.trend)}
+                </div>
+              </div>
+
+              {/* Contributor */}
+              <div className="col-span-6 flex items-center gap-3">
+                <div
+                  className={`relative w-12 h-12 rounded-full bg-gradient-to-br ${getAvatarGradient(index)} flex items-center justify-center text-white font-bold text-[18px] shadow-md border-2 border-white/25 group-hover:scale-125 group-hover:shadow-lg group-hover:rotate-12 transition-all duration-300 overflow-hidden`}
+                >
+                  {leader.avatar &&
+                  (leader.avatar.startsWith('http') || leader.avatar.startsWith('https')) ? (
+                    <img
+                      src={leader.avatar}
+                      alt={leader.username}
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        // Fallback to GitHub avatar if image fails to load
+                        const target = e.target as HTMLImageElement
+                        target.src = `https://github.com/${leader.username}.png?size=200`
+                      }}
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center">
+                      {leader.username.substring(0, 2).toUpperCase()}
+                    </div>
+                  )}
+                  {/* Glow ring on hover */}
+                  <div className="absolute inset-0 rounded-full border-2 border-[#c9983a]/0 group-hover:border-[#c9983a]/50 transition-all duration-300 animate-ping-on-hover" />
+                </div>
+                <div>
+                  <div
+                    className={`text-[15px] font-bold group-hover:text-[#c9983a] transition-colors duration-300 ${
+                      theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    {leader.username}
+                  </div>
+                  {activeFilter === 'contributions' && leader.contributions && (
+                    <div
+                      className={`text-[12px] transition-colors ${
+                        theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                      }`}
+                    >
+                      {leader.contributions} contributions
+                    </div>
+                  )}
+                  {activeFilter === 'ecosystems' && leader.ecosystems && (
+                    <div className="flex gap-1.5 mt-1">
+                      {leader.ecosystems.map((eco, idx) => (
+                        <span
+                          key={idx}
+                          className="px-2 py-0.5 bg-[#c9983a]/20 border border-[#c9983a]/30 rounded-[6px] text-[10px] font-semibold text-[#8b6f3a] hover:bg-[#c9983a]/30 transition-colors"
+                        >
+                          {eco}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Score */}
+              <div className="col-span-2 flex items-center justify-end">
+                <div className="relative px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/15 border border-[#c9983a]/40 shadow-sm group-hover:shadow-lg group-hover:border-[#c9983a]/70 group-hover:from-[#c9983a]/35 group-hover:to-[#d4af37]/25 group-hover:scale-110 transition-all duration-300">
+                  <div
+                    className={`text-[17px] font-black transition-colors ${
+                      theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    {leader.score}
+                  </div>
+                </div>
+              </div>
+
+              {/* Action */}
+              <div className="col-span-2 flex items-center justify-end opacity-0 group-hover:opacity-100 transition-all duration-300">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleRowClick(leader)
+                  }}
+                  className="px-4 py-2 rounded-[10px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white text-[12px] font-semibold shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300 border border-white/10"
+                >
+                  View Profile
+                </button>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
-  );
+  )
 }

--- a/src/features/leaderboard/components/LeaderboardTableState.tsx
+++ b/src/features/leaderboard/components/LeaderboardTableState.tsx
@@ -1,0 +1,75 @@
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+
+/**
+ * Props for {@link LeaderboardTableState}.
+ *
+ * The component renders the non-data states shared by the contributors and
+ * projects tables: an accessible empty state and an error state with a retry
+ * action. The loading state is intentionally not handled here — callers keep
+ * rendering their existing table skeletons during the loading phase.
+ */
+export interface LeaderboardTableStateProps {
+  /**
+   * Generic, user-facing error message. When set, the error state takes
+   * precedence over the empty state.
+   *
+   * Security: callers MUST pass copy that reveals no internals (no stack
+   * traces, HTTP status text or backend messages); this value is rendered
+   * verbatim.
+   */
+  error?: string | null
+  /**
+   * Retry handler wired to the underlying data source. When provided alongside
+   * an `error`, a "Try again" button is rendered that re-triggers the fetch.
+   */
+  onRetry?: () => void
+  /** Heading shown in the empty state, e.g. "No contributors yet". */
+  emptyTitle: string
+  /** Supporting copy shown beneath the empty-state heading. */
+  emptyHint: string
+}
+
+/** Shared visual styling for the retry call-to-action. */
+const RETRY_CLASSES =
+  'mt-4 inline-flex items-center gap-2 px-6 py-3 rounded-[14px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-semibold text-[14px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+
+/**
+ * Renders the empty or error state for a leaderboard table.
+ *
+ * State changes are announced to assistive technology: the empty state uses a
+ * polite `role="status"` live region, while the error state uses an assertive
+ * `role="alert"` so failures are surfaced promptly. Both are wrapped in an
+ * `aria-live` region so a transition (e.g. data -> error after a failed retry)
+ * is read out.
+ */
+export function LeaderboardTableState({
+  error,
+  onRetry,
+  emptyTitle,
+  emptyHint,
+}: LeaderboardTableStateProps) {
+  const { theme } = useTheme()
+  const muted = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+  const strong = theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+
+  if (error) {
+    return (
+      <div role="alert" aria-live="assertive" className="px-8 py-12 text-center">
+        <p className={`text-[15px] font-bold transition-colors ${strong}`}>Something went wrong</p>
+        <p className={`mt-1 text-[13px] transition-colors ${muted}`}>{error}</p>
+        {onRetry && (
+          <button type="button" onClick={onRetry} className={RETRY_CLASSES}>
+            Try again
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div role="status" aria-live="polite" className="px-8 py-12 text-center">
+      <p className={`text-[15px] font-bold transition-colors ${strong}`}>{emptyTitle}</p>
+      <p className={`mt-1 text-[13px] transition-colors ${muted}`}>{emptyHint}</p>
+    </div>
+  )
+}

--- a/src/features/leaderboard/components/ProjectsTable.test.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.test.tsx
@@ -1,42 +1,42 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Routes, Route, useParams } from "react-router-dom";
-import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
-import { ProjectsTable } from "./ProjectsTable";
-import { ProjectData } from "../types";
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route, useParams } from 'react-router-dom'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { ProjectsTable } from './ProjectsTable'
+import { ProjectData } from '../types'
 
 const projects: ProjectData[] = [
   {
-    id: "proj-1",
+    id: 'proj-1',
     rank: 1,
-    name: "DeFi Protocol",
-    logo: "🌐",
+    name: 'DeFi Protocol',
+    logo: '🌐',
     score: 8950,
-    trend: "up",
+    trend: 'up',
     trendValue: 2,
     contributors: 342,
-    ecosystems: ["Web3"],
-    activity: "Very High",
+    ecosystems: ['Web3'],
+    activity: 'Very High',
   },
   {
-    id: "proj-2",
+    id: 'proj-2',
     rank: 2,
-    name: "AI Framework",
-    logo: "🤖",
+    name: 'AI Framework',
+    logo: '🤖',
     score: 7840,
-    trend: "same",
+    trend: 'same',
     trendValue: 0,
     contributors: 289,
-    ecosystems: ["AI"],
-    activity: "High",
+    ecosystems: ['AI'],
+    activity: 'High',
   },
-];
+]
 
 /** A stand-in detail page that surfaces the matched project id for assertions. */
 function ProjectProbe() {
-  const { projectId } = useParams<{ projectId: string }>();
-  return <div data-testid="project-detail">project:{projectId}</div>;
+  const { projectId } = useParams<{ projectId: string }>()
+  return <div data-testid="project-detail">project:{projectId}</div>
 }
 
 /**
@@ -46,102 +46,124 @@ function ProjectProbe() {
 function renderTable(data: ProjectData[] = projects) {
   return render(
     <ThemeProvider>
-      <MemoryRouter initialEntries={["/dashboard/leaderboard"]}>
+      <MemoryRouter initialEntries={['/dashboard/leaderboard']}>
         <Routes>
           <Route
             path="/dashboard/leaderboard"
-            element={
-              <ProjectsTable data={data} activeFilter="overall" isLoaded />
-            }
+            element={<ProjectsTable data={data} activeFilter="overall" isLoaded />}
           />
-          <Route
-            path="/dashboard/projects/:projectId"
-            element={<ProjectProbe />}
-          />
+          <Route path="/dashboard/projects/:projectId" element={<ProjectProbe />} />
         </Routes>
       </MemoryRouter>
-    </ThemeProvider>,
-  );
+    </ThemeProvider>
+  )
 }
 
-describe("ProjectsTable — View Project navigation", () => {
-  it("renders a View Project link per project pointing at its detail route", () => {
-    renderTable();
+describe('ProjectsTable — View Project navigation', () => {
+  it('renders a View Project link per project pointing at its detail route', () => {
+    renderTable()
 
-    const links = screen.getAllByRole("link", { name: /project details$/i });
-    expect(links).toHaveLength(2);
+    const links = screen.getAllByRole('link', { name: /project details$/i })
+    expect(links).toHaveLength(2)
 
     expect(
-      screen.getByRole("link", { name: /view defi protocol project details/i }),
-    ).toHaveAttribute("href", "/dashboard/projects/proj-1");
+      screen.getByRole('link', { name: /view defi protocol project details/i })
+    ).toHaveAttribute('href', '/dashboard/projects/proj-1')
     expect(
-      screen.getByRole("link", { name: /view ai framework project details/i }),
-    ).toHaveAttribute("href", "/dashboard/projects/proj-2");
-  });
+      screen.getByRole('link', { name: /view ai framework project details/i })
+    ).toHaveAttribute('href', '/dashboard/projects/proj-2')
+  })
 
-  it("navigates to the correct project detail page when clicked", async () => {
-    const user = userEvent.setup();
-    renderTable();
+  it('navigates to the correct project detail page when clicked', async () => {
+    const user = userEvent.setup()
+    renderTable()
 
-    await user.click(
-      screen.getByRole("link", { name: /view ai framework project details/i }),
-    );
+    await user.click(screen.getByRole('link', { name: /view ai framework project details/i }))
 
-    expect(screen.getByTestId("project-detail")).toHaveTextContent(
-      "project:proj-2",
-    );
-  });
+    expect(screen.getByTestId('project-detail')).toHaveTextContent('project:proj-2')
+  })
 
-  it("is keyboard-focusable and activates the first project on Enter", async () => {
-    const user = userEvent.setup();
-    renderTable();
+  it('is keyboard-focusable and activates the first project on Enter', async () => {
+    const user = userEvent.setup()
+    renderTable()
 
-    await user.tab();
-    const firstLink = screen.getByRole("link", {
+    await user.tab()
+    const firstLink = screen.getByRole('link', {
       name: /view defi protocol project details/i,
-    });
-    expect(firstLink).toHaveFocus();
+    })
+    expect(firstLink).toHaveFocus()
 
-    await user.keyboard("{Enter}");
-    expect(screen.getByTestId("project-detail")).toHaveTextContent(
-      "project:proj-1",
-    );
-  });
+    await user.keyboard('{Enter}')
+    expect(screen.getByTestId('project-detail')).toHaveTextContent('project:proj-1')
+  })
 
-  it("renders a visible focus ring for keyboard users", () => {
-    renderTable();
-    const link = screen.getByRole("link", {
+  it('renders a visible focus ring for keyboard users', () => {
+    renderTable()
+    const link = screen.getByRole('link', {
       name: /view defi protocol project details/i,
-    });
-    expect(link.className).toMatch(/focus-visible:ring-2/);
-  });
+    })
+    expect(link.className).toMatch(/focus-visible:ring-2/)
+  })
 
-  it("URL-encodes ids that contain reserved characters", () => {
-    renderTable([{ ...projects[0], id: "acme/repo name" }]);
+  it('URL-encodes ids that contain reserved characters', () => {
+    renderTable([{ ...projects[0], id: 'acme/repo name' }])
     expect(
-      screen.getByRole("link", { name: /view defi protocol project details/i }),
-    ).toHaveAttribute("href", "/dashboard/projects/acme%2Frepo%20name");
-  });
+      screen.getByRole('link', { name: /view defi protocol project details/i })
+    ).toHaveAttribute('href', '/dashboard/projects/acme%2Frepo%20name')
+  })
 
-  it("renders a disabled, non-navigating control when a project has no id", () => {
-    const { id: _id, ...withoutId } = projects[0];
-    renderTable([withoutId]);
+  it('renders a disabled, non-navigating control when a project has no id', () => {
+    const { id: _id, ...withoutId } = projects[0]
+    renderTable([withoutId])
 
-    expect(
-      screen.queryByRole("link", { name: /project details/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /project details/i })).not.toBeInTheDocument()
 
-    const button = screen.getByRole("button", { name: /view project/i });
-    expect(button).toBeDisabled();
-  });
+    const button = screen.getByRole('button', { name: /view project/i })
+    expect(button).toBeDisabled()
+  })
 
-  it("renders correctly under the dark theme", () => {
-    localStorage.setItem("theme", "dark");
+  it('renders correctly under the dark theme', () => {
+    localStorage.setItem('theme', 'dark')
     try {
-      renderTable();
-      expect(screen.getByText("DeFi Protocol")).toBeInTheDocument();
+      renderTable()
+      expect(screen.getByText('DeFi Protocol')).toBeInTheDocument()
     } finally {
-      localStorage.clear();
+      localStorage.clear()
     }
-  });
-});
+  })
+})
+
+describe('ProjectsTable states', () => {
+  it('renders an accessible empty state for zero rows', () => {
+    renderTable([])
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText(/no projects yet/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it('renders an error state with an assertive live region and retry', async () => {
+    const onRetry = vi.fn()
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <ProjectsTable
+            data={[]}
+            activeFilter="overall"
+            isLoaded
+            error="We couldn't load projects. Please try again."
+            onRetry={onRetry}
+          />
+        </MemoryRouter>
+      </ThemeProvider>
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+    expect(screen.getByText(/please try again/i)).toBeInTheDocument()
+    expect(alert.textContent).not.toMatch(/stack|http|status\s*\d/i)
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -1,23 +1,31 @@
-import { TrendingUp, TrendingDown, Minus, Award } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { ProjectData, FilterType } from '../types';
-import { getAvatarGradient } from "../data/leaderboardData";
+import { TrendingUp, TrendingDown, Minus, Award } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { ProjectData, FilterType } from '../types'
+import { getAvatarGradient } from '../data/leaderboardData'
+import { LeaderboardTableState } from './LeaderboardTableState'
 
 interface ProjectsTableProps {
-  data: ProjectData[];
-  activeFilter: FilterType;
-  isLoaded: boolean;
+  data: ProjectData[]
+  activeFilter: FilterType
+  isLoaded: boolean
+  /**
+   * Generic, user-facing error message. When set, the table renders an error
+   * state with a retry action instead of rows. Must not expose internals.
+   */
+  error?: string | null
+  /** Retry handler wired to the data source; enables the error-state button. */
+  onRetry?: () => void
 }
 
 const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
-  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />;
-  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />;
-  return <Minus className="w-4 h-4 text-[#7a6b5a]" />;
-};
+  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
+  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
+  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
+}
 
 function isLogoUrl(logo: string): boolean {
-  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'));
+  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
 }
 
 /**
@@ -35,150 +43,207 @@ function isLogoUrl(logo: string): boolean {
  *   anchor at `/dashboard/projects/undefined`.
  */
 function projectDetailPath(id: string | undefined): string | undefined {
-  return id ? `/dashboard/projects/${encodeURIComponent(id)}` : undefined;
+  return id ? `/dashboard/projects/${encodeURIComponent(id)}` : undefined
 }
 
 /** Shared visual styling for the "View Project" call-to-action. */
 const VIEW_PROJECT_CLASSES =
-  'inline-block px-4 py-2 rounded-[10px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white text-[12px] font-semibold shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300 border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+  'inline-block px-4 py-2 rounded-[10px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white text-[12px] font-semibold shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300 border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
 
-export function ProjectsTable({ data, activeFilter, isLoaded }: ProjectsTableProps) {
-  const { theme } = useTheme();
+export function ProjectsTable({
+  data,
+  activeFilter,
+  isLoaded,
+  error,
+  onRetry,
+}: ProjectsTableProps) {
+  const { theme } = useTheme()
 
   return (
-    <div className={`backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden transition-all duration-700 delay-1000 ${
-      isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
-    }`}>
+    <div
+      className={`backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden transition-all duration-700 delay-1000 ${
+        isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+      }`}
+    >
       {/* Table Header */}
       <div className="grid grid-cols-12 gap-4 px-8 py-4 border-b border-white/10 backdrop-blur-[30px] bg-white/[0.08]">
-        <div className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-        }`}>Rank</div>
-        <div className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-        }`}>Trend</div>
-        <div className={`col-span-5 text-[12px] font-bold uppercase tracking-wider transition-colors ${
-          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-        }`}>Project</div>
-        <div className={`col-span-2 text-[12px] font-bold uppercase tracking-wider text-right flex items-center justify-end gap-1 transition-colors ${
-          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-        }`}>
+        <div
+          className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+          }`}
+        >
+          Rank
+        </div>
+        <div
+          className={`col-span-1 text-[12px] font-bold uppercase tracking-wider transition-colors ${
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+          }`}
+        >
+          Trend
+        </div>
+        <div
+          className={`col-span-5 text-[12px] font-bold uppercase tracking-wider transition-colors ${
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+          }`}
+        >
+          Project
+        </div>
+        <div
+          className={`col-span-2 text-[12px] font-bold uppercase tracking-wider text-right flex items-center justify-end gap-1 transition-colors ${
+            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+          }`}
+        >
           Score
           <Award className="w-3.5 h-3.5 animate-wiggle-slow" />
         </div>
         <div className="col-span-3"></div>
       </div>
 
-      {/* Table Rows */}
-      <div className="divide-y divide-white/10">
-        {data.map((project, index) => {
-          const detailPath = projectDetailPath(project.id);
-          return (
-          <div
-            key={project.rank}
-            className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
-            style={{
-              animation: isLoaded ? `slideInLeft 0.5s ease-out ${1.1 + index * 0.1}s both` : 'none',
-            }}
-          >
-            {/* Rank */}
-            <div className="col-span-1 flex items-center">
-              <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 group-hover:shadow-md transition-all duration-300">
-                <span className={`text-[15px] font-bold transition-colors ${
-                  theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>{project.rank}</span>
-              </div>
-            </div>
-
-            {/* Trend */}
-            <div className="col-span-1 flex items-center">
-              <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 transition-all duration-300">
-                {getTrendIcon(project.trend)}
-              </div>
-            </div>
-
-            {/* Project */}
-            <div className="col-span-5 flex items-center gap-3">
-              <div className={`relative w-12 h-12 rounded-full bg-gradient-to-br ${getAvatarGradient(index)} flex items-center justify-center text-white font-bold text-[18px] shadow-md border-2 border-white/25 overflow-hidden group-hover:scale-125 group-hover:shadow-lg group-hover:rotate-12 transition-all duration-300`}>
-                {isLogoUrl(project.logo) ? (
-                  <img src={project.logo} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  project.logo
-                )}
-                {/* Glow ring on hover */}
-                <div className="absolute inset-0 rounded-full border-2 border-[#c9983a]/0 group-hover:border-[#c9983a]/50 transition-all duration-300 animate-ping-on-hover" />
-              </div>
-              <div>
-                <div className={`text-[15px] font-bold group-hover:text-[#c9983a] transition-colors duration-300 ${
-                  theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>
-                  {project.name}
-                </div>
-                {activeFilter === 'contributions' && project.contributors && (
-                  <div className={`text-[12px] transition-colors ${
-                    theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                  }`}>{project.contributors} contributors</div>
-                )}
-                {project.ecosystems && (
-                  <div className="flex gap-1.5 mt-1">
-                    {project.ecosystems.map((eco, idx) => (
-                      <span key={idx} className="px-2 py-0.5 bg-[#c9983a]/20 border border-[#c9983a]/30 rounded-[6px] text-[10px] font-semibold text-[#8b6f3a] hover:bg-[#c9983a]/30 transition-colors">
-                        {eco}
-                      </span>
-                    ))}
+      {/* Table Rows — or an empty / error state in their place. */}
+      {error || data.length === 0 ? (
+        <LeaderboardTableState
+          error={error}
+          onRetry={onRetry}
+          emptyTitle="No projects yet"
+          emptyHint="Complete project setup to appear on the leaderboard."
+        />
+      ) : (
+        <div className="divide-y divide-white/10">
+          {data.map((project, index) => {
+            const detailPath = projectDetailPath(project.id)
+            return (
+              <div
+                key={project.rank}
+                className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
+                style={{
+                  animation: isLoaded
+                    ? `slideInLeft 0.5s ease-out ${1.1 + index * 0.1}s both`
+                    : 'none',
+                }}
+              >
+                {/* Rank */}
+                <div className="col-span-1 flex items-center">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 group-hover:shadow-md transition-all duration-300">
+                    <span
+                      className={`text-[15px] font-bold transition-colors ${
+                        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                      }`}
+                    >
+                      {project.rank}
+                    </span>
                   </div>
-                )}
-              </div>
-            </div>
+                </div>
 
-            {/* Score */}
-            <div className="col-span-2 flex items-center justify-end">
-              <div className="relative px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/15 border border-[#c9983a]/40 shadow-sm group-hover:shadow-lg group-hover:border-[#c9983a]/70 group-hover:from-[#c9983a]/35 group-hover:to-[#d4af37]/25 group-hover:scale-110 transition-all duration-300">
-                <div className={`text-[17px] font-black transition-colors ${
-                  theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>{project.score}</div>
-              </div>
-            </div>
+                {/* Trend */}
+                <div className="col-span-1 flex items-center">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-[10px] bg-gradient-to-br from-white/[0.15] to-white/[0.08] border border-white/20 shadow-sm group-hover:scale-110 transition-all duration-300">
+                    {getTrendIcon(project.trend)}
+                  </div>
+                </div>
 
-            {/* Action */}
-            {/* `group-focus-within` keeps this column visible when the "View
+                {/* Project */}
+                <div className="col-span-5 flex items-center gap-3">
+                  <div
+                    className={`relative w-12 h-12 rounded-full bg-gradient-to-br ${getAvatarGradient(index)} flex items-center justify-center text-white font-bold text-[18px] shadow-md border-2 border-white/25 overflow-hidden group-hover:scale-125 group-hover:shadow-lg group-hover:rotate-12 transition-all duration-300`}
+                  >
+                    {isLogoUrl(project.logo) ? (
+                      <img src={project.logo} alt="" className="w-full h-full object-cover" />
+                    ) : (
+                      project.logo
+                    )}
+                    {/* Glow ring on hover */}
+                    <div className="absolute inset-0 rounded-full border-2 border-[#c9983a]/0 group-hover:border-[#c9983a]/50 transition-all duration-300 animate-ping-on-hover" />
+                  </div>
+                  <div>
+                    <div
+                      className={`text-[15px] font-bold group-hover:text-[#c9983a] transition-colors duration-300 ${
+                        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                      }`}
+                    >
+                      {project.name}
+                    </div>
+                    {activeFilter === 'contributions' && project.contributors && (
+                      <div
+                        className={`text-[12px] transition-colors ${
+                          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        {project.contributors} contributors
+                      </div>
+                    )}
+                    {project.ecosystems && (
+                      <div className="flex gap-1.5 mt-1">
+                        {project.ecosystems.map((eco, idx) => (
+                          <span
+                            key={idx}
+                            className="px-2 py-0.5 bg-[#c9983a]/20 border border-[#c9983a]/30 rounded-[6px] text-[10px] font-semibold text-[#8b6f3a] hover:bg-[#c9983a]/30 transition-colors"
+                          >
+                            {eco}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Score */}
+                <div className="col-span-2 flex items-center justify-end">
+                  <div className="relative px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/15 border border-[#c9983a]/40 shadow-sm group-hover:shadow-lg group-hover:border-[#c9983a]/70 group-hover:from-[#c9983a]/35 group-hover:to-[#d4af37]/25 group-hover:scale-110 transition-all duration-300">
+                    <div
+                      className={`text-[17px] font-black transition-colors ${
+                        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                      }`}
+                    >
+                      {project.score}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Action */}
+                {/* `group-focus-within` keeps this column visible when the "View
                 Project" control receives keyboard focus, so its focus ring is
                 never hidden behind the hover-only reveal. */}
-            <div className="col-span-3 flex items-center justify-end opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all duration-300 gap-2">
-              {project.activity && (
-                <div className={`px-3 py-1.5 rounded-[8px] text-[11px] font-semibold ${
-                  project.activity === 'Very High' ? 'bg-green-500/20 text-green-700 border border-green-500/30' :
-                  project.activity === 'High' ? 'bg-blue-500/20 text-blue-700 border border-blue-500/30' :
-                  project.activity === 'Medium' ? 'bg-yellow-500/20 text-yellow-700 border border-yellow-500/30' :
-                  'bg-gray-500/20 text-gray-700 border border-gray-500/30'
-                }`}>
-                  {project.activity}
+                <div className="col-span-3 flex items-center justify-end opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all duration-300 gap-2">
+                  {project.activity && (
+                    <div
+                      className={`px-3 py-1.5 rounded-[8px] text-[11px] font-semibold ${
+                        project.activity === 'Very High'
+                          ? 'bg-green-500/20 text-green-700 border border-green-500/30'
+                          : project.activity === 'High'
+                            ? 'bg-blue-500/20 text-blue-700 border border-blue-500/30'
+                            : project.activity === 'Medium'
+                              ? 'bg-yellow-500/20 text-yellow-700 border border-yellow-500/30'
+                              : 'bg-gray-500/20 text-gray-700 border border-gray-500/30'
+                      }`}
+                    >
+                      {project.activity}
+                    </div>
+                  )}
+                  {detailPath ? (
+                    <Link
+                      to={detailPath}
+                      aria-label={`View ${project.name} project details`}
+                      className={VIEW_PROJECT_CLASSES}
+                    >
+                      View Project
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled
+                      aria-disabled="true"
+                      title="Project details are unavailable"
+                      className={`${VIEW_PROJECT_CLASSES} opacity-50 cursor-not-allowed hover:scale-100 hover:shadow-md`}
+                    >
+                      View Project
+                    </button>
+                  )}
                 </div>
-              )}
-              {detailPath ? (
-                <Link
-                  to={detailPath}
-                  aria-label={`View ${project.name} project details`}
-                  className={VIEW_PROJECT_CLASSES}
-                >
-                  View Project
-                </Link>
-              ) : (
-                <button
-                  type="button"
-                  disabled
-                  aria-disabled="true"
-                  title="Project details are unavailable"
-                  className={`${VIEW_PROJECT_CLASSES} opacity-50 cursor-not-allowed hover:scale-100 hover:shadow-md`}
-                >
-                  View Project
-                </button>
-              )}
-            </div>
-          </div>
-          );
-        })}
-      </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
     </div>
-  );
+  )
 }

--- a/src/features/leaderboard/pages/LeaderboardPage.test.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.test.tsx
@@ -1,352 +1,370 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
 
 // --- Mock the API client -------------------------------------------------
-const getLeaderboard = vi.fn();
-const getRecommendedProjects = vi.fn();
-vi.mock("../../../shared/api/client", () => ({
+const getLeaderboard = vi.fn()
+const getRecommendedProjects = vi.fn()
+vi.mock('../../../shared/api/client', () => ({
   getLeaderboard: (...args: unknown[]) => getLeaderboard(...args),
   getRecommendedProjects: (...args: unknown[]) => getRecommendedProjects(...args),
-}));
+}))
 
 // --- Mock heavy / presentational children -------------------------------
 // (ContributorsTable et al. import a missing module at runtime, so the page
 // must be tested in isolation from them.)
-vi.mock("../components/FallingPetals", () => ({
+vi.mock('../components/FallingPetals', () => ({
   FallingPetals: () => null,
-}));
-vi.mock("../components/LeaderboardStyles", () => ({
+}))
+vi.mock('../components/LeaderboardStyles', () => ({
   LeaderboardStyles: () => null,
-}));
-vi.mock("../components/LeaderboardTypeToggle", () => ({
+}))
+vi.mock('../components/LeaderboardTypeToggle', () => ({
   LeaderboardTypeToggle: ({ onToggle }: { onToggle: (t: string) => void }) => (
     <div>
-      <button onClick={() => onToggle("projects")}>to-projects</button>
-      <button onClick={() => onToggle("contributors")}>to-contributors</button>
+      <button onClick={() => onToggle('projects')}>to-projects</button>
+      <button onClick={() => onToggle('contributors')}>to-contributors</button>
     </div>
   ),
-}));
-vi.mock("../components/LeaderboardHero", () => ({
+}))
+vi.mock('../components/LeaderboardHero', () => ({
   LeaderboardHero: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="hero">{children}</div>
   ),
-}));
-vi.mock("../components/ContributorsPodium", () => ({
+}))
+vi.mock('../components/ContributorsPodium', () => ({
   ContributorsPodium: () => <div data-testid="podium" />,
-}));
-vi.mock("../components/ProjectsPodium", () => ({
+}))
+vi.mock('../components/ProjectsPodium', () => ({
   ProjectsPodium: () => <div data-testid="projects-podium" />,
-}));
-vi.mock("../components/ContributorsPodiumSkeleton", () => ({
+}))
+vi.mock('../components/ContributorsPodiumSkeleton', () => ({
   ContributorsPodiumSkeleton: () => <div data-testid="podium-skeleton" />,
-}));
-vi.mock("../components/ContributorsTableSkeleton", () => ({
+}))
+vi.mock('../components/ContributorsTableSkeleton', () => ({
   ContributorsTableSkeleton: () => <div data-testid="table-skeleton" />,
-}));
-vi.mock("../components/FiltersSection", () => ({
+}))
+vi.mock('../components/FiltersSection', () => ({
   FiltersSection: ({
     onEcosystemChange,
   }: {
-    onEcosystemChange: (e: { label: string; value: string }) => void;
+    onEcosystemChange: (e: { label: string; value: string }) => void
   }) => (
-    <button
-      onClick={() => onEcosystemChange({ label: "Eco One", value: "eco1" })}
-    >
-      pick-eco
-    </button>
+    <button onClick={() => onEcosystemChange({ label: 'Eco One', value: 'eco1' })}>pick-eco</button>
   ),
-}));
-vi.mock("../components/ContributorsTable", () => ({
+}))
+vi.mock('../components/ContributorsTable', () => ({
   ContributorsTable: ({
     data,
     onUserClick,
+    error,
+    onRetry,
   }: {
-    data: unknown[];
-    onUserClick: (username: string, userId?: string) => void;
+    data: unknown[]
+    onUserClick: (username: string, userId?: string) => void
+    error?: string | null
+    onRetry?: () => void
   }) => (
     <div data-testid="contributors-table" data-rows={data.length}>
-      {data.length} rows
-      <button onClick={() => onUserClick("octocat", "uid-1")}>row-click</button>
+      {error ? <div data-testid="contributors-error">{error}</div> : `${data.length} rows`}
+      {error && onRetry && <button onClick={onRetry}>retry-contributors</button>}
+      <button onClick={() => onUserClick('octocat', 'uid-1')}>row-click</button>
     </div>
   ),
-}));
-vi.mock("../components/ProjectsTable", () => ({
-  ProjectsTable: ({ data }: { data: unknown[] }) => (
-    <div data-testid="projects-table" data-rows={data.length} />
+}))
+vi.mock('../components/ProjectsTable', () => ({
+  ProjectsTable: ({
+    data,
+    error,
+    onRetry,
+  }: {
+    data: unknown[]
+    error?: string | null
+    onRetry?: () => void
+  }) => (
+    <div data-testid="projects-table" data-rows={data.length}>
+      {error && <div data-testid="projects-error">{error}</div>}
+      {error && onRetry && <button onClick={onRetry}>retry-projects</button>}
+    </div>
   ),
-}));
+}))
 
-import { LeaderboardPage } from "./LeaderboardPage";
+import { LeaderboardPage } from './LeaderboardPage'
 
 /** Build `count` leaderboard rows starting at the given rank. */
 function makePage(count: number, startRank = 1) {
   return Array.from({ length: count }, (_, i) => ({
     rank: startRank + i,
-    rank_tier: "bronze",
-    rank_tier_name: "Bronze",
+    rank_tier: 'bronze',
+    rank_tier_name: 'Bronze',
     username: `user${startRank + i}`,
-    avatar: "",
+    avatar: '',
     user_id: `id-${startRank + i}`,
     contributions: 1,
     ecosystems: [],
     score: 100 - i,
-    trend: "same" as const,
+    trend: 'same' as const,
     trendValue: 0,
-  }));
+  }))
 }
 
 const renderPage = () =>
   render(
     <ThemeProvider>
       <LeaderboardPage />
-    </ThemeProvider>,
-  );
+    </ThemeProvider>
+  )
 
-const rows = () =>
-  Number(
-    screen.getByTestId("contributors-table").getAttribute("data-rows"),
-  );
+const rows = () => Number(screen.getByTestId('contributors-table').getAttribute('data-rows'))
 
 beforeEach(() => {
-  getLeaderboard.mockReset();
-  getRecommendedProjects.mockReset();
-  getRecommendedProjects.mockResolvedValue({ projects: [] });
-  localStorage.clear();
-});
+  getLeaderboard.mockReset()
+  getRecommendedProjects.mockReset()
+  getRecommendedProjects.mockResolvedValue({ projects: [] })
+  localStorage.clear()
+})
 
-describe("LeaderboardPage pagination", () => {
+describe('LeaderboardPage pagination', () => {
   it("shows 'Load more' after a full first page", async () => {
-    getLeaderboard.mockResolvedValueOnce(makePage(10));
-    renderPage();
+    getLeaderboard.mockResolvedValueOnce(makePage(10))
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(10));
-    expect(
-      screen.getByRole("button", { name: "Load more" }),
-    ).toBeInTheDocument();
+    await waitFor(() => expect(rows()).toBe(10))
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
     // First page is always requested at offset 0.
-    expect(getLeaderboard).toHaveBeenCalledWith(10, 0, undefined);
-  });
+    expect(getLeaderboard).toHaveBeenCalledWith(10, 0, undefined)
+  })
 
   it("hides 'Load more' and shows end-of-list on a short first page", async () => {
-    getLeaderboard.mockResolvedValueOnce(makePage(4));
-    renderPage();
+    getLeaderboard.mockResolvedValueOnce(makePage(4))
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(4));
-    expect(
-      screen.queryByRole("button", { name: "Load more" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/reached the end of the leaderboard/i),
-    ).toBeInTheDocument();
-  });
+    await waitFor(() => expect(rows()).toBe(4))
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    expect(screen.getByText(/reached the end of the leaderboard/i)).toBeInTheDocument()
+  })
 
   it("appends a page and disables 'Load more' at the end of the list", async () => {
     getLeaderboard
       .mockResolvedValueOnce(makePage(10)) // initial
-      .mockResolvedValueOnce(makePage(3, 11)); // load more -> short page = end
-    renderPage();
+      .mockResolvedValueOnce(makePage(3, 11)) // load more -> short page = end
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(10));
-    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await waitFor(() => expect(rows()).toBe(10))
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-    await waitFor(() => expect(rows()).toBe(13));
+    await waitFor(() => expect(rows()).toBe(13))
     // The second request paged forward by the page size.
-    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 10, undefined);
-    expect(
-      screen.queryByRole("button", { name: "Load more" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/reached the end of the leaderboard/i),
-    ).toBeInTheDocument();
-  });
+    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 10, undefined)
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    expect(screen.getByText(/reached the end of the leaderboard/i)).toBeInTheDocument()
+  })
 
   it("handles an empty result set with no 'Load more' button", async () => {
-    getLeaderboard.mockResolvedValueOnce([]);
-    renderPage();
+    getLeaderboard.mockResolvedValueOnce([])
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(0));
-    expect(
-      screen.queryByRole("button", { name: "Load more" }),
-    ).not.toBeInTheDocument();
-    expect(getLeaderboard).toHaveBeenCalledTimes(1);
-  });
+    await waitFor(() => expect(rows()).toBe(0))
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    expect(getLeaderboard).toHaveBeenCalledTimes(1)
+  })
 
-  it("does not fire duplicate concurrent load-more requests on rapid clicks", async () => {
-    let resolveSecond: (v: unknown) => void = () => {};
+  it('does not fire duplicate concurrent load-more requests on rapid clicks', async () => {
+    let resolveSecond: (v: unknown) => void = () => {}
     const second = new Promise((res) => {
-      resolveSecond = res;
-    });
+      resolveSecond = res
+    })
     getLeaderboard
       .mockResolvedValueOnce(makePage(10)) // initial
-      .mockReturnValueOnce(second); // load more (kept pending)
+      .mockReturnValueOnce(second) // load more (kept pending)
 
-    renderPage();
-    await waitFor(() => expect(rows()).toBe(10));
+    renderPage()
+    await waitFor(() => expect(rows()).toBe(10))
 
-    const button = screen.getByRole("button", { name: /load more|loading/i });
+    const button = screen.getByRole('button', { name: /load more|loading/i })
     // Two rapid clicks before the in-flight request resolves.
-    fireEvent.click(button);
-    fireEvent.click(button);
+    fireEvent.click(button)
+    fireEvent.click(button)
 
     // Only the initial call + a single load-more call should have happened.
-    expect(getLeaderboard).toHaveBeenCalledTimes(2);
+    expect(getLeaderboard).toHaveBeenCalledTimes(2)
 
     await act(async () => {
-      resolveSecond(makePage(10, 11));
-      await second;
-    });
-    await waitFor(() => expect(rows()).toBe(20));
-  });
+      resolveSecond(makePage(10, 11))
+      await second
+    })
+    await waitFor(() => expect(rows()).toBe(20))
+  })
 
-  it("resets pagination to offset 0 when the ecosystem filter changes", async () => {
+  it('resets pagination to offset 0 when the ecosystem filter changes', async () => {
     getLeaderboard
       .mockResolvedValueOnce(makePage(10)) // initial (all ecosystems)
       .mockResolvedValueOnce(makePage(10, 11)) // load more
-      .mockResolvedValueOnce(makePage(5)); // refetch after filter change
-    renderPage();
+      .mockResolvedValueOnce(makePage(5)) // refetch after filter change
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(10));
-    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
-    await waitFor(() => expect(rows()).toBe(20));
+    await waitFor(() => expect(rows()).toBe(10))
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    await waitFor(() => expect(rows()).toBe(20))
 
     // Change the ecosystem filter -> pagination must restart at offset 0.
-    await userEvent.click(screen.getByRole("button", { name: "pick-eco" }));
+    await userEvent.click(screen.getByRole('button', { name: 'pick-eco' }))
 
-    await waitFor(() => expect(rows()).toBe(5));
-    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 0, "eco1");
-  });
+    await waitFor(() => expect(rows()).toBe(5))
+    expect(getLeaderboard).toHaveBeenLastCalledWith(10, 0, 'eco1')
+  })
 
-  it("keeps the list unchanged when load-more returns an empty page", async () => {
+  it('keeps the list unchanged when load-more returns an empty page', async () => {
     getLeaderboard
       .mockResolvedValueOnce(makePage(10)) // initial full page
-      .mockResolvedValueOnce([]); // load more -> nothing left
-    renderPage();
+      .mockResolvedValueOnce([]) // load more -> nothing left
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(10));
-    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
-
-    await waitFor(() =>
-      expect(
-        screen.getByText(/reached the end of the leaderboard/i),
-      ).toBeInTheDocument(),
-    );
-    expect(rows()).toBe(10);
-  });
-
-  it("disables load-more when the request errors", async () => {
-    getLeaderboard
-      .mockResolvedValueOnce(makePage(10))
-      .mockRejectedValueOnce(new Error("boom"));
-    renderPage();
-
-    await waitFor(() => expect(rows()).toBe(10));
-    await userEvent.click(screen.getByRole("button", { name: "Load more" }));
+    await waitFor(() => expect(rows()).toBe(10))
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
     await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Load more" }),
-      ).not.toBeInTheDocument(),
-    );
-  });
+      expect(screen.getByText(/reached the end of the leaderboard/i)).toBeInTheDocument()
+    )
+    expect(rows()).toBe(10)
+  })
 
-  it("renders an empty contributor state under the dark theme", async () => {
-    localStorage.setItem("theme", "dark");
-    getLeaderboard.mockResolvedValueOnce([]);
-    renderPage();
+  it('disables load-more when the request errors', async () => {
+    getLeaderboard.mockResolvedValueOnce(makePage(10)).mockRejectedValueOnce(new Error('boom'))
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(0));
-  });
+    await waitFor(() => expect(rows()).toBe(10))
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }))
 
-  it("recovers gracefully when the initial fetch fails", async () => {
-    getLeaderboard.mockRejectedValueOnce(new Error("boom"));
-    renderPage();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    )
+  })
+
+  it('renders an empty contributor state under the dark theme', async () => {
+    localStorage.setItem('theme', 'dark')
+    getLeaderboard.mockResolvedValueOnce([])
+    renderPage()
+
+    await waitFor(() => expect(rows()).toBe(0))
+  })
+
+  it('recovers gracefully when the initial fetch fails', async () => {
+    getLeaderboard.mockRejectedValueOnce(new Error('boom'))
+    renderPage()
 
     // Error path clears data, stops loading and disables load-more.
-    await waitFor(() => expect(rows()).toBe(0));
-    expect(
-      screen.queryByRole("button", { name: "Load more" }),
-    ).not.toBeInTheDocument();
-  });
+    await waitFor(() => expect(rows()).toBe(0))
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+  })
 
-  it("navigates to a contributor profile on row click", async () => {
-    getLeaderboard.mockResolvedValueOnce(makePage(10));
-    renderPage();
+  it('passes a generic error to the contributors table on fetch failure', async () => {
+    getLeaderboard.mockRejectedValueOnce(new Error('ECONNREFUSED 127.0.0.1:5432'))
+    renderPage()
 
-    await waitFor(() => expect(rows()).toBe(10));
+    await waitFor(() => expect(screen.getByTestId('contributors-error')).toBeInTheDocument())
+    const message = screen.getByTestId('contributors-error').textContent ?? ''
+    // The raw error must not leak; only generic copy is surfaced.
+    expect(message).toMatch(/please try again/i)
+    expect(message).not.toMatch(/ECONNREFUSED|5432/)
+  })
+
+  it('retries the contributors fetch from the table error state', async () => {
+    getLeaderboard.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(makePage(6))
+    renderPage()
+
+    await waitFor(() => expect(screen.getByTestId('contributors-error')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: 'retry-contributors' }))
+
+    await waitFor(() => expect(rows()).toBe(6))
+    expect(screen.queryByTestId('contributors-error')).not.toBeInTheDocument()
+    expect(getLeaderboard).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates to a contributor profile on row click', async () => {
+    getLeaderboard.mockResolvedValueOnce(makePage(10))
+    renderPage()
+
+    await waitFor(() => expect(rows()).toBe(10))
     // jsdom treats navigation as a no-op; we just exercise the handler.
-    await userEvent.click(screen.getByRole("button", { name: "row-click" }));
-  });
-});
+    await userEvent.click(screen.getByRole('button', { name: 'row-click' }))
+  })
+})
 
-describe("LeaderboardPage projects tab", () => {
-  it("loads, filters and maps recommended projects", async () => {
-    getLeaderboard.mockResolvedValue([]);
+describe('LeaderboardPage projects tab', () => {
+  it('loads, filters and maps recommended projects', async () => {
+    getLeaderboard.mockResolvedValue([])
     getRecommendedProjects.mockResolvedValueOnce({
       projects: [
-        { github_full_name: "a/very-high", contributors_count: 9, open_issues_count: 20, ecosystem_name: "Eco" },
-        { github_full_name: "b/high", contributors_count: 5, open_issues_count: 7 },
-        { github_full_name: "c/medium", contributors_count: 4, open_issues_count: 4 },
-        { github_full_name: "d/low", contributors_count: 2, open_issues_count: 1 },
-        { github_full_name: "owner/.github", contributors_count: 99, open_issues_count: 99 }, // filtered out
+        {
+          github_full_name: 'a/very-high',
+          contributors_count: 9,
+          open_issues_count: 20,
+          ecosystem_name: 'Eco',
+        },
+        { github_full_name: 'b/high', contributors_count: 5, open_issues_count: 7 },
+        { github_full_name: 'c/medium', contributors_count: 4, open_issues_count: 4 },
+        { github_full_name: 'd/low', contributors_count: 2, open_issues_count: 1 },
+        { github_full_name: 'owner/.github', contributors_count: 99, open_issues_count: 99 }, // filtered out
       ],
-    });
+    })
 
     render(
       <ThemeProvider>
         <LeaderboardPage />
-      </ThemeProvider>,
-    );
+      </ThemeProvider>
+    )
 
     // Switch to the projects leaderboard.
-    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+    await userEvent.click(screen.getByRole('button', { name: 'to-projects' }))
 
     await waitFor(() =>
-      expect(
-        Number(
-          screen
-            .getByTestId("projects-table")
-            .getAttribute("data-rows"),
-        ),
-      ).toBe(4),
-    );
-    expect(getRecommendedProjects).toHaveBeenCalledWith(50);
-  });
+      expect(Number(screen.getByTestId('projects-table').getAttribute('data-rows'))).toBe(4)
+    )
+    expect(getRecommendedProjects).toHaveBeenCalledWith(50)
+  })
 
-  it("shows the empty projects state when none are returned", async () => {
-    getLeaderboard.mockResolvedValue([]);
-    getRecommendedProjects.mockResolvedValueOnce({ projects: [] });
+  it('shows the empty projects state when none are returned', async () => {
+    getLeaderboard.mockResolvedValue([])
+    getRecommendedProjects.mockResolvedValueOnce({ projects: [] })
 
     render(
       <ThemeProvider>
         <LeaderboardPage />
-      </ThemeProvider>,
-    );
+      </ThemeProvider>
+    )
 
-    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+    await userEvent.click(screen.getByRole('button', { name: 'to-projects' }))
 
-    await waitFor(() =>
-      expect(
-        screen.getByText(/No projects yet/i),
-      ).toBeInTheDocument(),
-    );
-  });
+    await waitFor(() => expect(screen.getByText(/No projects yet/i)).toBeInTheDocument())
+  })
 
-  it("tolerates a failed recommended-projects fetch", async () => {
-    getLeaderboard.mockResolvedValue([]);
-    getRecommendedProjects.mockRejectedValueOnce(new Error("down"));
+  it('surfaces a generic error and retries the projects fetch', async () => {
+    getLeaderboard.mockResolvedValue([])
+    getRecommendedProjects
+      .mockRejectedValueOnce(new Error('postgres://secret@db down'))
+      .mockResolvedValueOnce({
+        projects: [{ github_full_name: 'a/repo', contributors_count: 3, open_issues_count: 1 }],
+      })
 
     render(
       <ThemeProvider>
         <LeaderboardPage />
-      </ThemeProvider>,
-    );
+      </ThemeProvider>
+    )
 
-    await userEvent.click(screen.getByRole("button", { name: "to-projects" }));
+    await userEvent.click(screen.getByRole('button', { name: 'to-projects' }))
+
+    await waitFor(() => expect(screen.getByTestId('projects-error')).toBeInTheDocument())
+    // Internal connection details must not leak into the UI.
+    expect(screen.getByTestId('projects-error').textContent ?? '').not.toMatch(/postgres|secret/)
+
+    await userEvent.click(screen.getByRole('button', { name: 'retry-projects' }))
 
     await waitFor(() =>
-      expect(screen.getByText(/No projects yet/i)).toBeInTheDocument(),
-    );
-  });
-});
+      expect(Number(screen.getByTestId('projects-table').getAttribute('data-rows'))).toBe(1)
+    )
+    expect(screen.queryByTestId('projects-error')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/leaderboard/pages/LeaderboardPage.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.tsx
@@ -1,20 +1,20 @@
-import { logger } from '../../../shared/utils/logger';
-import { useState, useEffect, useRef } from "react";
-import { LeaderboardType, FilterType, Petal, LeaderData, ProjectData } from "../types";
-import { getLeaderboard, getRecommendedProjects } from "../../../shared/api/client";
-import { clampLimit, clampOffset, hasMoreByPageSize } from "../../../shared/utils/pagination";
-import { useTheme } from "../../../shared/contexts/ThemeContext";
-import { FallingPetals } from "../components/FallingPetals";
-import { LeaderboardTypeToggle } from "../components/LeaderboardTypeToggle";
-import { LeaderboardHero } from "../components/LeaderboardHero";
-import { ContributorsPodium } from "../components/ContributorsPodium";
-import { ProjectsPodium } from "../components/ProjectsPodium";
-import { FiltersSection } from "../components/FiltersSection";
-import { ContributorsTable } from "../components/ContributorsTable";
-import { ProjectsTable } from "../components/ProjectsTable";
-import { LeaderboardStyles } from "../components/LeaderboardStyles";
-import { ContributorsPodiumSkeleton } from "../components/ContributorsPodiumSkeleton";
-import { ContributorsTableSkeleton } from "../components/ContributorsTableSkeleton";
+import { logger } from '../../../shared/utils/logger'
+import { useState, useEffect, useRef } from 'react'
+import { LeaderboardType, FilterType, Petal, LeaderData, ProjectData } from '../types'
+import { getLeaderboard, getRecommendedProjects } from '../../../shared/api/client'
+import { clampLimit, clampOffset, hasMoreByPageSize } from '../../../shared/utils/pagination'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { FallingPetals } from '../components/FallingPetals'
+import { LeaderboardTypeToggle } from '../components/LeaderboardTypeToggle'
+import { LeaderboardHero } from '../components/LeaderboardHero'
+import { ContributorsPodium } from '../components/ContributorsPodium'
+import { ProjectsPodium } from '../components/ProjectsPodium'
+import { FiltersSection } from '../components/FiltersSection'
+import { ContributorsTable } from '../components/ContributorsTable'
+import { ProjectsTable } from '../components/ProjectsTable'
+import { LeaderboardStyles } from '../components/LeaderboardStyles'
+import { ContributorsPodiumSkeleton } from '../components/ContributorsPodiumSkeleton'
+import { ContributorsTableSkeleton } from '../components/ContributorsTableSkeleton'
 
 /**
  * Number of contributors requested per leaderboard page.
@@ -23,137 +23,164 @@ import { ContributorsTableSkeleton } from "../components/ContributorsTableSkelet
  * field, so end-of-list is detected from the page size: a full page implies
  * more may follow, a short/empty page means we have reached the end.
  */
-const LEADERBOARD_PAGE_SIZE = 10;
+const LEADERBOARD_PAGE_SIZE = 10
+
+/**
+ * Generic, user-facing error copy shown when a leaderboard fetch fails.
+ *
+ * Security: intentionally free of any backend/HTTP detail so a failure never
+ * leaks internals to the UI; the underlying error is only sent to {@link logger}.
+ */
+const CONTRIBUTORS_ERROR = "We couldn't load contributors. Please try again."
+const PROJECTS_ERROR = "We couldn't load projects. Please try again."
 
 /** Transform a raw leaderboard API row into the UI {@link LeaderData} shape. */
-function transformLeader(
-  item: Awaited<ReturnType<typeof getLeaderboard>>[number],
-): LeaderData {
+function transformLeader(item: Awaited<ReturnType<typeof getLeaderboard>>[number]): LeaderData {
   return {
     rank: item.rank,
     rank_tier: item.rank_tier,
     rank_tier_name: item.rank_tier_name,
     username: item.username,
     avatar: item.avatar || `https://github.com/${item.username}.png?size=200`,
-    user_id: item.user_id || "",
+    user_id: item.user_id || '',
     score: item.score,
     trend: item.trend,
     trendValue: item.trendValue,
     contributions: item.contributions,
     ecosystems: item.ecosystems || [],
-  };
+  }
 }
 
 export function LeaderboardPage() {
-  const { theme } = useTheme();
-  const [activeFilter, setActiveFilter] = useState<FilterType>("overall");
-  const [leaderboardType, setLeaderboardType] =
-    useState<LeaderboardType>("contributors");
-  const [showEcosystemDropdown, setShowEcosystemDropdown] = useState(false);
+  const { theme } = useTheme()
+  const [activeFilter, setActiveFilter] = useState<FilterType>('overall')
+  const [leaderboardType, setLeaderboardType] = useState<LeaderboardType>('contributors')
+  const [showEcosystemDropdown, setShowEcosystemDropdown] = useState(false)
   const [selectedEcosystem, setSelectedEcosystem] = useState({
-    label: "All Ecosystems",
-    value: "all",
-  });
-  const [petals, setPetals] = useState<Petal[]>([]);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [leaderboardData, setLeaderboardData] = useState<LeaderData[]>([]);
-  const [projectsData, setProjectsData] = useState<ProjectData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingProjects, setIsLoadingProjects] = useState(true);
+    label: 'All Ecosystems',
+    value: 'all',
+  })
+  const [petals, setPetals] = useState<Petal[]>([])
+  const [isLoaded, setIsLoaded] = useState(false)
+  const [leaderboardData, setLeaderboardData] = useState<LeaderData[]>([])
+  const [projectsData, setProjectsData] = useState<ProjectData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true)
+  /** Generic error copy shown when the contributors fetch fails (null = ok). */
+  const [leaderboardError, setLeaderboardError] = useState<string | null>(null)
+  /** Generic error copy shown when the projects fetch fails (null = ok). */
+  const [projectsError, setProjectsError] = useState<string | null>(null)
+  // Bumping these tokens re-runs the corresponding fetch effect; the table
+  // "Try again" buttons increment them to retry against the data source.
+  const [contributorsRetry, setContributorsRetry] = useState(0)
+  const [projectsRetry, setProjectsRetry] = useState(0)
   /** Offset (start index) of the last loaded contributors page. */
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState(0)
   /** Whether the API may still have more contributors to load. */
-  const [hasMore, setHasMore] = useState(true);
+  const [hasMore, setHasMore] = useState(true)
   /** True while an additional ("load more") page is being fetched. */
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   // Synchronous guard so a rapid double-click of "Load more" cannot start two
   // concurrent requests before `isLoadingMore` state has flushed.
-  const loadingMoreRef = useRef(false);
+  const loadingMoreRef = useRef(false)
 
   const getProjectIcon = (githubFullName: string) => {
-    const [owner] = githubFullName.split("/");
+    const [owner] = githubFullName.split('/')
     // Use higher‑resolution owner avatar so leaderboard projects look crisp
-    return `https://github.com/${owner}.png?size=200`;
-  };
+    return `https://github.com/${owner}.png?size=200`
+  }
 
   // Fetch leaderboard data
   useEffect(() => {
     const fetchLeaderboard = async () => {
-      if (leaderboardType === "contributors") {
-        setIsLoading(true);
+      if (leaderboardType === 'contributors') {
+        setIsLoading(true)
+        setLeaderboardError(null)
         // Changing leaderboard type / filter / ecosystem resets pagination.
-        setOffset(0);
-        setHasMore(true);
-        const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
+        setOffset(0)
+        setHasMore(true)
+        const limit = clampLimit(LEADERBOARD_PAGE_SIZE)
         try {
           const data = await getLeaderboard(
             limit,
             0,
-            selectedEcosystem.value !== "all"
-              ? selectedEcosystem.value
-              : undefined,
-          );
-          setLeaderboardData(data.map(transformLeader));
+            selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined
+          )
+          setLeaderboardData(data.map(transformLeader))
           // A full first page implies more may exist; a short page is the end.
-          setHasMore(hasMoreByPageSize(data.length, limit));
-          setIsLoading(false);
+          setHasMore(hasMoreByPageSize(data.length, limit))
+          setIsLoading(false)
         } catch (err) {
-          logger.error("Failed to fetch leaderboard:", err);
-          setLeaderboardData([]);
-          setHasMore(false);
-          setIsLoading(false); // Set loading to false to show empty state instead of skeleton
+          logger.error('Failed to fetch leaderboard:', err)
+          setLeaderboardData([])
+          setHasMore(false)
+          // Surface a generic error state (with retry) rather than a blank table.
+          setLeaderboardError(CONTRIBUTORS_ERROR)
+          setIsLoading(false) // Set loading to false to show error state instead of skeleton
         }
       } else {
-        setIsLoading(false);
+        setIsLoading(false)
       }
-    };
+    }
 
-    fetchLeaderboard();
-  }, [leaderboardType, activeFilter, selectedEcosystem.value]);
+    fetchLeaderboard()
+  }, [leaderboardType, activeFilter, selectedEcosystem.value, contributorsRetry])
 
   // Fetch projects leaderboard (top projects by contributors count)
   useEffect(() => {
-    if (leaderboardType !== "projects") return;
-    let cancelled = false;
+    if (leaderboardType !== 'projects') return
+    let cancelled = false
     const fetchProjects = async () => {
-      setIsLoadingProjects(true);
+      setIsLoadingProjects(true)
+      setProjectsError(null)
       try {
-        const res = await getRecommendedProjects(50);
-        const projects = res?.projects ?? [];
-        if (cancelled) return;
+        const res = await getRecommendedProjects(50)
+        const projects = res?.projects ?? []
+        if (cancelled) return
         const mapped: ProjectData[] = projects
-          .filter((p) => (p.github_full_name.split("/")[1] || "") !== ".github")
+          .filter((p) => (p.github_full_name.split('/')[1] || '') !== '.github')
           .map((p, idx) => {
-            const repoName = p.github_full_name.split("/")[1] || p.github_full_name;
-            const contributors = p.contributors_count ?? 0;
-            const openIssues = p.open_issues_count ?? 0;
+            const repoName = p.github_full_name.split('/')[1] || p.github_full_name
+            const contributors = p.contributors_count ?? 0
+            const openIssues = p.open_issues_count ?? 0
             const activity =
-              openIssues > 10 ? "Very High" : openIssues > 5 ? "High" : openIssues > 2 ? "Medium" : "Low";
+              openIssues > 10
+                ? 'Very High'
+                : openIssues > 5
+                  ? 'High'
+                  : openIssues > 2
+                    ? 'Medium'
+                    : 'Low'
             return {
               id: p.id,
               rank: idx + 1,
               name: repoName,
               logo: getProjectIcon(p.github_full_name),
               score: contributors,
-              trend: "same" as const,
+              trend: 'same' as const,
               trendValue: 0,
               contributors,
               ecosystems: p.ecosystem_name ? [p.ecosystem_name] : [],
               activity,
-            };
-          });
-        setProjectsData(mapped);
+            }
+          })
+        setProjectsData(mapped)
       } catch (err) {
-        if (!cancelled) setProjectsData([]);
+        logger.error('Failed to fetch recommended projects:', err)
+        if (!cancelled) {
+          setProjectsData([])
+          // Surface a generic error state (with retry) rather than a blank table.
+          setProjectsError(PROJECTS_ERROR)
+        }
       } finally {
-        if (!cancelled) setIsLoadingProjects(false);
+        if (!cancelled) setIsLoadingProjects(false)
       }
-    };
-    fetchProjects();
+    }
+    fetchProjects()
     return () => {
-      cancelled = true;
-    };
-  }, [leaderboardType]);
+      cancelled = true
+    }
+  }, [leaderboardType, projectsRetry])
 
   /**
    * Append the next page of contributors to the leaderboard.
@@ -164,38 +191,38 @@ export function LeaderboardPage() {
    * being sent to the API.
    */
   const loadMore = async () => {
-    if (loadingMoreRef.current || isLoadingMore || !hasMore) return;
+    if (loadingMoreRef.current || isLoadingMore || !hasMore) return
 
-    loadingMoreRef.current = true;
-    setIsLoadingMore(true);
-    const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
-    const nextOffset = clampOffset(offset + limit);
+    loadingMoreRef.current = true
+    setIsLoadingMore(true)
+    const limit = clampLimit(LEADERBOARD_PAGE_SIZE)
+    const nextOffset = clampOffset(offset + limit)
     try {
       const data = await getLeaderboard(
         limit,
         nextOffset,
-        selectedEcosystem.value !== "all" ? selectedEcosystem.value : undefined,
-      );
+        selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined
+      )
 
       if (data.length > 0) {
-        setLeaderboardData((prev) => [...prev, ...data.map(transformLeader)]);
-        setOffset(nextOffset);
+        setLeaderboardData((prev) => [...prev, ...data.map(transformLeader)])
+        setOffset(nextOffset)
       }
       // Disable "Load more" once a short/empty page signals the end of list.
-      setHasMore(hasMoreByPageSize(data.length, limit));
+      setHasMore(hasMoreByPageSize(data.length, limit))
     } catch (err) {
-      logger.error("Failed to load more leaderboard:", err);
-      setHasMore(false);
+      logger.error('Failed to load more leaderboard:', err)
+      setHasMore(false)
     } finally {
-      loadingMoreRef.current = false;
-      setIsLoadingMore(false);
+      loadingMoreRef.current = false
+      setIsLoadingMore(false)
     }
-  };
+  }
 
   // Generate falling petals on mount
   useEffect(() => {
     const generatePetals = () => {
-      const newPetals: Petal[] = [];
+      const newPetals: Petal[] = []
       for (let i = 0; i < 30; i++) {
         newPetals.push({
           id: i,
@@ -204,18 +231,18 @@ export function LeaderboardPage() {
           duration: 8 + Math.random() * 6,
           rotation: Math.random() * 360,
           size: 0.6 + Math.random() * 0.8,
-        });
+        })
       }
-      setPetals(newPetals);
-    };
+      setPetals(newPetals)
+    }
 
-    generatePetals();
-    setTimeout(() => setIsLoaded(true), 100);
+    generatePetals()
+    setTimeout(() => setIsLoaded(true), 100)
 
     // Regenerate petals every 15 seconds for continuous effect
-    const interval = setInterval(generatePetals, 15000);
-    return () => clearInterval(interval);
-  }, []);
+    const interval = setInterval(generatePetals, 15000)
+    return () => clearInterval(interval)
+  }, [])
 
   // Ensure we have at least 3 items for the podium (pad with empty data if needed)
   const contributorTopThree: LeaderData[] = [
@@ -224,15 +251,15 @@ export function LeaderboardPage() {
       .fill(null)
       .map((_, i) => ({
         rank: leaderboardData.length + i + 1,
-        username: "-",
-        avatar: "👤",
+        username: '-',
+        avatar: '👤',
         score: 0,
-        trend: "same" as const,
+        trend: 'same' as const,
         trendValue: 0,
         contributions: 0,
         ecosystems: [],
       })),
-  ].slice(0, 3) as LeaderData[];
+  ].slice(0, 3) as LeaderData[]
 
   const projectTopThree: ProjectData[] = [
     ...projectsData.slice(0, 3),
@@ -240,16 +267,16 @@ export function LeaderboardPage() {
       .fill(null)
       .map((_, i) => ({
         rank: projectsData.length + i + 1,
-        name: "-",
-        logo: "📦",
+        name: '-',
+        logo: '📦',
         score: 0,
-        trend: "same" as const,
+        trend: 'same' as const,
         trendValue: 0,
         contributors: 0,
         ecosystems: [] as string[],
-        activity: "Low",
+        activity: 'Low',
       })),
-  ].slice(0, 3) as ProjectData[];
+  ].slice(0, 3) as ProjectData[]
 
   return (
     <div className="space-y-6 relative">
@@ -266,41 +293,33 @@ export function LeaderboardPage() {
       {/* Hero Header Section */}
       <LeaderboardHero leaderboardType={leaderboardType} isLoaded={isLoaded}>
         {/* Top 3 Podium - Contributors */}
-        {leaderboardType === "contributors" && isLoading && (
-          <ContributorsPodiumSkeleton />
+        {leaderboardType === 'contributors' && isLoading && <ContributorsPodiumSkeleton />}
+        {leaderboardType === 'contributors' && !isLoading && leaderboardData.length > 0 && (
+          <ContributorsPodium
+            topThree={contributorTopThree}
+            isLoaded={isLoaded}
+            actualCount={leaderboardData.length}
+          />
         )}
-        {leaderboardType === "contributors" &&
-          !isLoading &&
-          leaderboardData.length > 0 && (
-            <ContributorsPodium
-              topThree={contributorTopThree}
-              isLoaded={isLoaded}
-              actualCount={leaderboardData.length}
-            />
-          )}
-        {leaderboardType === "contributors" &&
-          !isLoading &&
-          leaderboardData.length === 0 && (
-            <div
-              className={`text-center py-8 transition-colors ${
-                theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
-              }`}
-            >
-              No contributors yet. Be the first to contribute!
-            </div>
-          )}
-
-        {/* Top 3 Podium - Projects */}
-        {leaderboardType === "projects" && isLoadingProjects && (
-          <ContributorsPodiumSkeleton />
-        )}
-        {leaderboardType === "projects" && !isLoadingProjects && projectsData.length > 0 && (
-          <ProjectsPodium topThree={projectTopThree} isLoaded={isLoaded} />
-        )}
-        {leaderboardType === "projects" && !isLoadingProjects && projectsData.length === 0 && (
+        {leaderboardType === 'contributors' && !isLoading && leaderboardData.length === 0 && (
           <div
             className={`text-center py-8 transition-colors ${
-              theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+            }`}
+          >
+            No contributors yet. Be the first to contribute!
+          </div>
+        )}
+
+        {/* Top 3 Podium - Projects */}
+        {leaderboardType === 'projects' && isLoadingProjects && <ContributorsPodiumSkeleton />}
+        {leaderboardType === 'projects' && !isLoadingProjects && projectsData.length > 0 && (
+          <ProjectsPodium topThree={projectTopThree} isLoaded={isLoaded} />
+        )}
+        {leaderboardType === 'projects' && !isLoadingProjects && projectsData.length === 0 && (
+          <div
+            className={`text-center py-8 transition-colors ${
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
             }`}
           >
             No projects yet. Complete project setup to appear here.
@@ -314,17 +333,15 @@ export function LeaderboardPage() {
         onFilterChange={setActiveFilter}
         selectedEcosystem={selectedEcosystem}
         onEcosystemChange={(ecosystem) => {
-          setSelectedEcosystem(ecosystem);
+          setSelectedEcosystem(ecosystem)
         }}
         showDropdown={showEcosystemDropdown}
-        onToggleDropdown={() =>
-          setShowEcosystemDropdown(!showEcosystemDropdown)
-        }
+        onToggleDropdown={() => setShowEcosystemDropdown(!showEcosystemDropdown)}
         isLoaded={isLoaded}
       />
 
       {/* Leaderboard Table - Contributors */}
-      {leaderboardType === "contributors" && (
+      {leaderboardType === 'contributors' && (
         <>
           {isLoading ? (
             <ContributorsTableSkeleton />
@@ -334,10 +351,12 @@ export function LeaderboardPage() {
                 data={leaderboardData}
                 activeFilter={activeFilter}
                 isLoaded={isLoaded}
+                error={leaderboardError}
+                onRetry={() => setContributorsRetry((n) => n + 1)}
                 onUserClick={(username, userId) => {
                   // Navigate to profile page with user identifier
-                  const identifier = userId || username;
-                  window.location.href = `/dashboard?tab=profile&user=${identifier}`;
+                  const identifier = userId || username
+                  window.location.href = `/dashboard?tab=profile&user=${identifier}`
                 }}
               />
               <div className="flex justify-center mt-6">
@@ -353,14 +372,14 @@ export function LeaderboardPage() {
                         Loading...
                       </>
                     ) : (
-                      "Load more"
+                      'Load more'
                     )}
                   </button>
                 ) : (
                   leaderboardData.length > 0 && (
                     <p
                       className={`text-[13px] font-medium transition-colors ${
-                        theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
+                        theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
                       }`}
                     >
                       You&apos;ve reached the end of the leaderboard.
@@ -374,7 +393,7 @@ export function LeaderboardPage() {
       )}
 
       {/* Leaderboard Table - Projects */}
-      {leaderboardType === "projects" && (
+      {leaderboardType === 'projects' && (
         <>
           {isLoadingProjects ? (
             <ContributorsTableSkeleton />
@@ -383,6 +402,8 @@ export function LeaderboardPage() {
               data={projectsData}
               activeFilter={activeFilter}
               isLoaded={isLoaded}
+              error={projectsError}
+              onRetry={() => setProjectsRetry((n) => n + 1)}
             />
           )}
         </>
@@ -391,5 +412,5 @@ export function LeaderboardPage() {
       {/* CSS Animations */}
       <LeaderboardStyles />
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
Adds accessible empty and error states to the leaderboard ContributorsTable and ProjectsTable. Previously, when the leaderboard API returned nothing or failed, the tables rendered blank with no explanation or way to recover.

## Changes
- New shared `LeaderboardTableState` component rendering the empty and error states.
- Empty state ("No contributors yet" / "No projects yet") announced via a polite `aria-live` region (`role="status"`).
- Error state with a "Try again" button announced via an assertive `aria-live` region (`role="alert"`); retry is wired to the data source through the page.
- LeaderboardPage tracks per-table error state, surfaces only generic copy, and re-fetches on retry. Existing loading skeletons are retained.
- Added RTL tests covering the empty, error, and retry-success states for both tables and the page wiring.

## Security
Error copy shown to users is generic and contains no stack traces, HTTP details, or backend messages; the underlying error is sent only to the logger. Tests assert that raw error details (e.g. connection strings) never reach the DOM.

## Tests
- Test Files: 4 passed (4)
- Tests: 35 passed (35)

closes #41
