### PR TITLE
test(roleswitcher): coverage + ARIA grouping and keyboard nav

### DIFF
--- a/src/shared/components/RoleSwitcher.test.tsx
+++ b/src/shared/components/RoleSwitcher.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RoleSwitcher } from './RoleSwitcher';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+describe('RoleSwitcher Accessibility and Features', () => {
+  const defaultProps = {
+    currentRole: 'contributor' as const,
+    onRoleChange: vi.fn(),
+    showMobileNav: false,
+    isSmallDevice: false,
+    closeMobileNav: vi.fn(),
+  };
+
+  it('renders a labeled radiogroup container and radio buttons', () => {
+    renderWithTheme(<RoleSwitcher {...defaultProps} />);
+    
+    const group = screen.getByRole('radiogroup', { name: 'Role Switcher' });
+    expect(group).toBeInTheDocument();
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    
+    expect(screen.getByRole('radio', { name: /CONTRIBUTOR/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /MAINTAINER/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /ADMIN/i })).toBeInTheDocument();
+  });
+
+  it('sets correct aria-checked and tabIndex attributes on buttons', () => {
+    const { rerender } = renderWithTheme(<RoleSwitcher {...defaultProps} currentRole="contributor" />);
+
+    const contributorRadio = screen.getByRole('radio', { name: /CONTRIBUTOR/i });
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+    const adminRadio = screen.getByRole('radio', { name: /ADMIN/i });
+
+    expect(contributorRadio).toHaveAttribute('aria-checked', 'true');
+    expect(contributorRadio).toHaveAttribute('tabIndex', '0');
+
+    expect(maintainerRadio).toHaveAttribute('aria-checked', 'false');
+    expect(maintainerRadio).toHaveAttribute('tabIndex', '-1');
+
+    expect(adminRadio).toHaveAttribute('aria-checked', 'false');
+    expect(adminRadio).toHaveAttribute('tabIndex', '-1');
+
+    // Rerender with admin as active
+    rerender(<RoleSwitcher {...defaultProps} currentRole="admin" />);
+    expect(contributorRadio).toHaveAttribute('aria-checked', 'false');
+    expect(contributorRadio).toHaveAttribute('tabIndex', '-1');
+    expect(adminRadio).toHaveAttribute('aria-checked', 'true');
+    expect(adminRadio).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('supports click interactions to change role and close mobile nav', async () => {
+    const onRoleChange = vi.fn();
+    const closeMobileNav = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        onRoleChange={onRoleChange} 
+        closeMobileNav={closeMobileNav} 
+      />
+    );
+
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+    await user.click(maintainerRadio);
+
+    expect(onRoleChange).toHaveBeenCalledTimes(1);
+    expect(onRoleChange).toHaveBeenCalledWith('maintainer');
+    expect(closeMobileNav).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates options forward with ArrowRight and ArrowDown keys and wraps around', () => {
+    const onRoleChange = vi.fn();
+    const closeMobileNav = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="contributor"
+        onRoleChange={onRoleChange} 
+        closeMobileNav={closeMobileNav} 
+      />
+    );
+
+    const group = screen.getByRole('radiogroup');
+    const contributorRadio = screen.getByRole('radio', { name: /CONTRIBUTOR/i });
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+    const adminRadio = screen.getByRole('radio', { name: /ADMIN/i });
+
+    // Focus contributor first
+    contributorRadio.focus();
+    expect(contributorRadio).toHaveFocus();
+
+    // ArrowRight: contributor -> maintainer
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('maintainer');
+    expect(maintainerRadio).toHaveFocus();
+
+    // Mock parent component updating props
+    rerender(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="maintainer"
+        onRoleChange={onRoleChange} 
+        closeMobileNav={closeMobileNav} 
+      />
+    );
+
+    // ArrowDown: maintainer -> admin
+    fireEvent.keyDown(group, { key: 'ArrowDown' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('admin');
+    expect(adminRadio).toHaveFocus();
+
+    // Mock parent component updating props
+    rerender(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="admin"
+        onRoleChange={onRoleChange} 
+        closeMobileNav={closeMobileNav} 
+      />
+    );
+
+    // ArrowRight: admin -> contributor (wrap around)
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('contributor');
+    expect(contributorRadio).toHaveFocus();
+  });
+
+  it('navigates options backward with ArrowLeft and ArrowUp keys and wraps around', () => {
+    const onRoleChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="contributor"
+        onRoleChange={onRoleChange} 
+      />
+    );
+
+    const group = screen.getByRole('radiogroup');
+    const contributorRadio = screen.getByRole('radio', { name: /CONTRIBUTOR/i });
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+    const adminRadio = screen.getByRole('radio', { name: /ADMIN/i });
+
+    // Focus contributor first
+    contributorRadio.focus();
+
+    // ArrowLeft: contributor -> admin (wrap around)
+    fireEvent.keyDown(group, { key: 'ArrowLeft' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('admin');
+    expect(adminRadio).toHaveFocus();
+
+    // Mock parent updating to admin
+    rerender(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="admin"
+        onRoleChange={onRoleChange} 
+      />
+    );
+
+    // ArrowUp: admin -> maintainer
+    fireEvent.keyDown(group, { key: 'ArrowUp' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('maintainer');
+    expect(maintainerRadio).toHaveFocus();
+  });
+
+  it('supports availableRoles filtering and navigates within subset', () => {
+    const onRoleChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="contributor"
+        onRoleChange={onRoleChange}
+        availableRoles={['contributor', 'maintainer']}
+      />
+    );
+
+    // Contributor and Maintainer should exist, Admin should not
+    expect(screen.getByRole('radio', { name: /CONTRIBUTOR/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /MAINTAINER/i })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /ADMIN/i })).not.toBeInTheDocument();
+
+    const group = screen.getByRole('radiogroup');
+    const contributorRadio = screen.getByRole('radio', { name: /CONTRIBUTOR/i });
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+
+    contributorRadio.focus();
+
+    // ArrowRight: contributor -> maintainer
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('maintainer');
+    expect(maintainerRadio).toHaveFocus();
+
+    // Mock parent update
+    rerender(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="maintainer"
+        onRoleChange={onRoleChange}
+        availableRoles={['contributor', 'maintainer']}
+      />
+    );
+
+    // ArrowRight: maintainer -> contributor (wrap around)
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(onRoleChange).toHaveBeenLastCalledWith('contributor');
+    expect(contributorRadio).toHaveFocus();
+  });
+
+  it('renders lock badge on Admin with correct role and accessible labels', () => {
+    renderWithTheme(<RoleSwitcher {...defaultProps} />);
+
+    // Lock badge wrapper
+    const lockBadge = screen.getByRole('img', { name: 'Admin role locked' });
+    expect(lockBadge).toBeInTheDocument();
+
+    // Lock icon inside badge
+    const lockIcon = screen.getByLabelText('Locked');
+    expect(lockIcon).toBeInTheDocument();
+    expect(lockIcon).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('adds descriptive aria-label and aria-hidden="false" attributes to all role icons', () => {
+    renderWithTheme(<RoleSwitcher {...defaultProps} />);
+
+    const contributorIcon = screen.getByLabelText('contributor icon');
+    const maintainerIcon = screen.getByLabelText('maintainer icon');
+    const adminIcon = screen.getByLabelText('admin icon');
+
+    expect(contributorIcon).toBeInTheDocument();
+    expect(contributorIcon).toHaveAttribute('aria-hidden', 'false');
+    
+    expect(maintainerIcon).toBeInTheDocument();
+    expect(maintainerIcon).toHaveAttribute('aria-hidden', 'false');
+
+    expect(adminIcon).toBeInTheDocument();
+    expect(adminIcon).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('handles tabIndex when currentRole is not found in visible roles list', () => {
+    renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="admin" 
+        availableRoles={['contributor', 'maintainer']} 
+      />
+    );
+
+    const contributorRadio = screen.getByRole('radio', { name: /CONTRIBUTOR/i });
+    const maintainerRadio = screen.getByRole('radio', { name: /MAINTAINER/i });
+
+    // Since 'admin' is currentRole but not in availableRoles, the first role (contributor) should get tabIndex=0
+    expect(contributorRadio).toHaveAttribute('tabIndex', '0');
+    expect(maintainerRadio).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('handles arrow key navigation when currentRole is not in the visible roles list', () => {
+    const onRoleChange = vi.fn();
+
+    renderWithTheme(
+      <RoleSwitcher 
+        {...defaultProps} 
+        currentRole="admin" 
+        availableRoles={['contributor', 'maintainer']}
+        onRoleChange={onRoleChange}
+      />
+    );
+
+    const group = screen.getByRole('radiogroup');
+
+    // ArrowRight should focus and select the first visible role (contributor)
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(onRoleChange).toHaveBeenCalledWith('contributor');
+  });
+
+  it('hides component on large nav when showMobileNav is false', () => {
+    renderWithTheme(<RoleSwitcher {...defaultProps} showMobileNav={false} />);
+    const group = screen.getByRole('radiogroup');
+    expect(group.className).toContain('hidden lg:inline-flex');
+  });
+
+  it('shows component when showMobileNav is true', () => {
+    renderWithTheme(<RoleSwitcher {...defaultProps} showMobileNav={true} />);
+    const group = screen.getByRole('radiogroup');
+    expect(group.className).toContain('inline-flex');
+  });
+});

--- a/src/shared/components/RoleSwitcher.tsx
+++ b/src/shared/components/RoleSwitcher.tsx
@@ -1,20 +1,49 @@
+import { useRef } from 'react';
 import { Shield, Users, Code, Lock } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 
-type RoleSwitcherRole = 'contributor' | 'maintainer' | 'admin';
+/**
+ * Valid roles that can be selected in the RoleSwitcher.
+ */
+export type RoleSwitcherRole = 'contributor' | 'maintainer' | 'admin';
 
+/**
+ * Properties for the RoleSwitcher component.
+ */
 interface RoleSwitcherProps {
+  /** The currently selected user role. */
   currentRole: RoleSwitcherRole;
+  /** Callback fired when a role selection changes. */
   onRoleChange: (role: RoleSwitcherRole) => void;
+  /** Flag showing whether mobile navigation view is open. */
   showMobileNav: boolean;
+  /** Flag indicating if the device is a small screen/mobile device. */
   isSmallDevice: boolean;
+  /** Callback to close the mobile navigation view. */
   closeMobileNav: () => void;
-  /** Subset of roles to display. Defaults to all three roles when omitted. */
+  /** Optional subset of roles to display. Defaults to all roles if omitted. */
   availableRoles?: RoleSwitcherRole[];
 }
 
-export function RoleSwitcher({ currentRole, onRoleChange, showMobileNav, closeMobileNav, availableRoles }: RoleSwitcherProps) {
+/**
+ * RoleSwitcher Component
+ * 
+ * Renders a segmented navigation control for switching between user roles. Uses `role="radiogroup"`
+ * for accessibility, supports Arrow Key navigation with auto-wrap, and provides explicit
+ * aria-labels for icons and badges.
+ * 
+ * @param props - The configuration props for RoleSwitcher.
+ * @returns A JSX element representing the RoleSwitcher.
+ */
+export function RoleSwitcher({
+  currentRole,
+  onRoleChange,
+  showMobileNav,
+  closeMobileNav,
+  availableRoles,
+}: RoleSwitcherProps) {
   const { theme } = useTheme();
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const allRoles = [
     { id: 'contributor' as const, label: 'CONTRIBUTOR', icon: Code },
@@ -26,8 +55,49 @@ export function RoleSwitcher({ currentRole, onRoleChange, showMobileNav, closeMo
     ? allRoles.filter((r) => availableRoles.includes(r.id))
     : allRoles;
 
+  const hasChecked = roles.some((r) => r.id === currentRole);
+
+  /**
+   * Handles keyboard navigation inside the radiogroup using arrow keys.
+   * Enables wrap-around selection and focus.
+   * 
+   * @param e - The keyboard event object.
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = roles.findIndex((r) => r.id === currentRole);
+    let nextIndex = currentIndex;
+
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (currentIndex === -1) {
+        nextIndex = 0;
+      } else {
+        nextIndex = (currentIndex + 1) % roles.length;
+      }
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (currentIndex === -1) {
+        nextIndex = roles.length - 1;
+      } else {
+        nextIndex = (currentIndex - 1 + roles.length) % roles.length;
+      }
+    }
+
+    if (nextIndex !== currentIndex && nextIndex >= 0 && nextIndex < roles.length) {
+      const nextRole = roles[nextIndex];
+      onRoleChange(nextRole.id);
+      closeMobileNav();
+      
+      // Schedule focus for screen-readers and visual consistency
+      buttonRefs.current[nextIndex]?.focus();
+    }
+  };
+
   return (
     <div 
+      role="radiogroup"
+      aria-label="Role Switcher"
+      onKeyDown={handleKeyDown}
       className={`w-[80%] lg:w-auto max-w-[800px] lg:max-w-none flex-col lg:flex-row gap-[8px] lg:gap-[2px] lg:h-[44px] items-start p-[2px] rounded-[10px] lg:rounded-[999px] shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ${
         theme === 'dark'
           ? 'bg-[#1a1612]'
@@ -41,11 +111,21 @@ export function RoleSwitcher({ currentRole, onRoleChange, showMobileNav, closeMo
         const isActive = currentRole === role.id;
         const isFirst = index === 0;
         const isLast = index === roles.length - 1;
+        const tabIndex = isActive || (!hasChecked && index === 0) ? 0 : -1;
         
         return (
           <button
             key={role.id}
-            onClick={() => {onRoleChange(role.id); closeMobileNav();}}
+            role="radio"
+            aria-checked={isActive}
+            tabIndex={tabIndex}
+            ref={(el) => {
+              buttonRefs.current[index] = el;
+            }}
+            onClick={() => {
+              onRoleChange(role.id);
+              closeMobileNav();
+            }}
             className={`h-[40px] relative shrink-0 w-full lg:w-[130px] px-3 ${
               isFirst ? 'rounded-bl-[10px] lg:rounded-bl-[20px] rounded-br-[4px] rounded-tl-[10px] lg:rounded-tl-[20px] rounded-tr-[4px] ' :
               isLast ? 'rounded-bl-[4px] rounded-br-[10px] lg:rounded-br-[20px] rounded-tl-[4px] rounded-tr-[10px] lg:rounded-tr-[20px]' :
@@ -68,9 +148,13 @@ export function RoleSwitcher({ currentRole, onRoleChange, showMobileNav, closeMo
                 ? 'text-[rgba(255,255,255,0.69)]'
                 : 'text-[rgba(45,40,32,0.75)]'
             }`}>
-              <Icon className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${
-                isActive ? '' : 'opacity-80'
-              }`} />
+              <Icon 
+                aria-label={`${role.id} icon`}
+                aria-hidden="false"
+                className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${
+                  isActive ? '' : 'opacity-80'
+                }`} 
+              />
               
               <span className={`text-[11px] font-medium leading-[0] tracking-wide ${
                 isActive ? 'text-shadow-[0px_1px_2px_rgba(0,0,0,0.3)]' : 'text-shadow-[0px_1px_0px_rgba(0,0,0,0.19)]'
@@ -81,8 +165,17 @@ export function RoleSwitcher({ currentRole, onRoleChange, showMobileNav, closeMo
 
             {/* Lock Badge for Admin - Restricted Access Indicator */}
             {role.id === 'admin' && (
-              <div className="absolute -top-2 -right-2 w-5 h-5 bg-gradient-to-br from-[#e8c571] to-[#c9983a] rounded-full shadow-[0_2px_8px_rgba(201,152,58,0.9),0_0_12px_rgba(201,152,58,0.7)] z-20 flex items-center justify-center border-[2px] border-white">
-                <Lock className="w-2.5 h-2.5 text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" strokeWidth={3} />
+              <div 
+                role="img"
+                aria-label="Admin role locked"
+                className="absolute -top-2 -right-2 w-5 h-5 bg-gradient-to-br from-[#e8c571] to-[#c9983a] rounded-full shadow-[0_2px_8px_rgba(201,152,58,0.9),0_0_12px_rgba(201,152,58,0.7)] z-20 flex items-center justify-center border-[2px] border-white"
+              >
+                <Lock 
+                  aria-label="Locked"
+                  aria-hidden="false"
+                  className="w-2.5 h-2.5 text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.6)]" 
+                  strokeWidth={3} 
+                />
               </div>
             )}
           </button>


### PR DESCRIPTION
Closes #174 


Implemented accessible ARIA grouping and keyboard navigation for the `RoleSwitcher` component as requested in #174.

### Changes Made
- Wrapped the buttons in a labeled `role="radiogroup"` container.
- Supported arrow-key navigation between roles (ArrowRight, ArrowDown, ArrowLeft, ArrowUp) with wrap-around capability.
- Added descriptive `aria-label` attributes to the role icons and the admin lock badge.
- Added comprehensive unit tests with >= 95% coverage, verifying selection and the admin-locked state.
- Added inline TSDoc documentation for components and props.

### Security Notes
- None. The changes are strictly UI/Accessibility improvements and introduce no security implications.

### Test Output
```text
 ✓ src/shared/components/RoleSwitcher.test.tsx (12 tests) 1914ms
 Test Files  1 passed (1)
      Tests  12 passed (12)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
All files          |   90.38 |    76.78 |      80 |   91.83 |
 components        |   97.22 |    85.41 |     100 |   97.05 |
  RoleSwitcher.tsx |   97.22 |    85.41 |     100 |   97.05 |
-------------------|---------|----------|---------|---------|
