### PR TITLE
feat(contributions): load live board data

### DIFF
--- a/src/features/dashboard/components/ContributionsTab.test.tsx
+++ b/src/features/dashboard/components/ContributionsTab.test.tsx
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+const mockGetProfileContributions = vi.fn();
+
+vi.mock("../../../shared/api/client", () => ({
+  getProfileContributions: () => mockGetProfileContributions(),
+}));
+
+vi.mock("../../../shared/contexts/ThemeContext", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useTheme: () => ({
+    theme: "light",
+    toggleTheme: vi.fn(),
+    setThemeFromAnimation: vi.fn(),
+  }),
+}));
+
+import { ContributionsTab } from "./ContributionsTab";
+
+function renderContributionsTab() {
+  return render(<ContributionsTab />);
+}
+
+beforeEach(() => {
+  mockGetProfileContributions.mockReset();
+});
+
+describe("ContributionsTab", () => {
+  it("fetches contribution items and groups them by status columns", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "applied-1",
+          title: "Apply live board data",
+          status: "applied",
+          project_name: "Grainlify Frontend",
+          badge: "165",
+          updated_at: "2026-06-22T00:00:00Z",
+          tag: "frontend",
+          url: "https://github.com/Grainlify/Grainlify-Frontend/issues/165",
+        },
+        {
+          id: "assigned-1",
+          title: "Assigned contribution work",
+          status: "assigned",
+          project_name: "StableRoute",
+          badge: "68",
+          updated_at: "2026-06-23T00:00:00Z",
+          tag: "enhancement",
+        },
+        {
+          id: "pending-1",
+          title: "Pending review contribution",
+          status: "pending_review",
+          project_name: "Agentpay",
+          badge: "88",
+          updated_at: "2026-06-24T00:00:00Z",
+          tag: "testing",
+        },
+        {
+          id: "complete-1",
+          title: "Completed contribution",
+          status: "completed",
+          project_name: "Docusaurus Glean",
+          updated_at: "2026-06-20T00:00:00Z",
+          tag: "bug",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Apply live board data").length).toBeGreaterThan(0),
+    );
+    expect(screen.getAllByText("Assigned contribution work").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending review contribution").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Completed contribution").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /see application/i })).toHaveAttribute(
+      "href",
+      "https://github.com/Grainlify/Grainlify-Frontend/issues/165",
+    );
+    expect(screen.queryByText("Add dark mode support to the dashboard")).not.toBeInTheDocument();
+    expect(mockGetProfileContributions).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading skeletons while contribution items are loading", () => {
+    mockGetProfileContributions.mockReturnValue(new Promise(() => {}));
+
+    renderContributionsTab();
+
+    expect(screen.getByLabelText("Loading contributions")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+  });
+
+  it("shows an empty state for each column that has no matching contributions", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "applied-only",
+          title: "Only applied item",
+          status: "applied",
+          project_name: "Grainlify Frontend",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    expect(await screen.findByText("Only applied item")).toBeInTheDocument();
+    expect(screen.getAllByText("No assigned contributions").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("No pending review contributions").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("No complete contributions").length).toBeGreaterThan(0);
+  });
+
+  it("shows an error state and retries the failed request", async () => {
+    mockGetProfileContributions.mockRejectedValueOnce(new Error("network"));
+
+    renderContributionsTab();
+
+    const errorMessage = await screen.findByText("Unable to load contributions");
+    const retry = errorMessage.closest('[role="alert"]')!.querySelector("button")!;
+
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "retry-1",
+          title: "Recovered contribution",
+          status: "assigned",
+          project_name: "Retry Project",
+        },
+      ],
+    });
+
+    await userEvent.click(retry);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Recovered contribution").length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByText("Unable to load contributions")).not.toBeInTheDocument();
+    expect(mockGetProfileContributions).toHaveBeenCalledTimes(2);
+  });
+
+  it("filters visible contribution cards by selected project", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "grainlify-1",
+          title: "Grainlify-only contribution",
+          status: "assigned",
+          project_name: "Grainlify Frontend",
+        },
+        {
+          id: "agentpay-1",
+          title: "Agentpay contribution",
+          status: "assigned",
+          project_name: "Agentpay",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Grainlify-only contribution").length).toBeGreaterThan(0),
+    );
+    expect(screen.getAllByText("Agentpay contribution").length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole("button", { name: /filter contributions/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Grainlify Frontend" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getAllByText("Grainlify-only contribution").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Agentpay contribution")).not.toBeInTheDocument();
+  });
+
+  it("filters contributions by search text", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "search-1",
+          title: "Search-visible contribution",
+          status: "assigned",
+          project_name: "Search Project",
+        },
+        {
+          id: "search-2",
+          title: "Hidden by search",
+          status: "assigned",
+          project_name: "Other Project",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await screen.findByText("Search-visible contribution");
+    await userEvent.type(screen.getByPlaceholderText("Search"), "visible");
+
+    expect(screen.getByText("Search-visible contribution")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden by search")).not.toBeInTheDocument();
+  });
+
+  it("supports project search, project reset, and restored board items", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "reset-1",
+          title: "Reset Grainlify contribution",
+          status: "assigned",
+          project_name: "Grainlify Frontend",
+        },
+        {
+          id: "reset-2",
+          title: "Reset Agentpay contribution",
+          status: "assigned",
+          project_name: "Agentpay",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await screen.findByText("Reset Grainlify contribution");
+    await userEvent.click(screen.getByRole("button", { name: /filter contributions/i }));
+    await userEvent.type(screen.getByPlaceholderText("Search projects"), "missing");
+    expect(screen.getByText("No items found")).toBeInTheDocument();
+
+    await userEvent.clear(screen.getByPlaceholderText("Search projects"));
+    await userEvent.click(screen.getByRole("button", { name: "Grainlify Frontend" }));
+    await userEvent.click(screen.getByRole("button", { name: "Reset" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText("Reset Grainlify contribution")).toBeInTheDocument();
+    expect(screen.getByText("Reset Agentpay contribution")).toBeInTheDocument();
+  });
+
+  it("filters by rewarded status", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "rewarded-1",
+          title: "Rewarded contribution",
+          status: "complete",
+          project_name: "Paid Project",
+          reward_status: "paid",
+        },
+        {
+          id: "unrewarded-1",
+          title: "Unrewarded contribution",
+          status: "complete",
+          project_name: "Open Project",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await screen.findByText("Rewarded contribution");
+    expect(screen.getByText("Unrewarded contribution")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /filter contributions/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Unrewarded" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText("Rewarded contribution")).toBeInTheDocument();
+    expect(screen.queryByText("Unrewarded contribution")).not.toBeInTheDocument();
+  });
+
+  it("closes and toggles filter panel sections without losing selections", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "panel-1",
+          title: "Panel interaction contribution",
+          status: "assigned",
+          project_name: "Panel Project",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    await screen.findByText("Panel interaction contribution");
+    await userEvent.click(screen.getByRole("button", { name: /filter contributions/i }));
+    expect(screen.getByRole("heading", { name: "Filter contributions" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /close filter/i }));
+    expect(
+      screen.queryByRole("heading", { name: "Filter contributions" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /filter contributions/i }));
+    await userEvent.click(screen.getByRole("button", { name: /projects/i }));
+    expect(screen.queryByPlaceholderText("Search projects")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /rewarded 2/i }));
+    expect(screen.queryByText("Rewarded, Unrewarded")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /rewarded 2/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Rewarded" }));
+    await userEvent.click(screen.getByRole("button", { name: "Unrewarded" }));
+    expect(screen.getByText("No reward filters selected")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Rewarded" }));
+    expect(screen.queryByText("No reward filters selected")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /rewarded 1/i })).toBeInTheDocument();
+  });
+
+  it("renders repository-supplied titles as escaped text", async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: "unsafe-title",
+          title: "<img src=x onerror=alert(1)>",
+          status: "complete",
+          project_name: "Security Project",
+        },
+      ],
+    });
+
+    renderContributionsTab();
+
+    expect(await screen.findByText("<img src=x onerror=alert(1)>")).toBeInTheDocument();
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+  });
+});

--- a/src/features/dashboard/components/ContributionsTab.tsx
+++ b/src/features/dashboard/components/ContributionsTab.tsx
@@ -1,142 +1,513 @@
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Filter,
-  Clock,
-  GitFork,
-  Star,
-  Search,
-  X,
-  Circle,
+  AlertCircle,
   Check,
   ChevronDown,
+  Circle,
+  Clock,
+  Filter,
+  GitFork,
+  RefreshCw,
+  Search,
+  Star,
+  X,
 } from "lucide-react";
+import {
+  getProfileContributions,
+  type ProfileContribution,
+} from "../../../shared/api/client";
+import { SkeletonLoader } from "../../../shared/components/SkeletonLoader";
 import { useTheme } from "../../../shared/contexts/ThemeContext";
+
+type ContributionStatus = "applied" | "assigned" | "pending" | "complete";
+type RewardFilter = "Rewarded" | "Unrewarded";
+
+type ContributionCardData = {
+  id: string;
+  title: string;
+  status: ContributionStatus;
+  badge: string | null;
+  time: string;
+  project: string;
+  contributor: string;
+  tag: string;
+  tagType: "bug" | "feature" | "enhancement";
+  url: string | null;
+  rewardFilter: RewardFilter;
+};
+
+type BoardState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ok"; contributions: ContributionCardData[] };
+
+const contributionColumns: Array<{
+  key: ContributionStatus;
+  title: string;
+  emptyLabel: string;
+}> = [
+  { key: "applied", title: "Applied", emptyLabel: "No applied contributions" },
+  {
+    key: "assigned",
+    title: "Assigned issue",
+    emptyLabel: "No assigned contributions",
+  },
+  {
+    key: "pending",
+    title: "Pending review",
+    emptyLabel: "No pending review contributions",
+  },
+  { key: "complete", title: "Complete", emptyLabel: "No complete contributions" },
+];
+
+const rewardOptions: RewardFilter[] = ["Rewarded", "Unrewarded"];
+const fallbackTitle = "Untitled contribution";
+const fallbackProject = "Unknown project";
+const fallbackTag = "contribution";
+const fallbackTime = "Recently";
+
+const normalizeText = (value: unknown, fallback: string) => {
+  if (typeof value !== "string" && typeof value !== "number") return fallback;
+  const text = String(value).trim();
+  return text && text.toLowerCase() !== "undefined" ? text : fallback;
+};
+
+const normalizeStatus = (status?: string | null): ContributionStatus => {
+  const normalized = status?.toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+
+  if (
+    ["complete", "completed", "merged", "done", "paid", "closed"].includes(
+      normalized,
+    )
+  ) {
+    return "complete";
+  }
+  if (
+    normalized.includes("pending") ||
+    normalized.includes("review") ||
+    normalized.includes("submitted")
+  ) {
+    return "pending";
+  }
+  if (normalized.includes("assign") || normalized.includes("progress")) {
+    return "assigned";
+  }
+  return "applied";
+};
+
+const getFirstLabel = (contribution: ProfileContribution) => {
+  const firstLabel = contribution.labels?.[0];
+  if (typeof firstLabel === "string") return firstLabel;
+  return firstLabel?.name ?? contribution.label ?? contribution.tag;
+};
+
+const getTagType = (tag: string): ContributionCardData["tagType"] => {
+  const normalized = tag.toLowerCase();
+  if (normalized.includes("bug") || normalized.includes("fix")) return "bug";
+  if (normalized.includes("feature")) return "feature";
+  return "enhancement";
+};
+
+const getBadge = (contribution: ProfileContribution) => {
+  const value =
+    contribution.badge ?? contribution.issue_number ?? contribution.number ?? null;
+  return value === null ? null : normalizeText(value, "");
+};
+
+const getContributionId = (contribution: ProfileContribution) =>
+  normalizeText(
+    contribution.id,
+    `${normalizeText(contribution.title, fallbackTitle)}-${normalizeText(
+      contribution.project_name ||
+        contribution.project ||
+        contribution.repository ||
+        contribution.github_full_name,
+      fallbackProject,
+    )}`,
+  );
+
+const getRewardFilter = (contribution: ProfileContribution): RewardFilter => {
+  const rewardStatus = contribution.reward_status?.toLowerCase() ?? "";
+  if (
+    contribution.rewarded ||
+    contribution.is_rewarded ||
+    (contribution.amount !== null && contribution.amount !== undefined) ||
+    rewardStatus.includes("reward") ||
+    rewardStatus.includes("paid") ||
+    rewardStatus.includes("complete")
+  ) {
+    return "Rewarded";
+  }
+  return "Unrewarded";
+};
+
+const formatContributionTime = (contribution: ProfileContribution) => {
+  const value =
+    contribution.updated_at ||
+    contribution.submitted_at ||
+    contribution.merged_at ||
+    contribution.created_at;
+  if (!value) return fallbackTime;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return normalizeText(value, fallbackTime);
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+};
+
+/**
+ * Converts nullable API rows into stable card data for the board.
+ *
+ * @remarks
+ * React renders all title/project/tag fields as text nodes, so repository-
+ * supplied strings such as issue titles are escaped by default rather than
+ * interpreted as HTML.
+ */
+function normalizeContribution(
+  contribution: ProfileContribution,
+): ContributionCardData {
+  const tag = normalizeText(getFirstLabel(contribution), fallbackTag);
+
+  return {
+    id: getContributionId(contribution),
+    title: normalizeText(contribution.title, fallbackTitle),
+    status: normalizeStatus(contribution.status),
+    badge: getBadge(contribution),
+    time: formatContributionTime(contribution),
+    project: normalizeText(
+      contribution.project_name ||
+        contribution.project ||
+        contribution.repository ||
+        contribution.github_full_name,
+      fallbackProject,
+    ),
+    contributor: normalizeText(
+      contribution.contributor_login || contribution.author_login,
+      fallbackProject,
+    ),
+    tag,
+    tagType: getTagType(tag),
+    url: contribution.url ?? null,
+    rewardFilter: getRewardFilter(contribution),
+  };
+}
+
+/**
+ * Groups normalized contribution cards into the four dashboard columns.
+ */
+function groupContributions(contributions: ContributionCardData[]) {
+  return contributionColumns.reduce(
+    (groups, column) => ({
+      ...groups,
+      [column.key]: contributions.filter((item) => item.status === column.key),
+    }),
+    {
+      applied: [],
+      assigned: [],
+      pending: [],
+      complete: [],
+    } as Record<ContributionStatus, ContributionCardData[]>,
+  );
+}
+
+function isProjectMatch(project: string, query: string) {
+  return project.toLowerCase().includes(query.trim().toLowerCase());
+}
+
+function ContributionSkeleton() {
+  return (
+    <div
+      aria-label="Loading contributions"
+      aria-busy="true"
+      className="grid grid-cols-1 md:grid-cols-4 gap-5"
+    >
+      {contributionColumns.map((column) => (
+        <div
+          key={column.key}
+          className="backdrop-blur-[30px] rounded-[16px] border p-5 bg-white/[0.15] border-white/25"
+        >
+          <SkeletonLoader className="h-5 w-32 mb-5" />
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={index}
+                className="rounded-[12px] border border-white/25 p-4 bg-white/[0.12]"
+              >
+                <SkeletonLoader className="h-5 w-full mb-3" />
+                <SkeletonLoader className="h-4 w-28 mb-3" />
+                <SkeletonLoader className="h-4 w-36 mb-3" />
+                <SkeletonLoader className="h-7 w-24" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ContributionError({
+  theme,
+  onRetry,
+}: {
+  theme: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className={`text-center py-16 backdrop-blur-[30px] bg-white/[0.12] rounded-[20px] border border-white/20 ${
+        theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+      }`}
+    >
+      <AlertCircle className="w-14 h-14 mx-auto mb-4 opacity-60" />
+      <p className="text-[16px] font-semibold">Unable to load contributions</p>
+      <p className="text-[13px] mt-2 mb-5">
+        Something went wrong while loading your contribution board.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-[12px] bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border-2 border-[#c9983a]/50 text-[#c9983a] text-[13px] font-semibold hover:scale-105 hover:shadow-[0_4px_12px_rgba(201,152,58,0.4)] transition-all duration-300"
+      >
+        <RefreshCw className="w-4 h-4" />
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function EmptyColumn({ label, theme }: { label: string; theme: string }) {
+  return (
+    <div
+      className={`rounded-[12px] border p-5 text-center text-[13px] ${
+        theme === "dark"
+          ? "bg-white/[0.05] border-white/10 text-[#b8a898]"
+          : "bg-white/[0.1] border-white/20 text-[#7a6b5a]"
+      }`}
+    >
+      {label}
+    </div>
+  );
+}
+
+function ContributionCard({
+  item,
+  theme,
+}: {
+  item: ContributionCardData;
+  theme: string;
+}) {
+  const isComplete = item.status === "complete";
+  const actionLabel =
+    item.status === "applied" || item.status === "assigned"
+      ? "See application"
+      : "See detail";
+
+  return (
+    <div
+      className={`rounded-[12px] border p-4 transition-all ${
+        theme === "dark"
+          ? "bg-white/[0.08] border-white/15 hover:border-white/25"
+          : "bg-white/[0.2] border-white/30 hover:border-white/40"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <h4
+          className={`text-[14px] font-semibold flex-1 transition-colors ${
+            theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
+          }`}
+        >
+          {item.title}
+        </h4>
+        {isComplete ? (
+          <Check className="w-4 h-4 text-green-600 flex-shrink-0" />
+        ) : item.badge ? (
+          <span className="px-2 py-0.5 bg-green-500/20 border border-green-600/30 rounded-[6px] text-[10px] font-semibold text-green-800 flex-shrink-0">
+            {item.badge}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className={`flex items-center space-x-2 mb-3 text-[12px] transition-colors ${
+          theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+        }`}
+      >
+        <Clock className="w-3.5 h-3.5" />
+        <span>{item.time}</span>
+      </div>
+
+      <div className="flex items-center space-x-2 mb-3">
+        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500" />
+        <span
+          className={`text-[12px] transition-colors ${
+            theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
+          }`}
+        >
+          {item.project}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <span
+          className={`px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
+            item.tagType === "bug"
+              ? "bg-red-500/15 border border-red-600/25 text-red-800"
+              : theme === "dark"
+                ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
+                : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
+          }`}
+        >
+          {item.tag}
+        </span>
+        {item.url ? (
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[12px] text-[#c9983a] hover:text-[#a67c2e] font-medium flex items-center space-x-1"
+          >
+            <span>{actionLabel}</span>
+            {actionLabel === "See application" ? (
+              <GitFork className="w-3 h-3" />
+            ) : (
+              <Star className="w-3 h-3" />
+            )}
+          </a>
+        ) : (
+          <span className="text-[12px] text-[#c9983a] font-medium flex items-center space-x-1">
+            <span>{actionLabel}</span>
+            {actionLabel === "See application" ? (
+              <GitFork className="w-3 h-3" />
+            ) : (
+              <Star className="w-3 h-3" />
+            )}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ContributionColumn({
+  column,
+  items,
+  theme,
+}: {
+  column: (typeof contributionColumns)[number];
+  items: ContributionCardData[];
+  theme: string;
+}) {
+  return (
+    <div
+      className={`backdrop-blur-[30px] rounded-[16px] border p-5 transition-colors ${
+        theme === "dark"
+          ? "bg-white/[0.08] border-white/10"
+          : "bg-white/[0.15] border-white/25"
+      }`}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3
+          className={`text-[16px] font-bold transition-colors ${
+            theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
+          }`}
+        >
+          {column.title}{" "}
+          <span className={theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"}>
+            {items.length}
+          </span>
+        </h3>
+      </div>
+      <div className="space-y-3">
+        {items.length > 0 ? (
+          items.map((item) => (
+            <ContributionCard key={item.id} item={item} theme={theme} />
+          ))
+        ) : (
+          <EmptyColumn label={column.emptyLabel} theme={theme} />
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function ContributionsTab() {
   const { theme } = useTheme();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [_selectedProject, setSelectedProject] = useState("");
-  const [selectedRewards, setSelectedRewards] = useState<string[]>([
-    "Rewarded",
-    "Unrewarded",
-  ]);
+  const [selectedProject, setSelectedProject] = useState("");
+  const [projectSearchQuery, setProjectSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedRewards, setSelectedRewards] =
+    useState<RewardFilter[]>(rewardOptions);
   const [isProjectSectionOpen, setIsProjectSectionOpen] = useState(true);
   const [isRewardedSectionOpen, setIsRewardedSectionOpen] = useState(true);
+  const [state, setState] = useState<BoardState>({ status: "loading" });
 
-  const contributions = {
-    applied: [
-      {
-        id: 1,
-        title: "Add dark mode support to the dashboard",
-        badge: "2001",
-        time: "1 day ago",
-        contributor: "contributor1",
-        tag: "enhancement",
-        tagType: "enhancement" as const,
-      },
-      {
-        id: 2,
-        title: "Improve accessibility in form components",
-        badge: "1002",
-        time: "1 day ago",
-        contributor: "contributor1",
-        tag: "good first issue",
-        tagType: "enhancement" as const,
-      },
-      {
-        id: 3,
-        title: "Refactor authentication logic",
-        badge: "2001",
-        time: "2 days ago",
-        contributor: "contributor1",
-        tag: "refactor",
-        tagType: "enhancement" as const,
-      },
-    ],
-    assigned: [
-      {
-        id: 1,
-        title: "Implement user profile page",
-        badge: "2001",
-        time: "1 day ago",
-        project: "React",
-        tag: "feature",
-        tagType: "feature" as const,
-      },
-      {
-        id: 2,
-        title: "Add unit tests for API endpoints",
-        badge: "2002",
-        time: "2 days ago",
-        project: "Next.js",
-        tag: "testing",
-        tagType: "enhancement" as const,
-      },
-    ],
-    pending: [
-      {
-        id: 1,
-        title: "Optimize database queries",
-        badge: "3001",
-        time: "1 day ago",
-        project: "React",
-        tag: "performance",
-        tagType: "enhancement" as const,
-      },
-      {
-        id: 2,
-        title: "Add error boundary component",
-        badge: "3002",
-        time: "1 day ago",
-        project: "Next.js",
-        tag: "enhancement",
-        tagType: "enhancement" as const,
-      },
-      {
-        id: 3,
-        title: "Refactor state management",
-        badge: "3003",
-        time: "1 day ago",
-        project: "Modus",
-        tag: "refactor",
-        tagType: "enhancement" as const,
-      },
-    ],
-    complete: [
-      {
-        id: 1,
-        title: "Fix memory leak in event listeners",
-        time: "20 days ago",
-        project: "React",
-        tag: "bug",
-        tagType: "bug" as const,
-      },
-      {
-        id: 2,
-        title: "Implement caching layer",
-        time: "10 days ago",
-        project: "Next.js",
-        tag: "enhancement",
-        tagType: "enhancement" as const,
-      },
-      {
-        id: 3,
-        title: "Code review API reflections",
-        time: "12 days ago",
-        project: "Modus",
-        tag: "enhancement",
-        tagType: "enhancement" as const,
-      },
-    ],
-  };
+  const fetchContributions = useCallback(() => {
+    setState({ status: "loading" });
+    getProfileContributions()
+      .then((response) => {
+        setState({
+          status: "ok",
+          contributions: (response.contributions || []).map(normalizeContribution),
+        });
+      })
+      .catch(() => setState({ status: "error" }));
+  }, []);
+
+  useEffect(() => {
+    fetchContributions();
+  }, [fetchContributions]);
+
+  const allContributions = useMemo(
+    () => (state.status === "ok" ? state.contributions : []),
+    [state],
+  );
+
+  const projectOptions = useMemo(
+    () =>
+      Array.from(new Set(allContributions.map((item) => item.project)))
+        .filter((project) => project !== fallbackProject)
+        .filter((project) => isProjectMatch(project, projectSearchQuery))
+        .sort((a, b) => a.localeCompare(b)),
+    [allContributions, projectSearchQuery],
+  );
+
+  const visibleContributions = useMemo(() => {
+    const normalizedSearch = searchQuery.trim().toLowerCase();
+
+    return allContributions.filter((item) => {
+      const matchesProject = selectedProject
+        ? item.project === selectedProject
+        : true;
+      const matchesReward = selectedRewards.includes(item.rewardFilter);
+      const matchesSearch = normalizedSearch
+        ? [item.title, item.project, item.tag, item.contributor].some((value) =>
+            value.toLowerCase().includes(normalizedSearch),
+          )
+        : true;
+
+      return matchesProject && matchesReward && matchesSearch;
+    });
+  }, [allContributions, searchQuery, selectedProject, selectedRewards]);
+
+  const groupedContributions = useMemo(
+    () => groupContributions(visibleContributions),
+    [visibleContributions],
+  );
 
   return (
     <>
       <div className="space-y-4">
-        {/* Filter and Search Bar */}
         <div className="flex items-center gap-2 sm:gap-3">
-          {/* Filter Button */}
           <button
+            type="button"
+            aria-label="Filter contributions"
             onClick={() => setIsFilterOpen(true)}
             className={`h-10 sm:h-12 flex-shrink-0 w-10 sm:w-12 flex items-center justify-center rounded-[12px] backdrop-blur-[30px] bg-white/[0.15] border border-white/25 hover:bg-white/[0.2] hover:border-[#c9983a]/40 transition-all ${
               theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"
@@ -145,7 +516,6 @@ export function ContributionsTab() {
             <Filter className="w-5 h-5" />
           </button>
 
-          {/* Search Bar */}
           <div className="relative flex-1">
             <Search
               className={`absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 z-10 transition-colors ${
@@ -154,6 +524,8 @@ export function ContributionsTab() {
             />
             <input
               type="text"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Search"
               className={`w-full pl-12 pr-4 py-2.5 sm:py-3 rounded-[12px] backdrop-blur-[30px] bg-white/[0.15] border border-white/25 focus:outline-none focus:bg-white/[0.2] focus:border-[#c9983a]/40 transition-all text-[13px] ${
                 theme === "dark"
@@ -164,673 +536,38 @@ export function ContributionsTab() {
           </div>
         </div>
 
-        {/* Desktop Kanban Board - Hidden on Mobile */}
-        <div className="hidden md:block overflow-x-auto scrollbar-hide">
-          <div className="flex gap-5 min-w-max pb-4">
-            {/* Applied Column */}
-            <div className="w-[320px] flex-shrink-0">
-              <div
-                className={`backdrop-blur-[30px] rounded-[16px] border p-5 transition-colors ${
-                  theme === "dark"
-                    ? "bg-white/[0.08] border-white/10"
-                    : "bg-white/[0.15] border-white/25"
-                }`}
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <h3
-                    className={`text-[16px] font-bold transition-colors ${
-                      theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                    }`}
-                  >
-                    Applied{" "}
-                    <span
-                      className={
-                        theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                      }
-                    >
-                      3
-                    </span>
-                  </h3>
-                </div>
-                <div className="space-y-3">
-                  {contributions.applied.map((item) => (
-                    <div
-                      key={item.id}
-                      className={`rounded-[12px] border p-4 transition-all ${
-                        theme === "dark"
-                          ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                          : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between mb-3">
-                        <h4
-                          className={`text-[14px] font-semibold flex-1 pr-2 transition-colors ${
-                            theme === "dark"
-                              ? "text-[#f5f5f5]"
-                              : "text-[#2d2820]"
-                          }`}
-                        >
-                          {item.title}
-                        </h4>
-                        <span className="px-2 py-0.5 bg-green-500/20 border border-green-600/30 rounded-[6px] text-[10px] font-semibold text-green-800">
-                          {item.badge}
-                        </span>
-                      </div>
-                      <div
-                        className={`flex items-center space-x-2 mb-3 text-[12px] transition-colors ${
-                          theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                        }`}
-                      >
-                        <Clock className="w-3.5 h-3.5" />
-                        <span>{item.time}</span>
-                      </div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-purple-500 to-pink-500" />
-                        <span
-                          className={`text-[12px] transition-colors ${
-                            theme === "dark"
-                              ? "text-[#d4d4d4]"
-                              : "text-[#7a6b5a]"
-                          }`}
-                        >
-                          {item.contributor}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <span
-                          className={`px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
-                            theme === "dark"
-                              ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                              : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                          }`}
-                        >
-                          {item.tag}
-                        </span>
-                        <button className="text-[12px] text-[#c9983a] hover:text-[#a67c2e] font-medium flex items-center space-x-1">
-                          <span>See application</span>
-                          <GitFork className="w-3 h-3" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Assigned Issue Column */}
-            <div className="w-[320px] flex-shrink-0">
-              <div
-                className={`backdrop-blur-[30px] rounded-[16px] border p-5 transition-colors ${
-                  theme === "dark"
-                    ? "bg-white/[0.08] border-white/10"
-                    : "bg-white/[0.15] border-white/25"
-                }`}
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <h3
-                    className={`text-[16px] font-bold transition-colors ${
-                      theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                    }`}
-                  >
-                    Assigned issue{" "}
-                    <span
-                      className={
-                        theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                      }
-                    >
-                      2
-                    </span>
-                  </h3>
-                </div>
-                <div className="space-y-3">
-                  {contributions.assigned.map((item) => (
-                    <div
-                      key={item.id}
-                      className={`rounded-[12px] border p-4 transition-all ${
-                        theme === "dark"
-                          ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                          : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between mb-3">
-                        <h4
-                          className={`text-[14px] font-semibold flex-1 pr-2 transition-colors ${
-                            theme === "dark"
-                              ? "text-[#f5f5f5]"
-                              : "text-[#2d2820]"
-                          }`}
-                        >
-                          {item.title}
-                        </h4>
-                        <span className="px-2 py-0.5 bg-green-500/20 border border-green-600/30 rounded-[6px] text-[10px] font-semibold text-green-800">
-                          {item.badge}
-                        </span>
-                      </div>
-                      <div
-                        className={`flex items-center space-x-2 mb-3 text-[12px] transition-colors ${
-                          theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                        }`}
-                      >
-                        <Clock className="w-3.5 h-3.5" />
-                        <span>{item.time}</span>
-                      </div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-blue-500 to-cyan-500" />
-                        <span
-                          className={`text-[12px] transition-colors ${
-                            theme === "dark"
-                              ? "text-[#d4d4d4]"
-                              : "text-[#7a6b5a]"
-                          }`}
-                        >
-                          {item.project}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <span
-                          className={`px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
-                            theme === "dark"
-                              ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                              : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                          }`}
-                        >
-                          {item.tag}
-                        </span>
-                        <button className="text-[12px] text-[#c9983a] hover:text-[#a67c2e] font-medium flex items-center space-x-1">
-                          <span>See application</span>
-                          <GitFork className="w-3 h-3" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Pending Review Column */}
-            <div className="w-[320px] flex-shrink-0">
-              <div
-                className={`backdrop-blur-[30px] rounded-[16px] border p-5 transition-colors ${
-                  theme === "dark"
-                    ? "bg-white/[0.08] border-white/10"
-                    : "bg-white/[0.15] border-white/25"
-                }`}
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <h3
-                    className={`text-[16px] font-bold transition-colors ${
-                      theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                    }`}
-                  >
-                    Pending review{" "}
-                    <span
-                      className={
-                        theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                      }
-                    >
-                      3
-                    </span>
-                  </h3>
-                </div>
-                <div className="space-y-3">
-                  {contributions.pending.map((item) => (
-                    <div
-                      key={item.id}
-                      className={`rounded-[12px] border p-4 transition-all ${
-                        theme === "dark"
-                          ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                          : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between mb-3">
-                        <h4
-                          className={`text-[14px] font-semibold flex-1 pr-2 transition-colors ${
-                            theme === "dark"
-                              ? "text-[#f5f5f5]"
-                              : "text-[#2d2820]"
-                          }`}
-                        >
-                          {item.title}
-                        </h4>
-                        <span className="px-2 py-0.5 bg-purple-500/20 border border-purple-600/30 rounded-[6px] text-[10px] font-semibold text-purple-800">
-                          {item.badge}
-                        </span>
-                      </div>
-                      <div
-                        className={`flex items-center space-x-2 mb-3 text-[12px] transition-colors ${
-                          theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                        }`}
-                      >
-                        <Clock className="w-3.5 h-3.5" />
-                        <span>{item.time}</span>
-                      </div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-green-500 to-emerald-500" />
-                        <span
-                          className={`text-[12px] transition-colors ${
-                            theme === "dark"
-                              ? "text-[#d4d4d4]"
-                              : "text-[#7a6b5a]"
-                          }`}
-                        >
-                          {item.project}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <span
-                          className={`px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
-                            theme === "dark"
-                              ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                              : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                          }`}
-                        >
-                          {item.tag}
-                        </span>
-                        <button className="text-[12px] text-[#c9983a] hover:text-[#a67c2e] font-medium flex items-center space-x-1">
-                          <span>See detail</span>
-                          <Star className="w-3 h-3" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Complete Column */}
-            <div className="w-[320px] flex-shrink-0">
-              <div
-                className={`backdrop-blur-[30px] rounded-[16px] border p-5 transition-colors ${
-                  theme === "dark"
-                    ? "bg-white/[0.08] border-white/10"
-                    : "bg-white/[0.15] border-white/25"
-                }`}
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <h3
-                    className={`text-[16px] font-bold transition-colors ${
-                      theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                    }`}
-                  >
-                    Complete{" "}
-                    <span
-                      className={
-                        theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                      }
-                    >
-                      3
-                    </span>
-                  </h3>
-                </div>
-                <div className="space-y-3">
-                  {contributions.complete.map((item) => (
-                    <div
-                      key={item.id}
-                      className={`rounded-[12px] border p-4 transition-all ${
-                        theme === "dark"
-                          ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                          : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between mb-3">
-                        <h4
-                          className={`text-[14px] font-semibold flex-1 pr-2 transition-colors ${
-                            theme === "dark"
-                              ? "text-[#f5f5f5]"
-                              : "text-[#2d2820]"
-                          }`}
-                        >
-                          {item.title}
-                        </h4>
-                      </div>
-                      <div
-                        className={`flex items-center space-x-2 mb-3 text-[12px] transition-colors ${
-                          theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                        }`}
-                      >
-                        <Clock className="w-3.5 h-3.5" />
-                        <span>{item.time}</span>
-                      </div>
-                      <div className="flex items-center space-x-2 mb-3">
-                        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-orange-500 to-red-500" />
-                        <span
-                          className={`text-[12px] transition-colors ${
-                            theme === "dark"
-                              ? "text-[#d4d4d4]"
-                              : "text-[#7a6b5a]"
-                          }`}
-                        >
-                          {item.project}
-                        </span>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <span
-                          className={`px-2 py-1 rounded-[6px] text-[11px] font-medium transition-colors ${
-                            item.tagType === "bug"
-                              ? "bg-red-500/15 border border-red-600/25 text-red-800"
-                              : theme === "dark"
-                                ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                                : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                          }`}
-                        >
-                          {item.tag}
-                        </span>
-                        <button className="text-[12px] text-[#c9983a] hover:text-[#a67c2e] font-medium flex items-center space-x-1">
-                          <span>See detail</span>
-                          <Star className="w-3 h-3" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
+        {state.status === "loading" ? (
+          <ContributionSkeleton />
+        ) : state.status === "error" ? (
+          <ContributionError theme={theme} onRetry={fetchContributions} />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-5">
+            {contributionColumns.map((column) => (
+              <ContributionColumn
+                key={column.key}
+                column={column}
+                items={groupedContributions[column.key]}
+                theme={theme}
+              />
+            ))}
           </div>
-        </div>
-
-        {/* Mobile Vertical Layout - Hidden on Desktop */}
-        <div className="md:hidden space-y-4">
-          {/* Applied Section */}
-          <div
-            className={`backdrop-blur-[30px] rounded-[16px] border p-4 transition-colors ${
-              theme === "dark"
-                ? "bg-white/[0.08] border-white/10"
-                : "bg-white/[0.15] border-white/25"
-            }`}
-          >
-            <h3
-              className={`text-[15px] font-bold mb-3 transition-colors ${
-                theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-              }`}
-            >
-              Applied{" "}
-              <span
-                className={
-                  theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                }
-              >
-                ({contributions.applied.length})
-              </span>
-            </h3>
-            <div className="space-y-2">
-              {contributions.applied.map((item) => (
-                <div
-                  key={item.id}
-                  className={`rounded-[10px] border p-3 transition-all ${
-                    theme === "dark"
-                      ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                      : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <h4
-                      className={`text-[13px] font-semibold flex-1 transition-colors ${
-                        theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                      }`}
-                    >
-                      {item.title}
-                    </h4>
-                    <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-600/30 rounded-[4px] text-[9px] font-semibold text-green-800 flex-shrink-0">
-                      {item.badge}
-                    </span>
-                  </div>
-                  <div
-                    className={`flex items-center space-x-1.5 mb-2 text-[11px] transition-colors ${
-                      theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                    }`}
-                  >
-                    <Clock className="w-3 h-3" />
-                    <span>{item.time}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <span
-                      className={`px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium transition-colors ${
-                        theme === "dark"
-                          ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                          : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                      }`}
-                    >
-                      {item.tag}
-                    </span>
-                  </div>
-                  <button className="text-[11px] text-[#c9983a] hover:text-[#a67c2e] font-medium w-full py-1.5">
-                    See application
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Assigned Issue Section */}
-          <div
-            className={`backdrop-blur-[30px] rounded-[16px] border p-4 transition-colors ${
-              theme === "dark"
-                ? "bg-white/[0.08] border-white/10"
-                : "bg-white/[0.15] border-white/25"
-            }`}
-          >
-            <h3
-              className={`text-[15px] font-bold mb-3 transition-colors ${
-                theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-              }`}
-            >
-              Assigned issue{" "}
-              <span
-                className={
-                  theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                }
-              >
-                ({contributions.assigned.length})
-              </span>
-            </h3>
-            <div className="space-y-2">
-              {contributions.assigned.map((item) => (
-                <div
-                  key={item.id}
-                  className={`rounded-[10px] border p-3 transition-all ${
-                    theme === "dark"
-                      ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                      : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <h4
-                      className={`text-[13px] font-semibold flex-1 transition-colors ${
-                        theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                      }`}
-                    >
-                      {item.title}
-                    </h4>
-                    <span className="px-1.5 py-0.5 bg-green-500/20 border border-green-600/30 rounded-[4px] text-[9px] font-semibold text-green-800 flex-shrink-0">
-                      {item.badge}
-                    </span>
-                  </div>
-                  <div
-                    className={`flex items-center space-x-1.5 mb-2 text-[11px] transition-colors ${
-                      theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                    }`}
-                  >
-                    <Clock className="w-3 h-3" />
-                    <span>{item.time}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <span
-                      className={`px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium transition-colors ${
-                        theme === "dark"
-                          ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                          : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                      }`}
-                    >
-                      {item.tag}
-                    </span>
-                  </div>
-                  <button className="text-[11px] text-[#c9983a] hover:text-[#a67c2e] font-medium w-full py-1.5">
-                    See application
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Pending Review Section */}
-          <div
-            className={`backdrop-blur-[30px] rounded-[16px] border p-4 transition-colors ${
-              theme === "dark"
-                ? "bg-white/[0.08] border-white/10"
-                : "bg-white/[0.15] border-white/25"
-            }`}
-          >
-            <h3
-              className={`text-[15px] font-bold mb-3 transition-colors ${
-                theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-              }`}
-            >
-              Pending review{" "}
-              <span
-                className={
-                  theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                }
-              >
-                ({contributions.pending.length})
-              </span>
-            </h3>
-            <div className="space-y-2">
-              {contributions.pending.map((item) => (
-                <div
-                  key={item.id}
-                  className={`rounded-[10px] border p-3 transition-all ${
-                    theme === "dark"
-                      ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                      : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <h4
-                      className={`text-[13px] font-semibold flex-1 transition-colors ${
-                        theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                      }`}
-                    >
-                      {item.title}
-                    </h4>
-                    <span className="px-1.5 py-0.5 bg-purple-500/20 border border-purple-600/30 rounded-[4px] text-[9px] font-semibold text-purple-800 flex-shrink-0">
-                      {item.badge}
-                    </span>
-                  </div>
-                  <div
-                    className={`flex items-center space-x-1.5 mb-2 text-[11px] transition-colors ${
-                      theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                    }`}
-                  >
-                    <Clock className="w-3 h-3" />
-                    <span>{item.time}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <span
-                      className={`px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium transition-colors ${
-                        theme === "dark"
-                          ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                          : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                      }`}
-                    >
-                      {item.tag}
-                    </span>
-                  </div>
-                  <button className="text-[11px] text-[#c9983a] hover:text-[#a67c2e] font-medium w-full py-1.5">
-                    See detail
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Complete Section */}
-          <div
-            className={`backdrop-blur-[30px] rounded-[16px] border p-4 transition-colors ${
-              theme === "dark"
-                ? "bg-white/[0.08] border-white/10"
-                : "bg-white/[0.15] border-white/25"
-            }`}
-          >
-            <h3
-              className={`text-[15px] font-bold mb-3 transition-colors ${
-                theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-              }`}
-            >
-              Complete{" "}
-              <span
-                className={
-                  theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                }
-              >
-                ({contributions.complete.length})
-              </span>
-            </h3>
-            <div className="space-y-2">
-              {contributions.complete.map((item) => (
-                <div
-                  key={item.id}
-                  className={`rounded-[10px] border p-3 transition-all ${
-                    theme === "dark"
-                      ? "bg-white/[0.08] border-white/15 hover:border-white/25"
-                      : "bg-white/[0.2] border-white/30 hover:border-white/40"
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <h4
-                      className={`text-[13px] font-semibold flex-1 transition-colors ${
-                        theme === "dark" ? "text-[#f5f5f5]" : "text-[#2d2820]"
-                      }`}
-                    >
-                      {item.title}
-                    </h4>
-                    <Check className="w-4 h-4 text-green-600 flex-shrink-0" />
-                  </div>
-                  <div
-                    className={`flex items-center space-x-1.5 mb-2 text-[11px] transition-colors ${
-                      theme === "dark" ? "text-[#d4d4d4]" : "text-[#7a6b5a]"
-                    }`}
-                  >
-                    <Clock className="w-3 h-3" />
-                    <span>{item.time}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <span
-                      className={`px-1.5 py-0.5 rounded-[4px] text-[10px] font-medium transition-colors ${
-                        item.tagType === "bug"
-                          ? "bg-red-500/15 border border-red-600/25 text-red-800"
-                          : theme === "dark"
-                            ? "bg-[#c9983a]/20 border border-[#c9983a]/30 text-[#f5c563]"
-                            : "bg-[#c9983a]/15 border border-[#c9983a]/25 text-[#8b6f3a]"
-                      }`}
-                    >
-                      {item.tag}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+        )}
       </div>
 
-      {/* Filter Modal */}
       {isFilterOpen && (
         <>
-          {/* Backdrop */}
           <div
             className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[50] transition-opacity"
             onClick={() => setIsFilterOpen(false)}
           />
 
-          {/* Filter Panel */}
           <div
-            className={`fixed top-0 right-0 h-full w-[400px] backdrop-blur-[40px] border-l z-[60] shadow-[0_0_40px_rgba(0,0,0,0.15)] p-6 flex flex-col animate-slide-in-right transition-colors ${
+            className={`fixed top-0 right-0 h-full w-[min(400px,100vw)] backdrop-blur-[40px] border-l z-[60] shadow-[0_0_40px_rgba(0,0,0,0.15)] p-6 flex flex-col animate-slide-in-right transition-colors ${
               theme === "dark"
                 ? "bg-[#2d2820]/95 border-white/10 text-[#f5efe5]"
                 : "bg-[#e5ddd1]/95 border-white/30 text-[#2d2820]"
             }`}
           >
-            {/* Header */}
             <div className="flex items-center justify-between mb-6">
               <h2
                 className={`text-[18px] font-bold ${
@@ -840,6 +577,8 @@ export function ContributionsTab() {
                 Filter contributions
               </h2>
               <button
+                type="button"
+                aria-label="Close filter"
                 onClick={() => setIsFilterOpen(false)}
                 className={`w-8 h-8 flex items-center justify-center rounded-lg transition-all ${
                   theme === "dark"
@@ -855,11 +594,10 @@ export function ContributionsTab() {
               </button>
             </div>
 
-            {/* Filter Content */}
             <div className="flex-1 space-y-5 overflow-y-auto scrollbar-hide">
-              {/* Projects Section */}
               <div>
                 <button
+                  type="button"
                   onClick={() => setIsProjectSectionOpen(!isProjectSectionOpen)}
                   className="w-full flex items-center justify-between mb-3"
                 >
@@ -872,6 +610,11 @@ export function ContributionsTab() {
                     >
                       Projects
                     </span>
+                    {selectedProject && (
+                      <span className="px-2 py-0.5 bg-[#c9983a] text-white text-[11px] font-semibold rounded-full">
+                        1
+                      </span>
+                    )}
                   </div>
                   <ChevronDown
                     className={`w-5 h-5 transition-transform ${isProjectSectionOpen ? "rotate-180" : ""} ${
@@ -882,7 +625,6 @@ export function ContributionsTab() {
 
                 {isProjectSectionOpen && (
                   <div className="space-y-3">
-                    {/* Search Field */}
                     <div className="relative">
                       <Search
                         className={`absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 ${
@@ -891,7 +633,11 @@ export function ContributionsTab() {
                       />
                       <input
                         type="text"
-                        placeholder="Search"
+                        value={projectSearchQuery}
+                        onChange={(event) =>
+                          setProjectSearchQuery(event.target.value)
+                        }
+                        placeholder="Search projects"
                         className={`w-full pl-10 pr-4 py-3 rounded-[12px] backdrop-blur-[30px] border transition-all text-[13px] focus:outline-none focus:border-[#c9983a]/40 ${
                           theme === "dark"
                             ? "bg-white/[0.05] border-white/10 text-[#f5efe5] placeholder-[#b8a898] focus:bg-white/[0.1]"
@@ -900,27 +646,53 @@ export function ContributionsTab() {
                       />
                     </div>
 
-                    {/* Results Section */}
                     <div
-                      className={`backdrop-blur-[20px] rounded-[12px] border p-4 ${
+                      className={`backdrop-blur-[20px] rounded-[12px] border p-3 space-y-2 ${
                         theme === "dark"
                           ? "bg-white/[0.05] border-white/10"
                           : "bg-white/[0.1] border-white/20"
                       }`}
                     >
-                      <p
-                        className={`text-[12px] text-center ${theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}
-                      >
-                        No items found
-                      </p>
+                      {projectOptions.length > 0 ? (
+                        projectOptions.map((project) => (
+                          <button
+                            key={project}
+                            type="button"
+                            aria-pressed={selectedProject === project}
+                            onClick={() =>
+                              setSelectedProject(
+                                selectedProject === project ? "" : project,
+                              )
+                            }
+                            className={`w-full px-4 py-3 rounded-[12px] text-left text-[13px] font-medium transition-all flex items-center justify-between ${
+                              selectedProject === project
+                                ? "bg-[#c9983a] text-white shadow-[0_4px_12px_rgba(201,152,58,0.3)]"
+                                : theme === "dark"
+                                  ? "bg-white/[0.05] border border-white/10 text-[#f5efe5] hover:bg-white/[0.1]"
+                                  : "bg-white/[0.1] border border-white/20 text-[#2d2820] hover:bg-white/[0.15]"
+                            }`}
+                          >
+                            <span>{project}</span>
+                            {selectedProject === project && (
+                              <Check className="w-4 h-4" />
+                            )}
+                          </button>
+                        ))
+                      ) : (
+                        <p
+                          className={`text-[12px] text-center py-2 ${theme === "dark" ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}
+                        >
+                          No items found
+                        </p>
+                      )}
                     </div>
                   </div>
                 )}
               </div>
 
-              {/* Rewarded Section */}
               <div>
                 <button
+                  type="button"
                   onClick={() =>
                     setIsRewardedSectionOpen(!isRewardedSectionOpen)
                   }
@@ -948,7 +720,6 @@ export function ContributionsTab() {
 
                 {isRewardedSectionOpen && (
                   <div className="space-y-2">
-                    {/* Main Dropdown showing current selection */}
                     <div
                       className={`px-4 py-3 rounded-[12px] backdrop-blur-[30px] border ${
                         theme === "dark"
@@ -959,19 +730,21 @@ export function ContributionsTab() {
                       <span
                         className={`text-[13px] ${theme === "dark" ? "text-[#f5efe5]" : "text-[#2d2820]"}`}
                       >
-                        {selectedRewards.join(", ")}
+                        {selectedRewards.length > 0
+                          ? selectedRewards.join(", ")
+                          : "No reward filters selected"}
                       </span>
                     </div>
 
-                    {/* Options List */}
                     <div className="space-y-1">
-                      {["Rewarded", "Unrewarded"].map((reward) => (
+                      {rewardOptions.map((reward) => (
                         <button
                           key={reward}
+                          type="button"
                           onClick={() => {
                             if (selectedRewards.includes(reward)) {
                               setSelectedRewards(
-                                selectedRewards.filter((r) => r !== reward),
+                                selectedRewards.filter((item) => item !== reward),
                               );
                             } else {
                               setSelectedRewards([...selectedRewards, reward]);
@@ -997,16 +770,17 @@ export function ContributionsTab() {
               </div>
             </div>
 
-            {/* Footer Buttons */}
             <div
               className={`flex items-center gap-3 mt-6 pt-6 border-t ${
                 theme === "dark" ? "border-white/10" : "border-white/20"
               }`}
             >
               <button
+                type="button"
                 onClick={() => {
                   setSelectedProject("");
-                  setSelectedRewards(["Rewarded", "Unrewarded"]);
+                  setProjectSearchQuery("");
+                  setSelectedRewards(rewardOptions);
                 }}
                 className={`flex-1 px-4 py-3 rounded-[12px] backdrop-blur-[30px] border text-[13px] font-semibold transition-all ${
                   theme === "dark"
@@ -1017,6 +791,7 @@ export function ContributionsTab() {
                 Reset
               </button>
               <button
+                type="button"
                 onClick={() => setIsFilterOpen(false)}
                 className="flex-1 px-4 py-3 rounded-[12px] bg-[#c9983a] text-white text-[13px] font-semibold shadow-[0_4px_12px_rgba(201,152,58,0.3)] hover:shadow-[0_6px_16px_rgba(201,152,58,0.4)] transition-all"
               >

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -289,6 +289,45 @@ export type ProfileReward = {
 export const getProfileRewards = () =>
   apiRequest<{ rewards: ProfileReward[] }>('/profile/rewards', { requiresAuth: true })
 
+export type ProfileContribution = {
+  id: string | number
+  title?: string | null
+  status?: string | null
+  project_name?: string | null
+  project?: string | null
+  repository?: string | null
+  github_full_name?: string | null
+  contributor_login?: string | null
+  author_login?: string | null
+  badge?: string | number | null
+  issue_number?: number | null
+  number?: number | null
+  tag?: string | null
+  label?: string | null
+  labels?: Array<string | { name?: string | null }> | null
+  url?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+  submitted_at?: string | null
+  merged_at?: string | null
+  rewarded?: boolean | null
+  is_rewarded?: boolean | null
+  reward_status?: string | null
+  amount?: number | string | null
+}
+
+/**
+ * Fetches the authenticated contributor's board items.
+ *
+ * @returns API contribution rows for the Applied, Assigned, Pending Review,
+ * and Complete board. The UI normalizes nullable fields before rendering so
+ * repository-supplied text is displayed as escaped React text, never HTML.
+ */
+export const getProfileContributions = () =>
+  apiRequest<{ contributions: ProfileContribution[] }>('/profile/contributions', {
+    requiresAuth: true,
+  })
+
 export const getProjectsContributed = (userId?: string, login?: string) => {
   const params = new URLSearchParams()
   if (userId) params.append('user_id', userId)


### PR DESCRIPTION
## Summary
- Replace the hardcoded `ContributionsTab` board data with authenticated API-backed contribution loading.
- Normalize contribution rows, group them into Applied, Assigned, Pending Review, and Complete columns, and wire the project filter/search to the visible cards.
- Add loading skeletons, per-column empty states, a global error state with retry, and focused tests for grouping, filtering, retry, empty states, coverage, and title escaping.

Closes #165.

## Security notes
- Repository/API-supplied contribution titles, projects, labels, and contributor names are rendered as React text nodes.
- No `dangerouslySetInnerHTML` is used.
- Added a regression test that renders `<img src=x onerror=alert(1)>` as escaped text and verifies no injected image node is created.

## Validation
- `npm test -- src/features/dashboard/components/ContributionsTab.test.tsx`
  - 1 test file passed
  - 10 tests passed
- `npm run test:coverage -- src/features/dashboard/components/ContributionsTab.test.tsx`
  - 1 test file passed
  - 10 tests passed
  - Coverage summary: Statements 95%, Functions 96.36%, Lines 99.22%
  - `ContributionsTab.tsx`: Statements 96.66%, Functions 98.03%, Lines 99.11%
- `npx eslint src/features/dashboard/components/ContributionsTab.tsx src/features/dashboard/components/ContributionsTab.test.tsx`
  - Passed
- `git diff --check`
  - Passed

## Existing repository-wide validation blockers
- `npm run lint -- --quiet` currently fails on existing unrelated files:
  - `src/features/maintainers/components/InstallGitHubAppModal.test.tsx`: existing `@ts-ignore` rule violation
  - `src/features/settings/components/terms/TermsTab.tsx`: existing `console` rule violation
- `npm run typecheck` and `npm run build` currently fail because `src/app/utils/renderMarkdown.tsx` imports missing `rehype-sanitize`.
- `npm run test` currently reports 714 passing tests and 6 failing tests in `src/shared/hooks/useLandingStats.test.ts`, where the mocked `../i18n` module does not export `I18nProvider`.
