### PR TITLE
fix(hooks): robust optimistic data retry and empty detection

### DIFF
--- a/src/shared/hooks/useOptimisticData.test.ts
+++ b/src/shared/hooks/useOptimisticData.test.ts
@@ -1,228 +1,357 @@
 // @vitest-environment jsdom
-import { renderHook, act } from '@testing-library/react';
-import { useOptimisticData } from './useOptimisticData';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react'
+import { useOptimisticData } from './useOptimisticData'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 describe('useOptimisticData', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-  });
+    vi.useFakeTimers()
+  })
 
   afterEach(() => {
-    vi.useRealTimers();
-  });
+    vi.useRealTimers()
+  })
 
   it('should return initial data', () => {
-    const { result } = renderHook(() => useOptimisticData('initial'));
-    expect(result.current.data).toBe('initial');
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.hasError).toBe(false);
-  });
+    const { result } = renderHook(() => useOptimisticData('initial'))
+    expect(result.current.data).toBe('initial')
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.hasError).toBe(false)
+  })
 
   it('should fetch data successfully', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial'));
-    
-    const fetchFn = vi.fn().mockResolvedValue('fetched data');
-    
-    await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+    const { result } = renderHook(() => useOptimisticData('initial'))
 
-    expect(result.current.data).toBe('fetched data');
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.hasError).toBe(false);
-  });
+    const fetchFn = vi.fn().mockResolvedValue('fetched data')
+
+    await act(async () => {
+      await result.current.fetchData(fetchFn)
+    })
+
+    expect(result.current.data).toBe('fetched data')
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.hasError).toBe(false)
+  })
 
   it('should ignore aborted requests due to component unmount', async () => {
-    const { result, unmount } = renderHook(() => useOptimisticData('initial'));
-    
-    let providedSignal: AbortSignal | undefined;
+    const { result, unmount } = renderHook(() => useOptimisticData('initial'))
+
+    let providedSignal: AbortSignal | undefined
     const fetchFn = vi.fn().mockImplementation((signal: AbortSignal) => {
-      providedSignal = signal;
-      return new Promise(resolve => setTimeout(() => resolve('fetched'), 100));
-    });
+      providedSignal = signal
+      return new Promise((resolve) => setTimeout(() => resolve('fetched'), 100))
+    })
 
     act(() => {
-      result.current.fetchData(fetchFn);
-    });
+      result.current.fetchData(fetchFn)
+    })
 
-    expect(providedSignal).toBeDefined();
-    expect(providedSignal!.aborted).toBe(false);
+    expect(providedSignal).toBeDefined()
+    expect(providedSignal!.aborted).toBe(false)
 
-    unmount();
+    unmount()
 
-    expect(providedSignal!.aborted).toBe(true);
-  });
+    expect(providedSignal!.aborted).toBe(true)
+  })
 
   it('should simulate two rapid fetchData calls with different keys where first resolves last, asserting only the second applies', async () => {
     const { result, rerender } = renderHook(
       ({ cacheKey }) => useOptimisticData('initial', { cacheKey }),
       { initialProps: { cacheKey: 'key1' } }
-    );
+    )
 
-    let resolve1: (val: string) => void;
-    const promise1 = new Promise<string>(resolve => { resolve1 = resolve; });
-    const fetchFn1 = vi.fn().mockReturnValue(promise1);
-
-    act(() => {
-      result.current.fetchData(fetchFn1);
-    });
-
-    rerender({ cacheKey: 'key2' });
-
-    let resolve2: (val: string) => void;
-    const promise2 = new Promise<string>(resolve => { resolve2 = resolve; });
-    const fetchFn2 = vi.fn().mockReturnValue(promise2);
+    let resolve1: (val: string) => void
+    const promise1 = new Promise<string>((resolve) => {
+      resolve1 = resolve
+    })
+    const fetchFn1 = vi.fn().mockReturnValue(promise1)
 
     act(() => {
-      result.current.fetchData(fetchFn2);
-    });
+      result.current.fetchData(fetchFn1)
+    })
+
+    rerender({ cacheKey: 'key2' })
+
+    let resolve2: (val: string) => void
+    const promise2 = new Promise<string>((resolve) => {
+      resolve2 = resolve
+    })
+    const fetchFn2 = vi.fn().mockReturnValue(promise2)
+
+    act(() => {
+      result.current.fetchData(fetchFn2)
+    })
 
     // second resolves first
     await act(async () => {
-      resolve2!('data2');
-      await promise2;
-    });
+      resolve2!('data2')
+      await promise2
+    })
 
-    expect(result.current.data).toBe('data2');
+    expect(result.current.data).toBe('data2')
 
     // first resolves last
     await act(async () => {
-      resolve1!('data1');
-      await promise1;
-    });
+      resolve1!('data1')
+      await promise1
+    })
 
     // Result should still be data2 because promise1 was superseded
-    expect(result.current.data).toBe('data2');
-  });
+    expect(result.current.data).toBe('data2')
+  })
 
   it('should return cached data per key', async () => {
     const { result, rerender } = renderHook(
       ({ cacheKey }) => useOptimisticData('initial', { cacheKey, cacheDuration: 5000 }),
       { initialProps: { cacheKey: 'key1' } }
-    );
+    )
 
-    const fetchFn1 = vi.fn().mockResolvedValue('data1');
+    const fetchFn1 = vi.fn().mockResolvedValue('data1')
     await act(async () => {
-      await result.current.fetchData(fetchFn1);
-    });
+      await result.current.fetchData(fetchFn1)
+    })
 
-    expect(result.current.data).toBe('data1');
-    expect(fetchFn1).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toBe('data1')
+    expect(fetchFn1).toHaveBeenCalledTimes(1)
 
     // Re-fetch key1 -> should use cache
     await act(async () => {
-      await result.current.fetchData(fetchFn1);
-    });
-    expect(fetchFn1).toHaveBeenCalledTimes(1); // not called again
+      await result.current.fetchData(fetchFn1)
+    })
+    expect(fetchFn1).toHaveBeenCalledTimes(1) // not called again
 
     // Switch to key2 -> should fetch
-    rerender({ cacheKey: 'key2' });
-    const fetchFn2 = vi.fn().mockResolvedValue('data2');
+    rerender({ cacheKey: 'key2' })
+    const fetchFn2 = vi.fn().mockResolvedValue('data2')
     await act(async () => {
-      await result.current.fetchData(fetchFn2);
-    });
-    expect(result.current.data).toBe('data2');
-    expect(fetchFn2).toHaveBeenCalledTimes(1);
+      await result.current.fetchData(fetchFn2)
+    })
+    expect(result.current.data).toBe('data2')
+    expect(fetchFn2).toHaveBeenCalledTimes(1)
 
     // Switch back to key1 -> should use cache
-    rerender({ cacheKey: 'key1' });
-    const fetchFn3 = vi.fn().mockResolvedValue('data3');
+    rerender({ cacheKey: 'key1' })
+    const fetchFn3 = vi.fn().mockResolvedValue('data3')
     await act(async () => {
-      await result.current.fetchData(fetchFn3);
-    });
-    expect(result.current.data).toBe('data1');
-    expect(fetchFn3).not.toHaveBeenCalled();
-  });
+      await result.current.fetchData(fetchFn3)
+    })
+    expect(result.current.data).toBe('data1')
+    expect(fetchFn3).not.toHaveBeenCalled()
+  })
 
   it('should force refresh bypasses cache', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial', { cacheDuration: 5000 }));
+    const { result } = renderHook(() => useOptimisticData('initial', { cacheDuration: 5000 }))
 
-    const fetchFn1 = vi.fn().mockResolvedValue('data1');
+    const fetchFn1 = vi.fn().mockResolvedValue('data1')
     await act(async () => {
-      await result.current.fetchData(fetchFn1);
-    });
+      await result.current.fetchData(fetchFn1)
+    })
 
-    expect(result.current.data).toBe('data1');
+    expect(result.current.data).toBe('data1')
 
-    const fetchFn2 = vi.fn().mockResolvedValue('data2');
+    const fetchFn2 = vi.fn().mockResolvedValue('data2')
     await act(async () => {
       // call with forceRefresh = true
-      await result.current.fetchData(fetchFn2, true);
-    });
+      await result.current.fetchData(fetchFn2, true)
+    })
 
-    expect(result.current.data).toBe('data2');
-    expect(fetchFn2).toHaveBeenCalledTimes(1);
-  });
-  
+    expect(result.current.data).toBe('data2')
+    expect(fetchFn2).toHaveBeenCalledTimes(1)
+  })
+
   it('swallows AbortError and does not treat it as a real failure', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial'));
-    
+    const { result } = renderHook(() => useOptimisticData('initial'))
+
     const fetchFn = vi.fn().mockImplementation(() => {
       return new Promise((_resolve, reject) => {
-        const error = new Error('The user aborted a request.');
-        error.name = 'AbortError';
-        reject(error);
-      });
-    });
+        const error = new Error('The user aborted a request.')
+        error.name = 'AbortError'
+        reject(error)
+      })
+    })
 
     await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+      await result.current.fetchData(fetchFn)
+    })
 
-    expect(result.current.hasError).toBe(false);
-  });
+    expect(result.current.hasError).toBe(false)
+  })
 
   it('sets error state correctly for network errors', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial'));
-    
-    // Suppress console.error in tests to avoid noisy output
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useOptimisticData('initial'))
 
-    const fetchFn = vi.fn().mockRejectedValue(new TypeError('Network Error'));
+    // Suppress console.error in tests to avoid noisy output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError('Network Error'))
 
     await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+      await result.current.fetchData(fetchFn)
+    })
 
-    expect(result.current.hasError).toBe(true);
-    
-    consoleSpy.mockRestore();
-  });
+    expect(result.current.hasError).toBe(true)
+
+    consoleSpy.mockRestore()
+  })
 
   it('sets error state correctly for non-network errors', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial'));
-    
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useOptimisticData('initial'))
 
-    const fetchFn = vi.fn().mockRejectedValue(new Error('Unknown backend crash'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const fetchFn = vi.fn().mockRejectedValue(new Error('Unknown backend crash'))
 
     await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+      await result.current.fetchData(fetchFn)
+    })
 
-    expect(result.current.hasError).toBe(true);
-    expect(result.current.isLoading).toBe(false);
-    
-    consoleSpy.mockRestore();
-  });
+    expect(result.current.hasError).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+
+    consoleSpy.mockRestore()
+  })
 
   it('clears cache successfully', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial', { cacheDuration: 5000 }));
-    const fetchFn = vi.fn().mockResolvedValue('data1');
-    
+    const { result } = renderHook(() => useOptimisticData('initial', { cacheDuration: 5000 }))
+    const fetchFn = vi.fn().mockResolvedValue('data1')
+
     await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+      await result.current.fetchData(fetchFn)
+    })
 
     act(() => {
-      result.current.clearCache();
-    });
+      result.current.clearCache()
+    })
 
     await act(async () => {
-      await result.current.fetchData(fetchFn);
-    });
+      await result.current.fetchData(fetchFn)
+    })
 
-    expect(fetchFn).toHaveBeenCalledTimes(2);
-  });
-});
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    { value: [], expected: true, label: 'empty array' },
+    { value: ['item'], expected: false, label: 'populated array' },
+    { value: '', expected: true, label: 'empty string' },
+    { value: 'value', expected: false, label: 'populated string' },
+    { value: { count: undefined }, expected: true, label: 'object with only undefined' },
+    { value: { count: null }, expected: true, label: 'object with only null' },
+    { value: { count: 0 }, expected: false, label: 'object with numeric value' },
+    { value: new Date('2026-01-01T00:00:00.000Z'), expected: false, label: 'date object' },
+    { value: 0, expected: false, label: 'number primitive' },
+    { value: false, expected: false, label: 'boolean primitive' },
+  ])('detects empty state for $label', ({ value, expected }) => {
+    const { result } = renderHook(() => useOptimisticData<unknown>(value))
+
+    expect(result.current.isEmpty).toBe(expected)
+  })
+
+  it('treats circular objects as non-empty instead of recursing forever', () => {
+    const circular: { self?: unknown } = {}
+    circular.self = circular
+
+    const { result } = renderHook(() => useOptimisticData<unknown>(circular))
+
+    expect(result.current.isEmpty).toBe(false)
+  })
+
+  it('allows callers to customize empty detection', async () => {
+    const { result } = renderHook(() =>
+      useOptimisticData('initial', {
+        isEmpty: (value) => value === 'none',
+      })
+    )
+
+    const fetchFn = vi.fn().mockResolvedValue('none')
+
+    await act(async () => {
+      await result.current.fetchData(fetchFn)
+    })
+
+    expect(result.current.data).toBe('none')
+    expect(result.current.isEmpty).toBe(true)
+  })
+
+  it('sets loading when fetching with empty initial data', async () => {
+    const { result } = renderHook(() => useOptimisticData<string[]>([]))
+    let resolveFetch!: (value: string[]) => void
+    const pendingFetch = new Promise<string[]>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchFn = vi.fn().mockReturnValue(pendingFetch)
+
+    act(() => {
+      void result.current.fetchData(fetchFn)
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      resolveFetch(['loaded'])
+      await pendingFetch
+    })
+
+    expect(result.current.data).toEqual(['loaded'])
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('ignores retry before any fetch function has been registered', () => {
+    const { result } = renderHook(() => useOptimisticData('initial'))
+
+    act(() => {
+      result.current.retry()
+    })
+
+    expect(result.current.data).toBe('initial')
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it('retries with the latest fetch function', async () => {
+    const { result } = renderHook(() => useOptimisticData('initial'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const staleFetchFn = vi.fn().mockRejectedValue(new Error('stale request failed'))
+    await act(async () => {
+      await result.current.fetchData(staleFetchFn)
+    })
+
+    const latestFetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('latest request failed'))
+      .mockResolvedValueOnce('latest data')
+
+    await act(async () => {
+      await result.current.fetchData(latestFetchFn)
+    })
+
+    await act(async () => {
+      result.current.retry()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(staleFetchFn).toHaveBeenCalledTimes(1)
+    expect(latestFetchFn).toHaveBeenCalledTimes(2)
+    expect(result.current.data).toBe('latest data')
+    expect(result.current.hasError).toBe(false)
+
+    consoleSpy.mockRestore()
+  })
+
+  it('keeps fetchData stable after data changes and non-memoized initial data rerenders', async () => {
+    const { result, rerender } = renderHook(({ seed }) => useOptimisticData({ value: seed }), {
+      initialProps: { seed: 'initial' },
+    })
+    const firstFetchData = result.current.fetchData
+
+    await act(async () => {
+      await result.current.fetchData(vi.fn().mockResolvedValue({ value: 'loaded' }))
+    })
+
+    rerender({ seed: 'new-inline-object' })
+
+    expect(result.current.data).toEqual({ value: 'loaded' })
+    expect(result.current.fetchData).toBe(firstFetchData)
+  })
+})

--- a/src/shared/hooks/useOptimisticData.ts
+++ b/src/shared/hooks/useOptimisticData.ts
@@ -1,143 +1,189 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { logger } from '../../shared/utils/logger';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
+import { logger } from '../../shared/utils/logger'
+
+const MAX_RETRIES = 5
 
 /** Cache entry for optimistic data */
 interface CacheEntry<T> {
-  data: T;
-  timestamp: number;
+  data: T
+  timestamp: number
 }
 
 /** Options for the hook */
-interface UseOptimisticDataOptions {
+interface UseOptimisticDataOptions<T> {
   /** Cache duration in ms, default 30000 */
-  cacheDuration?: number;
+  cacheDuration?: number
   /** Cache key for shared caching */
-  cacheKey?: string;
+  cacheKey?: string
+  /** Custom empty-state predicate for domain-specific data shapes */
+  isEmpty?: (data: T) => boolean
 }
 
 /** Return type of the hook */
 export interface UseOptimisticDataReturn<T> {
   /** Current data */
-  data: T;
+  data: T
   /** Loading state */
-  isLoading: boolean;
+  isLoading: boolean
   /** Whether an error occurred */
-  hasError: boolean;
+  hasError: boolean
   /** Raw error object (if any) */
-  error: any;
+  error: unknown
   /** Retry the last fetch (max 5 attempts) */
-  retry: () => void;
-  /** Whether the data is empty (array/object) */
-  isEmpty: boolean;
+  retry: () => void
+  /** Whether the data is empty */
+  isEmpty: boolean
   /** Function to manually fetch data */
-  fetchData: (
-    fetchFn: (signal: AbortSignal) => Promise<T>,
-    forceRefresh?: boolean
-  ) => Promise<void>;
+  fetchData: (fetchFn: (signal: AbortSignal) => Promise<T>, forceRefresh?: boolean) => Promise<void>
   /** Clear cached data */
-  clearCache: () => void;
+  clearCache: () => void
+}
+
+/**
+ * Default empty-state predicate for arrays, objects, and primitive values.
+ *
+ * Objects with only nullish or otherwise empty values are treated as empty, so
+ * `{ value: undefined }` does not accidentally count as populated data.
+ */
+function defaultIsEmptyValue(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (value == null) return true
+  if (typeof value === 'string') return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+
+  if (typeof value === 'object') {
+    if (value instanceof Date) return false
+    if (seen.has(value)) return false
+
+    seen.add(value)
+    const values = Object.values(value as Record<string, unknown>)
+    return values.length === 0 || values.every((item) => defaultIsEmptyValue(item, seen))
+  }
+
+  return false
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'AbortError'
+  )
 }
 
 /**
  * Optimistic data hook with caching, abort support, retry and empty‑state handling.
  *
  * @param initialData – The initial value displayed before any fetch.
- * @param options – Configuration of cache duration and cache key.
+ * @param options – Configuration of cache duration, cache key, and empty-state detection.
  */
 export function useOptimisticData<T>(
   initialData: T,
-  options: UseOptimisticDataOptions = {}
+  options: UseOptimisticDataOptions<T> = {}
 ): UseOptimisticDataReturn<T> {
-  const { cacheDuration = 30000, cacheKey = 'default' } = options;
+  const { cacheDuration = 30000, cacheKey = 'default', isEmpty: isEmptyOption } = options
 
-  const [data, setData] = useState<T>(initialData);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [hasError, setHasError] = useState<boolean>(false);
-  const [error, setError] = useState<any>(null);
-  const [retryCount, setRetryCount] = useState<number>(0);
-  const MAX_RETRIES = 5;
+  const [data, setData] = useState<T>(initialData)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [hasError, setHasError] = useState<boolean>(false)
+  const [error, setError] = useState<unknown>(null)
 
-  const cacheRef = useRef<Map<string, CacheEntry<T>>>(new Map());
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const lastFetchFnRef = useRef<((signal: AbortSignal) => Promise<T>) | null>(null);
+  const cacheRef = useRef<Map<string, CacheEntry<T>>>(new Map())
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const lastFetchFnRef = useRef<((signal: AbortSignal) => Promise<T>) | null>(null)
+  const dataRef = useRef<T>(initialData)
+  const retryCountRef = useRef<number>(0)
+  const emptyPredicate = isEmptyOption ?? defaultIsEmptyValue
+  const emptyPredicateRef = useRef<(data: T) => boolean>(emptyPredicate)
+
+  useEffect(() => {
+    dataRef.current = data
+  }, [data])
+
+  useEffect(() => {
+    emptyPredicateRef.current = emptyPredicate
+  }, [emptyPredicate])
+
+  const updateData = useCallback((nextData: T) => {
+    dataRef.current = nextData
+    setData(nextData)
+  }, [])
 
   // Abort any in‑flight request when the component unmounts
   useEffect(() => {
     return () => {
-      abortControllerRef.current?.abort();
-    };
-  }, []);
+      abortControllerRef.current?.abort()
+    }
+  }, [])
 
   const fetchData = useCallback(
     async (fetchFn: (signal: AbortSignal) => Promise<T>, forceRefresh = false) => {
-      const now = Date.now();
-      lastFetchFnRef.current = fetchFn;
+      const now = Date.now()
+      lastFetchFnRef.current = fetchFn
 
       // Cancel any previous request
-      abortControllerRef.current?.abort();
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
-      const signal = controller.signal;
+      abortControllerRef.current?.abort()
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+      const signal = controller.signal
 
       // Serve from cache when possible
-      const cached = cacheRef.current.get(cacheKey);
+      const cached = cacheRef.current.get(cacheKey)
       if (!forceRefresh && cached && now - cached.timestamp < cacheDuration) {
-        setData(cached.data);
-        setIsLoading(false);
-        setHasError(false);
-        setError(null);
-        return;
+        updateData(cached.data)
+        setIsLoading(false)
+        setHasError(false)
+        setError(null)
+        return
       }
 
       // Determine whether we already have data to decide loading state
-      const hasExistingData =
-        data !== initialData ||
-        (Array.isArray(data) && data.length > 0) ||
-        (typeof data === 'object' && data !== null && Object.keys(data as object).length > 0);
+      const hasExistingData = !emptyPredicateRef.current(dataRef.current)
 
       if (!hasExistingData) {
-        setIsLoading(true);
+        setIsLoading(true)
       }
 
-      setHasError(false);
-      setError(null);
+      setHasError(false)
+      setError(null)
 
       try {
-        const result = await fetchFn(signal);
-        if (signal.aborted) return;
-        cacheRef.current.set(cacheKey, { data: result, timestamp: Date.now() });
-        setData(result);
-        setHasError(false);
-        setError(null);
-      } catch (err: any) {
-        if (err?.name === 'AbortError' || signal.aborted) return;
-        logger.error('Failed to fetch data:', err);
-        setHasError(true);
-        setError(err);
+        const result = await fetchFn(signal)
+        if (signal.aborted) return
+        cacheRef.current.set(cacheKey, { data: result, timestamp: Date.now() })
+        updateData(result)
+        setHasError(false)
+        setError(null)
+      } catch (err: unknown) {
+        if (isAbortError(err) || signal.aborted) return
+        logger.error('Failed to fetch data:', err)
+        setHasError(true)
+        setError(err)
       } finally {
-        setIsLoading(false);
-        setRetryCount(0);
+        if (!signal.aborted) {
+          setIsLoading(false)
+          retryCountRef.current = 0
+        }
       }
     },
-    [cacheDuration, cacheKey, data, initialData]
-  );
+    [cacheDuration, cacheKey, updateData]
+  )
 
   const retry = useCallback(() => {
-    if (retryCount < MAX_RETRIES && lastFetchFnRef.current) {
-      setRetryCount((c) => c + 1);
-      fetchData(lastFetchFnRef.current, true);
+    const latestFetchFn = lastFetchFnRef.current
+    if (retryCountRef.current < MAX_RETRIES && latestFetchFn) {
+      retryCountRef.current += 1
+      void fetchData(latestFetchFn, true)
     }
-  }, [retryCount, fetchData]);
+  }, [fetchData])
 
   const clearCache = useCallback(() => {
-    cacheRef.current.clear();
-  }, []);
+    cacheRef.current.clear()
+  }, [])
 
   const isEmpty = useMemo(() => {
-    if (Array.isArray(data)) return data.length === 0;
-    if (typeof data === 'object' && data !== null) return Object.keys(data as object).length === 0;
-    return false;
-  }, [data]);
+    return emptyPredicate(data)
+  }, [data, emptyPredicate])
 
-  return { data, isLoading, hasError, error, retry, isEmpty, fetchData, clearCache };
+  return { data, isLoading, hasError, error, retry, isEmpty, fetchData, clearCache }
 }


### PR DESCRIPTION
## Summary
- Add a configurable `isEmpty` predicate to `useOptimisticData` with a safer default for arrays, primitives, and objects whose values are only nullish/empty.
- Keep the latest fetch function in a ref so manual `retry()` calls the current fetch path instead of a stale one.
- Remove `data`/`initialData` from the `fetchData` callback dependencies by tracking current data in refs, which keeps `fetchData` stable across data updates and non-memoized initial data rerenders.
- Add focused hook tests for empty detection, custom empty predicates, latest retry behavior, abort handling, cache behavior, and callback stability.

Closes #179

## Validation
- `npx vitest run src/shared/hooks/useOptimisticData.test.ts` (1 file, 26 tests passed)
- `npx eslint src/shared/hooks/useOptimisticData.ts src/shared/hooks/useOptimisticData.test.ts`
- `npx prettier --check src/shared/hooks/useOptimisticData.ts src/shared/hooks/useOptimisticData.test.ts`
- `npm run build` (passed; existing chunk-size warning only)
- `git diff --check`

## Coverage
- `npx vitest run src/shared/hooks/useOptimisticData.test.ts --coverage` runs the target test file successfully and reports `src/shared/hooks/useOptimisticData.ts` at 100% statements, 100% branches, 100% functions, and 100% lines.
- The command still exits non-zero because the current repo-wide coverage configuration includes unrelated untested files and existing parse exclusions for `src/imports/FinalButtons.tsx` and `src/app/components/landing/Navbar.tsx`.

## Existing unrelated failures
- `npm run typecheck` currently fails outside this change in `src/shared/components/SearchModal.tsx` and `src/shared/utils/focusTrap.ts` due `RefObject<... | null>` vs `RefObject<...>` typing.
- `npm test` currently fails outside this change in existing suites including `src/shared/api/client.test.ts`, `src/shared/hooks/useLandingStats.test.ts`, `src/features/landing/components/ImageWithFallback.test.tsx`, `src/features/blog/pages/BlogPage.test.tsx`, and `src/features/maintainers/components/dashboard/ActivityItem.test.tsx`.

## Security notes
- No secrets, auth tokens, wallet/payment data, or network endpoints are added.
- Abort errors remain ignored as cancellation, while real fetch errors are stored as `unknown` and logged through the existing guarded logger.
