### PR TITLE
fix(maintainers): sort activity by timestamp not parsed text

### DIFF
--- a/src/features/maintainers/components/dashboard/ActivityItem.test.tsx
+++ b/src/features/maintainers/components/dashboard/ActivityItem.test.tsx
@@ -18,17 +18,17 @@ const baseActivity = {
 
 describe('ActivityItem', () => {
   it('is non-interactive when no onClick is provided', () => {
-    const { container, queryByRole } = render(<ActivityItem activity={baseActivity as any} index={0} />);
-    expect(queryByRole('button')).toBeNull();
+    const { container } = render(<ActivityItem activity={baseActivity as any} index={0} />);
+    expect((container.firstChild as HTMLElement).getAttribute('role')).toBeNull();
     expect(container.firstChild).toHaveClass('cursor-default');
   });
 
   it('calls onClick when clicked and shows interactive attributes', () => {
     const handler = vi.fn();
-    const { getByRole, container } = render(<ActivityItem activity={baseActivity as any} index={0} onClick={handler} />);
-    const row = getByRole('button');
+    const { container } = render(<ActivityItem activity={baseActivity as any} index={0} onClick={handler} />);
+    const row = container.firstChild as HTMLElement;
     expect(row).toHaveAttribute('tabindex', '0');
-    expect(container.firstChild).toHaveClass('cursor-pointer');
+    expect(row).toHaveClass('cursor-pointer');
 
     fireEvent.click(row);
     expect(handler).toHaveBeenCalledTimes(1);
@@ -36,8 +36,8 @@ describe('ActivityItem', () => {
 
   it('activates on Enter and Space key presses', () => {
     const handler = vi.fn();
-    const { getByRole } = render(<ActivityItem activity={baseActivity as any} index={0} onClick={handler} />);
-    const row = getByRole('button');
+    const { container } = render(<ActivityItem activity={baseActivity as any} index={0} onClick={handler} />);
+    const row = container.firstChild as HTMLElement;
 
     fireEvent.keyDown(row, { key: 'Enter' });
     fireEvent.keyDown(row, { key: ' ' });

--- a/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
+import { DashboardTab } from './DashboardTab';
+import { getProjectIssues, getProjectPRs } from '../../../../shared/api/client';
+
+// Mock theme hook to avoid needing full provider
+vi.mock('../../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+// Mock API Client
+vi.mock('../../../../shared/api/client', () => ({
+  getProjectIssues: vi.fn(),
+  getProjectPRs: vi.fn(),
+}));
+
+// Mock logger to prevent cluttering the test logs
+vi.mock('../../../../shared/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// Mock recharts to avoid rendering logs / size errors in JSDOM environment
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+}));
+
+describe('DashboardTab', () => {
+  const mockProjects = [
+    { id: 'proj-1', github_full_name: 'test/repo', status: 'active' }
+  ];
+
+  const RealDate = window.Date;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Stub Date constructor and Date.now for deterministic relative time calculations
+    const mockSystemTime = new Date('2026-06-23T12:00:00Z');
+    
+    // Create a mock Date constructor
+    const MockDateConstructor = function (this: any, ...args: any[]) {
+      if (args.length === 0) {
+        return new RealDate(mockSystemTime.getTime());
+      }
+      return new (RealDate as any)(...args);
+    } as any;
+
+    MockDateConstructor.prototype = RealDate.prototype;
+    MockDateConstructor.now = () => mockSystemTime.getTime();
+    MockDateConstructor.parse = RealDate.parse;
+    MockDateConstructor.UTC = RealDate.UTC;
+
+    (window as any).Date = MockDateConstructor;
+  });
+
+  afterEach(() => {
+    (window as any).Date = RealDate;
+  });
+
+  /**
+   * Helper to retrieve only the activity headings from the DOM.
+   * Filters out StatsCard headings by targeting the 'font-medium' class on ActivityItem headings.
+   */
+  const getActivityHeadings = () => {
+    return screen.getAllByRole('heading', { level: 3 }).filter(el => 
+      el.className.includes('font-medium')
+    );
+  };
+
+  it('correctly sorts activity items chronologically (most recent first) and formats relative time', async () => {
+    const oneDayAgo = '2026-06-22T12:00:00Z';
+    const twoHoursAgo = '2026-06-23T10:00:00Z';
+    const fiveMinsAgo = '2026-06-23T11:55:00Z';
+
+    vi.mocked(getProjectIssues).mockResolvedValue({
+      issues: [
+        {
+          github_issue_id: 10,
+          number: 1,
+          title: 'Older Issue',
+          comments_count: 0,
+          projectId: 'proj-1',
+          updated_at: oneDayAgo,
+        },
+        {
+          github_issue_id: 20,
+          number: 2,
+          title: 'Newer Issue',
+          comments_count: 0,
+          projectId: 'proj-1',
+          updated_at: fiveMinsAgo,
+        }
+      ] as any
+    });
+
+    vi.mocked(getProjectPRs).mockResolvedValue({
+      prs: [
+        {
+          github_pr_id: 30,
+          number: 3,
+          title: 'Middle PR',
+          state: 'open',
+          merged: false,
+          updated_at: twoHoursAgo,
+        }
+      ] as any
+    });
+
+    render(<DashboardTab selectedProjects={mockProjects} isLoadingProjects={false} />);
+
+    // Wait until the statistics cards are rendered, signaling that loading has finished.
+    await waitFor(() => {
+      expect(screen.getByText('Repository Views')).toBeInTheDocument();
+    });
+
+    const activityElements = getActivityHeadings();
+    expect(activityElements).toHaveLength(3);
+    expect(activityElements[0].textContent).toBe('Newer Issue');
+    expect(activityElements[1].textContent).toBe('Middle PR');
+    expect(activityElements[2].textContent).toBe('Older Issue');
+
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+    expect(screen.getByText('2 hours ago')).toBeInTheDocument();
+    expect(screen.getByText('1 day ago')).toBeInTheDocument();
+  });
+
+  it('maintains stable ordering for ties (stable sorting)', async () => {
+    const sameTime = '2026-06-23T11:00:00Z'; // 1 hour ago
+
+    vi.mocked(getProjectIssues).mockResolvedValue({
+      issues: [
+        {
+          github_issue_id: 100,
+          number: 10,
+          title: 'Same Time Issue',
+          comments_count: 0,
+          projectId: 'proj-1',
+          updated_at: sameTime,
+        }
+      ] as any
+    });
+
+    vi.mocked(getProjectPRs).mockResolvedValue({
+      prs: [
+        {
+          github_pr_id: 200,
+          number: 20,
+          title: 'Same Time PR',
+          state: 'open',
+          merged: false,
+          updated_at: sameTime,
+        }
+      ] as any
+    });
+
+    render(<DashboardTab selectedProjects={mockProjects} isLoadingProjects={false} />);
+
+    // Wait until the statistics cards are rendered, signaling that loading has finished.
+    await waitFor(() => {
+      expect(screen.getByText('Repository Views')).toBeInTheDocument();
+    });
+
+    const activityElements = getActivityHeadings();
+    expect(activityElements).toHaveLength(2);
+    expect(activityElements[0].textContent).toBe('Same Time PR');
+    expect(activityElements[1].textContent).toBe('Same Time Issue');
+  });
+
+  it('guards against invalid/NaN dates and lists them at the bottom with "unknown time" label', async () => {
+    const validTime = '2026-06-23T11:00:00Z'; // 1 hour ago
+    const invalidTime = 'this-is-not-a-valid-date-string';
+
+    vi.mocked(getProjectIssues).mockResolvedValue({
+      issues: [
+        {
+          github_issue_id: 11,
+          number: 11,
+          title: 'Invalid Time Issue',
+          comments_count: 0,
+          projectId: 'proj-1',
+          updated_at: invalidTime,
+        }
+      ] as any
+    });
+
+    vi.mocked(getProjectPRs).mockResolvedValue({
+      prs: [
+        {
+          github_pr_id: 22,
+          number: 22,
+          title: 'Valid Time PR',
+          state: 'open',
+          merged: false,
+          updated_at: validTime,
+        }
+      ] as any
+    });
+
+    render(<DashboardTab selectedProjects={mockProjects} isLoadingProjects={false} />);
+
+    // Wait until the statistics cards are rendered, signaling that loading has finished.
+    await waitFor(() => {
+      expect(screen.getByText('Repository Views')).toBeInTheDocument();
+    });
+
+    const activityElements = getActivityHeadings();
+    expect(activityElements).toHaveLength(2);
+    expect(activityElements[0].textContent).toBe('Valid Time PR');
+    expect(activityElements[1].textContent).toBe('Invalid Time Issue');
+
+    expect(screen.getByText('1 hour ago')).toBeInTheDocument();
+    expect(screen.getByText('unknown time')).toBeInTheDocument();
+  });
+});

--- a/src/features/maintainers/components/dashboard/DashboardTab.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.tsx
@@ -151,8 +151,12 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
 
   // Helper function to format time ago (memoized to prevent unnecessary re-renders)
   const formatTimeAgo = useCallback((date: Date): string => {
+    const timeMs = date.getTime();
+    if (isNaN(timeMs)) {
+      return 'unknown time';
+    }
     const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
+    const diffMs = now.getTime() - timeMs;
     const diffMins = Math.floor(diffMs / 60000);
     const diffHours = Math.floor(diffMs / 3600000);
     const diffDays = Math.floor(diffMs / 86400000);
@@ -165,26 +169,17 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
     return `${diffMonths} month${diffMonths !== 1 ? 's' : ''} ago`;
   }, []);
 
-  // Helper function to parse time ago for sorting (memoized)
-  const parseTimeAgo = useCallback((timeAgo: string): number => {
-    const now = new Date().getTime();
-    if (timeAgo.includes('minute')) {
-      const mins = parseInt(timeAgo) || 0;
-      return now - mins * 60000;
-    }
-    if (timeAgo.includes('hour')) {
-      const hours = parseInt(timeAgo) || 0;
-      return now - hours * 3600000;
-    }
-    if (timeAgo.includes('day')) {
-      const days = parseInt(timeAgo) || 0;
-      return now - days * 86400000;
-    }
-    if (timeAgo.includes('month')) {
-      const months = parseInt(timeAgo) || 0;
-      return now - months * 30 * 86400000;
-    }
-    return now;
+  /**
+   * Safely parses a date string, returning its Unix timestamp in milliseconds.
+   * Returns 0 if the date string is null, undefined, or invalid to prevent NaN sorting issues.
+   * 
+   * @param dateStr - The date string to parse.
+   * @returns The parsed Unix time in milliseconds, or 0 if invalid.
+   */
+  const safeParseDate = useCallback((dateStr?: string | null): number => {
+    if (!dateStr) return 0;
+    const parsed = Date.parse(dateStr);
+    return isNaN(parsed) ? 0 : parsed;
   }, []);
 
   // Calculate stats from real data
@@ -255,20 +250,21 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
 
     // Add recent PRs
     prs.slice(0, 10).forEach(pr => {
+      const timestamp = pr.updated_at || pr.last_seen_at || '';
       combined.push({
         id: pr.github_pr_id,
         type: 'pr',
         number: pr.number,
         title: pr.title,
         label: pr.merged ? 'Merged' : pr.state === 'open' ? 'Open' : 'Closed',
-        timeAgo: pr.updated_at
-          ? formatTimeAgo(new Date(pr.updated_at))
-          : formatTimeAgo(new Date(pr.last_seen_at)),
+        timestamp,
+        timeAgo: timestamp ? formatTimeAgo(new Date(timestamp)) : 'unknown time',
       });
     });
 
     // Add recent issues
     issues.slice(0, 10).forEach(issue => {
+      const timestamp = issue.updated_at || issue.last_seen_at || '';
       combined.push({
         id: issue.github_issue_id,
         type: 'issue',
@@ -276,21 +272,24 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         title: issue.title,
         label: issue.comments_count > 0 ? `${issue.comments_count} comment${issue.comments_count !== 1 ? 's' : ''}` : null,
         projectId: issue.projectId,
-        timeAgo: issue.updated_at
-          ? formatTimeAgo(new Date(issue.updated_at))
-          : formatTimeAgo(new Date(issue.last_seen_at)),
+        timestamp,
+        timeAgo: timestamp ? formatTimeAgo(new Date(timestamp)) : 'unknown time',
       });
     });
 
-    // Sort by time (most recent first)
-    combined.sort((a, b) => {
-      const timeA = parseTimeAgo(a.timeAgo);
-      const timeB = parseTimeAgo(b.timeAgo);
-      return timeB - timeA;
+    // Sort by timestamp (most recent first) with stable tie-breaking
+    const indexed = combined.map((activity, idx) => ({ activity, idx }));
+    indexed.sort((a, b) => {
+      const timeA = safeParseDate(a.activity.timestamp);
+      const timeB = safeParseDate(b.activity.timestamp);
+      if (timeB !== timeA) {
+        return timeB - timeA;
+      }
+      return a.idx - b.idx; // Stable tie-breaking using original array indices
     });
 
-    return combined; // Return all activities (will be sliced in render based on state)
-  }, [issues, prs, formatTimeAgo, parseTimeAgo]);
+    return indexed.map(item => item.activity);
+  }, [issues, prs, formatTimeAgo, safeParseDate]);
 
   // Generate chart data from real data (last 6 months)
   const chartData: ChartDataPoint[] = useMemo(() => {

--- a/src/features/maintainers/types/index.ts
+++ b/src/features/maintainers/types/index.ts
@@ -10,14 +10,26 @@ export interface StatCard {
   icon: LucideIcon;
 }
 
+/**
+ * Represents a maintainer activity entry displayed in the dashboard timeline.
+ */
 export interface Activity {
+  /** The unique identifier of the issue or PR (e.g. GitHub ID) */
   id: number;
+  /** The type of activity, either a Pull Request ('pr') or an Issue ('issue') */
   type: 'pr' | 'issue';
+  /** The GitHub issue or PR number */
   number: number;
+  /** The title of the issue or PR */
   title: string;
+  /** An optional label indicating status or additional metadata (e.g. "Merged", comment counts) */
   label: string | null;
+  /** The formatted relative time string (e.g. "3 days ago") */
   timeAgo: string;
+  /** The unique project ID, required for navigating to issues */
   projectId?: string;
+  /** The actual ISO timestamp of when the activity occurred (used for chronological sorting) */
+  timestamp: string;
 }
 
 export interface ChartDataPoint {


### PR DESCRIPTION
# Description
Fixes the activity timeline sorting in `DashboardTab` by using raw ISO 8601 timestamps instead of parsing display strings like "3 days ago" with `parseTimeAgo()`.

## Changes Proposed
- **Types**: Added `timestamp: string` field to `Activity` interface in [index.ts](file:///c:/Users/USER/Desktop/Grainlify-Frontend/src/features/maintainers/types/index.ts).
- **Sorting Logic**: Replaced `parseTimeAgo` with a robust `safeParseDate` helper in [DashboardTab.tsx](file:///c:/Users/USER/Desktop/Grainlify-Frontend/src/features/maintainers/components/dashboard/DashboardTab.tsx) that returns epoch milliseconds, falling back safely to `0` when encountering invalid or null dates.
- **Stable Tie-Breaking**: Implemented a stable tie-breaker during sorting using the original array indices of activity items.
- **Date Validation**: Updated `formatTimeAgo` to handle invalid/NaN date instances gracefully, returning `"unknown time"`.
- **Tests**:
  - Fixed a pre-existing test in [ActivityItem.test.tsx](file:///c:/Users/USER/Desktop/Grainlify-Frontend/src/features/maintainers/components/dashboard/ActivityItem.test.tsx) where checking for buttons was returning multiple matches because of the nested review button.
  - Added new comprehensive unit tests in [DashboardTab.test.tsx](file:///c:/Users/USER/Desktop/Grainlify-Frontend/src/features/maintainers/components/dashboard/DashboardTab.test.tsx) asserting chronological sorting, stable tie-breaking, and invalid date handling.

## Security Notes
- Invalid/NaN date inputs are gracefully handled via `safeParseDate` (defaults to `0` / oldest time) and `formatTimeAgo` (returns `"unknown time"`), protecting the UI from crashes or rendering incorrect `NaN` date formats.

## Verification & Test Output
- All 67 tests under `src/features/maintainers` pass successfully.
- Ran project build and TypeScript compilation check (`npm run build`, `npm run typecheck`, `npm run lint`). No type or style errors were introduced.

Closes #186 