### PR TITLE
test: cover DataState state branches

### DIFF
--- a/src/shared/components/DataState.test.tsx
+++ b/src/shared/components/DataState.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DataState } from './DataState'
+
+function renderDataState(props: Partial<React.ComponentProps<typeof DataState>> = {}) {
+  return render(
+    <DataState isLoading={false} isEmpty={false} hasError={false} {...props}>
+      <section>Loaded content</section>
+    </DataState>
+  )
+}
+
+describe('DataState', () => {
+  it('renders the loading branch as a status region', () => {
+    const { container } = renderDataState({
+      isLoading: true,
+      hasError: true,
+      isEmpty: true,
+      error: new Error('500 internal detail'),
+    })
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(container.querySelector('.glass-loader')).toBeInTheDocument()
+    expect(screen.queryByText('Loaded content')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Something went wrong/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a friendly error message and calls retry when available', () => {
+    const onRetry = vi.fn()
+    renderDataState({
+      hasError: true,
+      error: new Error('Failed to fetch /internal/projects'),
+      onRetry,
+    })
+
+    expect(
+      screen.getByText(
+        'Unable to connect to the server. Please check your internet connection and try again.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText('/internal/projects')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('omits the retry button when an error has no retry handler', () => {
+    renderDataState({
+      hasError: true,
+      error: new Error('Timeout'),
+    })
+
+    expect(screen.getByText('The request took too long. Please try again.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+  })
+
+  it('renders the default empty message', () => {
+    renderDataState({ isEmpty: true })
+
+    expect(screen.getByText('No data available.')).toBeInTheDocument()
+    expect(screen.queryByText('Loaded content')).not.toBeInTheDocument()
+  })
+
+  it('renders a custom empty message', () => {
+    renderDataState({
+      isEmpty: true,
+      emptyMessage: 'No projects matched this filter.',
+    })
+
+    expect(screen.getByText('No projects matched this filter.')).toBeInTheDocument()
+    expect(screen.queryByText('No data available.')).not.toBeInTheDocument()
+  })
+
+  it('renders children for the content branch', () => {
+    renderDataState()
+
+    expect(screen.getByText('Loaded content')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByText('No data available.')).not.toBeInTheDocument()
+  })
+})

--- a/src/shared/components/DataState.tsx
+++ b/src/shared/components/DataState.tsx
@@ -1,21 +1,23 @@
-import React, { ReactNode } from 'react';
-import { getUserFriendlyError } from '../utils/errorHandler';
-import './DataState.css';
+import React, { ReactNode } from 'react'
+import { getUserFriendlyError } from '../utils/errorHandler'
+import './DataState.css'
 
 interface DataStateProps {
-  isLoading: boolean;
-  isEmpty: boolean;
-  hasError: boolean;
-  error?: any;
-  onRetry?: () => void;
-  emptyMessage?: string;
-  children?: ReactNode;
+  isLoading: boolean
+  isEmpty: boolean
+  hasError: boolean
+  error?: unknown
+  onRetry?: () => void
+  emptyMessage?: string
+  children?: ReactNode
 }
 
 /**
- * DataState component renders appropriate UI based on loading, empty, and error states.
- * It expects the parent to provide the state flags from useOptimisticData or similar hook.
- * When data is present (not loading, not empty, no error) it simply renders its children.
+ * Renders the canonical loading, error, empty, or content branch for shared data views.
+ *
+ * Parents provide derived state from `useOptimisticData` or similar hooks. Loading
+ * takes precedence over error and empty states, and successful data simply renders
+ * the supplied children without wrapping markup.
  */
 export const DataState: React.FC<DataStateProps> = ({
   isLoading,
@@ -31,7 +33,7 @@ export const DataState: React.FC<DataStateProps> = ({
       <div className="data-state data-state--loading" role="status">
         <div className="glass-loader" />
       </div>
-    );
+    )
   }
 
   if (hasError) {
@@ -44,7 +46,7 @@ export const DataState: React.FC<DataStateProps> = ({
           </button>
         )}
       </div>
-    );
+    )
   }
 
   if (isEmpty) {
@@ -52,8 +54,8 @@ export const DataState: React.FC<DataStateProps> = ({
       <div className="data-state data-state--empty">
         <p className="empty-message">{emptyMessage}</p>
       </div>
-    );
+    )
   }
 
-  return <>{children}</>;
-};
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Add focused tests for `DataState` loading, error, empty, and content rendering branches.
- Assert retry callback behavior and the no-handler error branch.
- Cover default and custom empty messages, plus loading-state precedence over error/empty flags.
- Tighten the component `error` prop from `any` to `unknown` and document the branch ordering contract.

Closes #176

## Validation
- `npx vitest run src/shared/components/DataState.test.tsx` (1 file, 6 tests passed)
- `npx eslint src/shared/components/DataState.tsx src/shared/components/DataState.test.tsx`
- `npx prettier --check src/shared/components/DataState.tsx src/shared/components/DataState.test.tsx`
- `npm run build`
- `git diff --check`

## Notes
- `npm run typecheck` currently fails outside this change in `src/shared/components/SearchModal.tsx` and `src/shared/utils/focusTrap.ts` due existing `RefObject<... | null>` vs `RefObject<...>` errors.
- `npm test` currently fails outside this change in existing suites including `src/shared/api/client.test.ts`, `src/features/blog/pages/BlogPage.test.tsx`, `src/shared/contexts/AuthContext.test.tsx`, and `src/features/maintainers/components/dashboard/ActivityItem.test.tsx`. The new `DataState` test file passes in isolation.

## Security notes
- Test-only UI state coverage.
- The error branch asserts user-friendly error rendering so raw internal fetch details are not displayed.