### PR TITLE
fix(a11y): add aria-label to LanguageIcon fallback dot and memoize component — #184

### DIFF
--- a/src/shared/components/LanguageIcon.tsx
+++ b/src/shared/components/LanguageIcon.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import {
   siTypescript,
   siJavascript,
@@ -89,8 +90,8 @@ const cssIconPath = "M1.5 0h21l-1.91 21.563L11.977 24l-8.564-2.438L1.5 0zm17.09 
 // Batchfile (Windows CMD) - terminal-style icon
 const batchfileIconPath = "M2 4h20v16H2V4zm2 2v2h16V6H4zm0 4h16v2H4v-2zm0 4h10v2H4v-2z";
 
-export function LanguageIcon({ language, className = 'w-4 h-4' }: LanguageIconProps) {
-  const config = languageMapping[language];
+export const LanguageIcon = memo(function LanguageIcon({ language, className = 'w-4 h-4' }: LanguageIconProps) {
+  const config = useMemo(() => languageMapping[language], [language]);
 
   // Special handling for CSS (no icon in simple-icons)
   if (language === 'CSS') {
@@ -125,8 +126,13 @@ export function LanguageIcon({ language, className = 'w-4 h-4' }: LanguageIconPr
   }
 
   if (!config) {
-    // Fallback to colored dot if language not found
-    return <div className={`rounded-full bg-[#9b8b7a] ${className}`} />;
+    return (
+      <div
+        role="img"
+        aria-label={language}
+        className={`rounded-full bg-[#9b8b7a] ${className}`}
+      />
+    );
   }
 
   return (
@@ -141,4 +147,4 @@ export function LanguageIcon({ language, className = 'w-4 h-4' }: LanguageIconPr
       <path d={config.icon.path} />
     </svg>
   );
-}
+});


### PR DESCRIPTION
## Summary

- The fallback colored dot for unknown languages had no accessible name — invisible to screen readers and colorblind users. Adds `role="img"` and `aria-label={language}` to the fallback `<div>`.
- Wraps the component with `React.memo` to skip re-renders when props are unchanged.
- Adds `useMemo` for the language-to-icon map lookup.

## Test plan

- [x] Visual: unknown language (e.g. `COBOL`) now announced as "COBOL" by screen readers
- [x] Known languages already had `<title>{language}</title>` inside the SVG — unchanged
- [x] No logic changes; TypeScript compiles cleanly

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)