### PR TITLE
fix(validation): accept localhost/IP in validateUrl and tighten email regex — #180

### DIFF
--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -88,10 +88,26 @@ describe('validateUrl', () => {
     expect(result).toContain('valid URL')
   })
 
-  it('rejects hostname without dot', () => {
-    const result = validateUrl('https://localhost')
-    // localhost has no dot but is technically valid; our rule catches it
-    expect(result).toBe('URL must have a valid hostname')
+  it('accepts localhost (no dot required)', () => {
+    expect(validateUrl('https://localhost')).toBe(true)
+  })
+
+  it('accepts localhost with port', () => {
+    expect(validateUrl('http://localhost:3000')).toBe(true)
+  })
+
+  it('accepts IP address', () => {
+    expect(validateUrl('http://192.168.1.1')).toBe(true)
+  })
+
+  it('rejects javascript: scheme', () => {
+    const result = validateUrl('javascript:alert(1)')
+    expect(result).toContain('http')
+  })
+
+  it('rejects data: scheme', () => {
+    const result = validateUrl('data:text/html,<h1>hi</h1>')
+    expect(result).toContain('http')
   })
 })
 
@@ -134,6 +150,18 @@ describe('validateEmail', () => {
 
   it('rejects trailing dot after TLD', () => {
     expect(validateEmail('user@example.')).toContain('valid email')
+  })
+
+  it('rejects double dot in domain', () => {
+    expect(validateEmail('user@example..com')).toContain('valid email')
+  })
+
+  it('accepts subdomain email', () => {
+    expect(validateEmail('user@mail.example.co.uk')).toBe(true)
+  })
+
+  it('rejects missing domain before dot', () => {
+    expect(validateEmail('user@.com')).toContain('valid email')
   })
 })
 

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -39,7 +39,7 @@ export function validateUrl(value: string): string | true {
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       return 'URL must start with http:// or https://'
     }
-    if (!url.hostname.includes('.')) {
+    if (!url.hostname) {
       return 'URL must have a valid hostname'
     }
     return true
@@ -58,7 +58,7 @@ export function validateUrl(value: string): string | true {
 export function validateEmail(value: string): string | true {
   const trimmed = value.trim()
   if (!trimmed) return true
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+  if (!/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(trimmed)) {
     return 'Please enter a valid email address'
   }
   return true


### PR DESCRIPTION
## Summary

- **`validateUrl`**: removed the `hostname.includes('.')` check that incorrectly rejected `localhost`, bare IPs, and other valid hosts. The `URL` constructor already enforces a non-empty hostname; `javascript:` and `data:` schemes are still blocked by the explicit protocol check.
- **`validateEmail`**: upgraded regex from `/[^\s@]+@[^\s@]+\.[^\s@]+/` to `/[^\s@]+@[^\s@.]+(\.[^\s@.]+)+/` — rejects double dots in domain (`user@example..com`), missing domain before dot (`user@.com`), while supporting subdomains and avoiding catastrophic backtracking.
- **Tests**: updated 1 existing test (localhost now accepted) and added 8 new edge-case tests.

## Test plan

- [x] 41/41 tests pass (`npx vitest run src/shared/utils/validation.test.ts`)
- [x] `https://localhost`, `http://localhost:3000`, `http://192.168.1.1` → accepted
- [x] `javascript:alert(1)`, `data:text/html,...` → rejected
- [x] `user@example..com`, `user@.com` → rejected
- [x] `user@mail.example.co.uk` → accepted

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)