### PR TITLE
fix(config): validate API env at boot

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,13 @@
+import { createRoot } from 'react-dom/client'
+import App from './app/App.tsx'
+import { validateEnv } from './shared/config/api'
+import { ErrorBoundary } from './shared/components/ErrorBoundary'
+import './styles/index.css'
 
-  import { createRoot } from "react-dom/client";
-  import App from "./app/App.tsx";
-  import { ErrorBoundary } from "./shared/components/ErrorBoundary";
-  import "./styles/index.css";
+validateEnv()
 
-  createRoot(document.getElementById("root")!).render(
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
-  );
-  
+createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+)

--- a/src/shared/config/api.test.ts
+++ b/src/shared/config/api.test.ts
@@ -1,101 +1,168 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 describe('API Configuration', () => {
   beforeEach(() => {
-    vi.resetModules();
-  });
+    vi.resetModules()
+  })
 
   afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
 
   describe('validateEnv', () => {
-    it('throws in dev when VITE_API_BASE_URL is missing', async () => {
-      vi.stubEnv('DEV', true);
-      vi.stubEnv('VITE_API_BASE_URL', '');
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173');
+    it('does not throw at module import time when VITE_API_BASE_URL is missing', async () => {
+      vi.stubEnv('DEV', true)
+      vi.stubEnv('VITE_API_BASE_URL', '')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
 
-      await expect(() => import('./api')).rejects.toThrow(
-        'VITE_API_BASE_URL is not set',
-      );
-    });
+      const mod = await import('./api')
 
-    it('uses fallback default in production when VITE_API_BASE_URL is missing', async () => {
-      vi.stubEnv('DEV', false);
-      vi.stubEnv('VITE_API_BASE_URL', '');
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173');
+      expect(mod.API_BASE_URL).toBe('http://localhost:8080')
+    })
 
-      const mod = await import('./api');
-      expect(mod.API_BASE_URL).toBe('http://localhost:8080');
-    });
-  });
+    it('throws in dev when VITE_API_BASE_URL is missing during explicit validation', async () => {
+      vi.stubEnv('DEV', true)
+      vi.stubEnv('VITE_API_BASE_URL', '')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).toThrow('VITE_API_BASE_URL is not set')
+    })
+
+    it('throws in production when VITE_API_BASE_URL is missing during explicit validation', async () => {
+      vi.stubEnv('DEV', false)
+      vi.stubEnv('PROD', true)
+      vi.stubEnv('VITE_API_BASE_URL', '')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).toThrow('VITE_API_BASE_URL is not set')
+    })
+
+    it('throws when VITE_API_BASE_URL is not an absolute URL', async () => {
+      vi.stubEnv('DEV', false)
+      vi.stubEnv('PROD', true)
+      vi.stubEnv('VITE_API_BASE_URL', 'api.localhost')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).toThrow('VITE_API_BASE_URL must be a valid absolute URL')
+    })
+
+    it('throws when VITE_API_BASE_URL uses a non-http protocol', async () => {
+      vi.stubEnv('DEV', false)
+      vi.stubEnv('PROD', true)
+      vi.stubEnv('VITE_API_BASE_URL', 'ftp://api.example.com')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).toThrow('VITE_API_BASE_URL must use http or https')
+    })
+
+    it('throws when VITE_FRONTEND_BASE_URL is set to an invalid URL', async () => {
+      vi.stubEnv('DEV', false)
+      vi.stubEnv('PROD', true)
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'grainlify.local')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).toThrow('VITE_FRONTEND_BASE_URL must be a valid absolute URL')
+    })
+
+    it('passes when required URLs are valid', async () => {
+      vi.stubEnv('DEV', false)
+      vi.stubEnv('PROD', true)
+      vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://grainlify.example.com')
+
+      const mod = await import('./api')
+
+      expect(() => mod.validateEnv()).not.toThrow()
+    })
+  })
 
   describe('API_BASE_URL', () => {
     it('reads from VITE_API_BASE_URL', async () => {
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com');
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.API_BASE_URL).toBe('http://test-api.com');
-    });
+      const mod = await import('./api')
+      expect(mod.API_BASE_URL).toBe('http://test-api.com')
+    })
 
     it('strips trailing slash', async () => {
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com/');
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com/')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.API_BASE_URL).toBe('http://test-api.com');
-    });
+      const mod = await import('./api')
+      expect(mod.API_BASE_URL).toBe('http://test-api.com')
+    })
 
     it('strips multiple trailing slashes', async () => {
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com///');
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com///')
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'http://localhost:5173')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.API_BASE_URL).toBe('http://test-api.com');
-    });
-  });
+      const mod = await import('./api')
+      expect(mod.API_BASE_URL).toBe('http://test-api.com')
+    })
+  })
 
   describe('FRONTEND_BASE_URL', () => {
     it('reads from VITE_FRONTEND_BASE_URL when set', async () => {
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com');
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com')
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.FRONTEND_BASE_URL).toBe('https://myapp.com');
-    });
+      const mod = await import('./api')
+      expect(mod.FRONTEND_BASE_URL).toBe('https://myapp.com')
+    })
 
     it('defaults to window.location.origin when not set', async () => {
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', '');
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', '')
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.FRONTEND_BASE_URL).toBe(window.location.origin);
-    });
+      const mod = await import('./api')
+      expect(mod.FRONTEND_BASE_URL).toBe(window.location.origin)
+    })
+
+    it('uses a safe fallback when window is unavailable', async () => {
+      vi.stubGlobal('window', undefined)
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', '')
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('DEV', false)
+
+      const mod = await import('./api')
+      expect(mod.FRONTEND_BASE_URL).toBe('http://localhost:5173')
+    })
 
     it('strips trailing slash from FRONTEND_BASE_URL', async () => {
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com/');
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com/')
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.FRONTEND_BASE_URL).toBe('https://myapp.com');
-    });
-  });
+      const mod = await import('./api')
+      expect(mod.FRONTEND_BASE_URL).toBe('https://myapp.com')
+    })
+  })
 
   describe('OAUTH_CALLBACK_URL', () => {
     it('constructs callback URL from FRONTEND_BASE_URL', async () => {
-      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com');
-      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com');
-      vi.stubEnv('DEV', false);
+      vi.stubEnv('VITE_FRONTEND_BASE_URL', 'https://myapp.com')
+      vi.stubEnv('VITE_API_BASE_URL', 'http://test-api.com')
+      vi.stubEnv('DEV', false)
 
-      const mod = await import('./api');
-      expect(mod.OAUTH_CALLBACK_URL).toBe('https://myapp.com/auth/callback');
-    });
-  });
-});
+      const mod = await import('./api')
+      expect(mod.OAUTH_CALLBACK_URL).toBe('https://myapp.com/auth/callback')
+    })
+  })
+})

--- a/src/shared/config/api.ts
+++ b/src/shared/config/api.ts
@@ -1,70 +1,109 @@
 /**
  * API Configuration
- * 
+ *
  * This module centralizes all API configuration and URLs for the Grainlify frontend.
  * All configuration is driven by environment variables (VITE_* prefix required by Vite).
- * 
+ *
  * **IMPORTANT:** Never hardcode backend URLs directly in API calls. Always import and use
  * `API_BASE_URL` from this file to ensure consistency across the application.
- * 
+ *
  * ## Environment Variables
- * 
+ *
  * Required:
  * - `VITE_API_BASE_URL`: Backend API base URL
  *   - Development: `http://localhost:8080`
  *   - Production: `https://api.grainlify.com` (or your production backend URL)
- * 
+ *
  * Optional:
  * - `VITE_FRONTEND_BASE_URL`: Frontend base URL (defaults to `window.location.origin`)
  *   - Development: `http://localhost:5173`
  *   - Production: `https://grainlify.com`
- * 
+ *
  * ## Usage
- * 
+ *
  * ```typescript
  * import { API_BASE_URL } from '@/shared/config/api';
- * 
+ *
  * // Make API request
  * const response = await fetch(`${API_BASE_URL}/projects`);
  * ```
- * 
+ *
  * ## Security Note
- * 
+ *
  * Environment variables prefixed with `VITE_` are exposed to the browser and should NOT
  * contain sensitive secrets. Backend secrets (OAuth client secrets, admin tokens) must
  * remain server-side only.
- * 
+ *
  * @module shared/config/api
  */
 
 function stripTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, '');
+  return url.replace(/\/+$/, '')
 }
 
-function validateEnv(): void {
-  const { VITE_API_BASE_URL } = import.meta.env;
-  if (!VITE_API_BASE_URL && import.meta.env.DEV) {
-    throw new Error(
-      'VITE_API_BASE_URL is not set. Please add it to your .env file. ' +
-      'See .env.example for reference.',
-    );
+function getBrowserOrigin(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+
+  return 'http://localhost:5173'
+}
+
+function assertHttpUrl(name: string, value: string): void {
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid absolute URL. Received: ${value || '(empty)'}.`)
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error(`${name} must use http or https. Received: ${value}.`)
   }
 }
 
-validateEnv();
+/**
+ * Validates public URL environment variables before the app boots.
+ *
+ * @remarks
+ * This function intentionally runs from the app entrypoint instead of module import,
+ * so config tests and non-browser tooling can import this module safely.
+ *
+ * @example
+ * ```env
+ * VITE_API_BASE_URL=https://api.grainlify.com
+ * VITE_FRONTEND_BASE_URL=https://grainlify.com
+ * ```
+ */
+export function validateEnv(): void {
+  const { VITE_API_BASE_URL, VITE_FRONTEND_BASE_URL } = import.meta.env
+
+  if (!VITE_API_BASE_URL) {
+    throw new Error(
+      'VITE_API_BASE_URL is not set. Please add it to your environment. ' +
+        'See .env.example for reference.'
+    )
+  }
+
+  assertHttpUrl('VITE_API_BASE_URL', VITE_API_BASE_URL)
+
+  if (VITE_FRONTEND_BASE_URL) {
+    assertHttpUrl('VITE_FRONTEND_BASE_URL', VITE_FRONTEND_BASE_URL)
+  }
+}
 
 /**
  * Backend API base URL
- * 
+ *
  * Source of truth for all backend API requests. This value comes from the
  * `VITE_API_BASE_URL` environment variable.
- * 
+ *
  * **Default:** `http://localhost:8080` (for development)
- * 
+ *
  * @example
  * ```typescript
  * import { API_BASE_URL } from '@/shared/config/api';
- * 
+ *
  * // Fetch user profile
  * const response = await fetch(`${API_BASE_URL}/profile`, {
  *   headers: {
@@ -72,61 +111,61 @@ validateEnv();
  *   }
  * });
  * ```
- * 
+ *
  * @constant
  * @type {string}
  */
 export const API_BASE_URL = stripTrailingSlash(
-  import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
-);
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+)
 
 /**
  * Frontend base URL
- * 
+ *
  * Used for constructing OAuth callback URLs and other frontend-specific URLs.
  * Defaults to the current browser origin if not specified.
- * 
+ *
  * **Default:** `window.location.origin`
- * 
+ *
  * @example
  * ```typescript
  * import { FRONTEND_BASE_URL } from '@/shared/config/api';
- * 
+ *
  * // Construct callback URL
  * const callbackUrl = `${FRONTEND_BASE_URL}/auth/callback`;
  * ```
- * 
+ *
  * @constant
  * @type {string}
  */
 export const FRONTEND_BASE_URL = stripTrailingSlash(
-  import.meta.env.VITE_FRONTEND_BASE_URL || window.location.origin,
-);
+  import.meta.env.VITE_FRONTEND_BASE_URL || getBrowserOrigin()
+)
 
 /**
  * OAuth callback URL
- * 
+ *
  * The URL where GitHub OAuth will redirect users after authentication.
  * The backend uses this URL to redirect users back to the frontend with a JWT token.
- * 
+ *
  * The callback page (`/auth/callback`) extracts the token from the URL query parameter
  * and stores it in localStorage under the key `patchwork_jwt`.
- * 
+ *
  * **Format:** `{FRONTEND_BASE_URL}/auth/callback`
- * 
+ *
  * **Security Note:** The JWT is stored in localStorage, which is vulnerable to XSS attacks.
  * For production, consider using httpOnly cookies for enhanced security.
- * 
+ *
  * @example
  * ```typescript
  * import { OAUTH_CALLBACK_URL } from '@/shared/config/api';
- * 
+ *
  * // Backend redirects here after OAuth: /auth/callback?token=<jwt>
  * console.log(OAUTH_CALLBACK_URL); // http://localhost:5173/auth/callback
  * ```
- * 
+ *
  * @constant
  * @type {string}
  * @see {@link AuthCallbackPage} The component that handles this callback
  */
-export const OAUTH_CALLBACK_URL = `${FRONTEND_BASE_URL}/auth/callback`;
+export const OAUTH_CALLBACK_URL = `${FRONTEND_BASE_URL}/auth/callback`


### PR DESCRIPTION
## Summary
- export an explicit `validateEnv()` helper and call it from `src/main.tsx` before the app renders
- validate `VITE_API_BASE_URL` in production as well as development
- reject invalid or non-http(s) API/frontend URL values
- avoid import-time throws so tests and non-browser tooling can import the config safely
- add a safe frontend-origin fallback when `window` is unavailable
- cover the new missing/invalid URL and fallback cases in `api.test.ts`

Closes #181

## Validation
- `npx vitest run src/shared/config/api.test.ts` (15 passed)
- `npx eslint src/shared/config/api.ts src/shared/config/api.test.ts src/main.tsx`
- `npx prettier --check src/shared/config/api.ts src/shared/config/api.test.ts src/main.tsx`
- `npm run build` (passed; existing chunk-size warning only)
- `git diff --check`

## Existing unrelated failures observed
- `npm run typecheck` currently fails on existing `RefObject` typing issues in `src/shared/components/SearchModal.tsx` and `src/shared/utils/focusTrap.ts`.
- `npm test` currently has unrelated existing failures in suites such as `src/shared/api/client.test.ts`, `src/shared/hooks/useLandingStats.test.ts`, `src/features/landing/components/ImageWithFallback.test.tsx`, `src/features/blog/pages/BlogPage.test.tsx`, and `src/features/maintainers/components/dashboard/ActivityItem.test.tsx`.

## Security note
This prevents production from silently falling back to a localhost API URL when the required public Vite config is missing. It only validates public `VITE_` URL values and does not expose or require secrets.
