### PR TITLE
Add keyboard navigation and ARIA roles to Dropdown

### DIFF
--- a/src/shared/components/ui/Dropdown.test.tsx
+++ b/src/shared/components/ui/Dropdown.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Dropdown } from './Dropdown'
+
+const themeState = vi.hoisted(() => ({ theme: 'light' as 'light' | 'dark' }))
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: themeState.theme,
+    toggleTheme: vi.fn(),
+    setThemeFromAnimation: vi.fn(),
+  }),
+}))
+
+const OPTIONS = [
+  { name: 'Frontend' },
+  { name: 'Backend' },
+  { name: 'Design' },
+  { name: 'Documentation' },
+]
+
+function DropdownHarness({
+  onToggle,
+  initialSelectedValues = ['Backend'],
+  renderOption,
+}: {
+  onToggle?: (value: string) => void
+  initialSelectedValues?: string[]
+  renderOption?: (option: (typeof OPTIONS)[number], isSelected: boolean) => ReactNode
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [searchValue, setSearchValue] = useState('')
+  const [selectedValues, setSelectedValues] = useState<string[]>(initialSelectedValues)
+
+  return (
+    <Dropdown
+      filterType="skills"
+      options={OPTIONS}
+      selectedValues={selectedValues}
+      onToggle={(value) => {
+        setSelectedValues((current) =>
+          current.includes(value)
+            ? current.filter((selected) => selected !== value)
+            : [...current, value]
+        )
+        onToggle?.(value)
+      }}
+      searchValue={searchValue}
+      onSearchChange={setSearchValue}
+      isOpen={isOpen}
+      onToggleOpen={() => setIsOpen((open) => !open)}
+      onClose={() => setIsOpen(false)}
+      renderOption={renderOption}
+    />
+  )
+}
+
+describe('Dropdown accessibility', () => {
+  beforeEach(() => {
+    themeState.theme = 'light'
+  })
+
+  it('exposes listbox state on the trigger', () => {
+    render(<DropdownHarness />)
+
+    const trigger = screen.getByRole('button', { name: /select skills/i })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-controls')
+  })
+
+  it('renders a labelled listbox with option selection semantics', async () => {
+    const user = userEvent.setup()
+    render(<DropdownHarness />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+
+    expect(screen.getByRole('listbox', { name: 'Select skills' })).toBeInTheDocument()
+    expect(screen.getAllByRole('option')).toHaveLength(OPTIONS.length)
+    expect(screen.getByRole('option', { name: 'Backend' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('option', { name: 'Frontend' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
+  it('moves from search to options with arrow keys and toggles with Enter', async () => {
+    const onToggle = vi.fn()
+    const user = userEvent.setup()
+    render(<DropdownHarness onToggle={onToggle} />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+    const search = screen.getByRole('searchbox', { name: 'Search skills' })
+    await waitFor(() => expect(search).toHaveFocus())
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Frontend' })).toHaveFocus())
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'Frontend' }), { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Backend' })).toHaveFocus())
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'Backend' }), { key: 'Enter' })
+
+    expect(onToggle).toHaveBeenCalledWith('Backend')
+    expect(screen.getByRole('listbox', { name: 'Select skills' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Backend' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
+  it('keeps keyboard navigation aligned with search filtering', async () => {
+    const onToggle = vi.fn()
+    const user = userEvent.setup()
+    render(<DropdownHarness onToggle={onToggle} />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+    const search = screen.getByRole('searchbox', { name: 'Search skills' })
+    await user.type(search, 'doc')
+
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Documentation' })).toHaveFocus())
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'Documentation' }), { key: 'Enter' })
+
+    expect(onToggle).toHaveBeenCalledWith('Documentation')
+  })
+
+  it('closes with Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<DropdownHarness />)
+    const trigger = screen.getByRole('button', { name: /select skills/i })
+
+    await user.click(trigger)
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+
+    fireEvent.keyDown(screen.getByRole('searchbox', { name: 'Search skills' }), {
+      key: 'Escape',
+    })
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it('opens from the trigger with arrow keys and supports Home and End navigation', async () => {
+    render(<DropdownHarness />)
+    const trigger = screen.getByRole('button', { name: /select skills/i })
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+
+    const search = screen.getByRole('searchbox', { name: 'Search skills' })
+    fireEvent.keyDown(search, { key: 'End' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Documentation' })).toHaveFocus())
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'Documentation' }), { key: 'Home' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Frontend' })).toHaveFocus())
+
+    fireEvent.keyDown(screen.getByRole('option', { name: 'Frontend' }), { key: 'ArrowUp' })
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Documentation' })).toHaveFocus())
+  })
+
+  it('keeps focus on search when arrowing through an empty result set', async () => {
+    const user = userEvent.setup()
+    render(<DropdownHarness />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+    const search = screen.getByRole('searchbox', { name: 'Search skills' })
+    await user.type(search, 'zzz')
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0)
+    expect(screen.getByText('No options found')).toBeInTheDocument()
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+
+    expect(search).toHaveFocus()
+  })
+
+  it('toggles an option on click and preserves the open listbox', async () => {
+    const onToggle = vi.fn()
+    const user = userEvent.setup()
+    render(<DropdownHarness onToggle={onToggle} />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+    await user.click(screen.getByRole('option', { name: 'Design' }))
+
+    expect(onToggle).toHaveBeenCalledWith('Design')
+    expect(screen.getByRole('listbox', { name: 'Select skills' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Design' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('closes from the close button and by clicking outside', async () => {
+    const user = userEvent.setup()
+    render(<DropdownHarness />)
+    const trigger = screen.getByRole('button', { name: /select skills/i })
+
+    await user.click(trigger)
+    await user.click(screen.getByRole('button', { name: 'Close skills dropdown' }))
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+    await waitFor(() => expect(trigger).toHaveFocus())
+
+    await user.click(trigger)
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+    fireEvent.mouseDown(document.body)
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+  })
+
+  it('supports custom option rendering without removing option semantics', async () => {
+    const user = userEvent.setup()
+    render(
+      <DropdownHarness
+        renderOption={(option, isSelected) => (
+          <span>
+            {option.name}
+            {isSelected ? ' selected' : ' available'}
+          </span>
+        )}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+
+    expect(screen.getByRole('option', { name: 'Backend selected' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(screen.getByRole('option', { name: 'Frontend available' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
+  it('keeps semantics in dark theme for selected and unselected states', async () => {
+    themeState.theme = 'dark'
+    const user = userEvent.setup()
+    render(<DropdownHarness initialSelectedValues={[]} />)
+
+    await user.click(screen.getByRole('button', { name: /select skills/i }))
+
+    expect(screen.getByRole('listbox', { name: 'Select skills' })).toHaveAttribute(
+      'aria-multiselectable',
+      'true'
+    )
+    expect(screen.getByRole('option', { name: 'Frontend' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+})

--- a/src/shared/components/ui/Dropdown.tsx
+++ b/src/shared/components/ui/Dropdown.tsx
@@ -1,25 +1,29 @@
-import { ChevronDown, Search, X } from 'lucide-react';
-import { useTheme } from '../../contexts/ThemeContext';
-import { useRef, useEffect, ReactNode } from 'react';
+import { ChevronDown, Search, X } from 'lucide-react'
+import { useTheme } from '../../contexts/ThemeContext'
+import { useRef, useEffect, ReactNode, KeyboardEvent, useId, useState } from 'react'
 
 interface DropdownOption {
-  name: string;
-  [key: string]: any;
+  name: string
+  [key: string]: unknown
 }
 
 interface DropdownProps {
-  filterType: string;
-  options: DropdownOption[];
-  selectedValues: string[];
-  onToggle: (value: string) => void;
-  searchValue: string;
-  onSearchChange: (value: string) => void;
-  isOpen: boolean;
-  onToggleOpen: () => void;
-  onClose: () => void;
-  renderOption?: (option: DropdownOption, isSelected: boolean) => ReactNode;
+  filterType: string
+  options: DropdownOption[]
+  selectedValues: string[]
+  onToggle: (value: string) => void
+  searchValue: string
+  onSearchChange: (value: string) => void
+  isOpen: boolean
+  onToggleOpen: () => void
+  onClose: () => void
+  renderOption?: (option: DropdownOption, isSelected: boolean) => ReactNode
 }
 
+/**
+ * Searchable multi-select dropdown with listbox semantics and keyboard support.
+ * Option labels are rendered as React text, so user-provided names are escaped by React.
+ */
 export function Dropdown({
   filterType,
   options,
@@ -30,70 +34,183 @@ export function Dropdown({
   isOpen,
   onToggleOpen,
   onClose,
-  renderOption
+  renderOption,
 }: DropdownProps) {
-  const { theme } = useTheme();
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { theme } = useTheme()
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const [activeOptionIndex, setActiveOptionIndex] = useState(-1)
+  const reactId = useId()
+  const listboxId = `${reactId}-listbox`
+  const headingId = `${reactId}-heading`
 
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        onClose();
+        onClose()
       }
-    };
+    }
 
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose])
 
   const filteredOptions = options.filter((option) =>
     option.name.toLowerCase().includes(searchValue.toLowerCase())
-  );
+  )
+
+  useEffect(() => {
+    optionRefs.current = optionRefs.current.slice(0, filteredOptions.length)
+    if (!isOpen) {
+      setActiveOptionIndex(-1)
+      return
+    }
+
+    setActiveOptionIndex((currentIndex) =>
+      currentIndex >= filteredOptions.length ? -1 : currentIndex
+    )
+  }, [filteredOptions.length, isOpen])
+
+  useEffect(() => {
+    if (isOpen) {
+      setActiveOptionIndex(-1)
+    }
+  }, [searchValue, isOpen])
+
+  const focusTrigger = () => {
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const closeAndRestoreFocus = () => {
+    onClose()
+    focusTrigger()
+  }
+
+  const focusOption = (index: number) => {
+    if (filteredOptions.length === 0) {
+      setActiveOptionIndex(-1)
+      return
+    }
+
+    const normalizedIndex = (index + filteredOptions.length) % filteredOptions.length
+    setActiveOptionIndex(normalizedIndex)
+    requestAnimationFrame(() => optionRefs.current[normalizedIndex]?.focus())
+  }
+
+  const handleKeyboardNavigation = (event: KeyboardEvent<HTMLElement>) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        event.stopPropagation()
+        focusOption(activeOptionIndex + 1)
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        event.stopPropagation()
+        focusOption(activeOptionIndex === -1 ? filteredOptions.length - 1 : activeOptionIndex - 1)
+        break
+      case 'Home':
+        event.preventDefault()
+        event.stopPropagation()
+        focusOption(0)
+        break
+      case 'End':
+        event.preventDefault()
+        event.stopPropagation()
+        focusOption(filteredOptions.length - 1)
+        break
+      case 'Escape':
+        event.preventDefault()
+        event.stopPropagation()
+        closeAndRestoreFocus()
+        break
+      default:
+        break
+    }
+  }
+
+  const handleOptionKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    option: DropdownOption,
+    index: number
+  ) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      event.stopPropagation()
+      setActiveOptionIndex(index)
+      onToggle(option.name)
+      return
+    }
+
+    handleKeyboardNavigation(event)
+  }
 
   return (
     <div ref={dropdownRef} className="relative">
       <button
+        ref={triggerRef}
         onClick={onToggleOpen}
+        onKeyDown={(event) => {
+          if (!isOpen && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+            event.preventDefault()
+            onToggleOpen()
+          }
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
         className={`px-4 py-2.5 border-[1.5px] rounded-[12px] text-[14px] transition-all flex items-center space-x-2 font-semibold hover:scale-105 shadow-md ${
           selectedValues.length > 0
             ? theme === 'dark'
               ? 'bg-[#a17932] border-[#c9983a] text-white'
               : 'bg-[#b8872f] border-[#a17932] text-white'
             : theme === 'dark'
-            ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4] hover:bg-white/[0.12] hover:text-[#f5f5f5] backdrop-blur-[30px]'
-            : 'bg-white/[0.15] border-white/25 text-[#6b5d4d] hover:bg-white/[0.2] hover:text-[#2d2820] backdrop-blur-[30px]'
+              ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4] hover:bg-white/[0.12] hover:text-[#f5f5f5] backdrop-blur-[30px]'
+              : 'bg-white/[0.15] border-white/25 text-[#6b5d4d] hover:bg-white/[0.2] hover:text-[#2d2820] backdrop-blur-[30px]'
         }`}
       >
         <span>
           Select {filterType}
           {selectedValues.length > 0 && ` (${selectedValues.length})`}
         </span>
-        <ChevronDown className={`w-4 h-4 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+        <ChevronDown
+          className={`w-4 h-4 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
+        />
       </button>
 
       {/* Dropdown */}
       {isOpen && (
-        <div className={`absolute top-full left-0 mt-2 w-[340px] rounded-[16px] border-[1.5px] shadow-[0_20px_60px_rgba(0,0,0,0.4)] z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200 backdrop-blur-[40px] ${
-          theme === 'dark'
-            ? 'bg-[#2d2820]/[0.95] border-[#c9983a]/30'
-            : 'bg-[#d4c5b0]/[0.95] border-[#c9983a]/30'
-        }`}>
-          {/* Header with Title and Close Button */}
-          <div className={`px-5 py-3.5 flex items-center justify-between border-b-[1.5px] ${
+        <div
+          className={`absolute top-full left-0 mt-2 w-[340px] rounded-[16px] border-[1.5px] shadow-[0_20px_60px_rgba(0,0,0,0.4)] z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200 backdrop-blur-[40px] ${
             theme === 'dark'
-              ? 'border-white/[0.15] bg-gradient-to-b from-white/[0.03] to-transparent'
-              : 'border-white/[0.2] bg-gradient-to-b from-white/[0.05] to-transparent'
-          }`}>
-            <h3 className={`text-[15px] font-bold capitalize ${
-              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+              ? 'bg-[#2d2820]/[0.95] border-[#c9983a]/30'
+              : 'bg-[#d4c5b0]/[0.95] border-[#c9983a]/30'
+          }`}
+        >
+          {/* Header with Title and Close Button */}
+          <div
+            className={`px-5 py-3.5 flex items-center justify-between border-b-[1.5px] ${
+              theme === 'dark'
+                ? 'border-white/[0.15] bg-gradient-to-b from-white/[0.03] to-transparent'
+                : 'border-white/[0.2] bg-gradient-to-b from-white/[0.05] to-transparent'
+            }`}
+          >
+            <h3
+              id={headingId}
+              className={`text-[15px] font-bold capitalize ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               Select {filterType}
             </h3>
             <button
-              onClick={onClose}
+              onClick={closeAndRestoreFocus}
+              aria-label={`Close ${filterType} dropdown`}
               className={`p-1.5 rounded-lg transition-all hover:scale-110 ${
                 theme === 'dark'
                   ? 'hover:bg-white/[0.1] text-[#c9983a] hover:text-[#f5c563]'
@@ -107,18 +224,22 @@ export function Dropdown({
           {/* Search Input */}
           <div className="p-4">
             <div className="relative group">
-              <Search 
+              <Search
                 className={`absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 transition-colors ${
-                  theme === 'dark' 
-                    ? 'text-[#b8a898] group-focus-within:text-[#c9983a]' 
+                  theme === 'dark'
+                    ? 'text-[#b8a898] group-focus-within:text-[#c9983a]'
                     : 'text-[#7a6b5a] group-focus-within:text-[#c9983a]'
-                }`} 
+                }`}
               />
               <input
+                ref={searchRef}
                 type="text"
+                role="searchbox"
+                aria-label={`Search ${filterType}`}
                 placeholder={`Search ${filterType}...`}
                 value={searchValue}
                 onChange={(e) => onSearchChange(e.target.value)}
+                onKeyDown={handleKeyboardNavigation}
                 autoFocus
                 className={`w-full pl-10 pr-3 py-2.5 rounded-[11px] border-[1.5px] focus:outline-none transition-all text-[14px] placeholder:text-[14px] font-normal ${
                   theme === 'dark'
@@ -130,34 +251,60 @@ export function Dropdown({
           </div>
 
           {/* Options List */}
-          <div className="max-h-[320px] overflow-y-auto">
+          <div
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={headingId}
+            aria-multiselectable="true"
+            className="max-h-[320px] overflow-y-auto"
+            onKeyDown={handleKeyboardNavigation}
+          >
             {filteredOptions.length > 0 ? (
               <div className="pb-2">
                 {filteredOptions.map((option, idx) => {
-                  const isSelected = selectedValues.includes(option.name);
-                  
+                  const isSelected = selectedValues.includes(option.name)
+
                   return (
                     <button
                       key={idx}
+                      ref={(node) => {
+                        optionRefs.current[idx] = node
+                      }}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      tabIndex={activeOptionIndex === idx ? 0 : -1}
                       onClick={() => onToggle(option.name)}
+                      onFocus={() => setActiveOptionIndex(idx)}
+                      onKeyDown={(event) => handleOptionKeyDown(event, option, idx)}
                       className={`w-full px-4 py-3 transition-all flex items-start justify-between group ${
-                        theme === 'dark'
-                          ? 'hover:bg-white/[0.05]'
-                          : 'hover:bg-black/[0.03]'
+                        theme === 'dark' ? 'hover:bg-white/[0.05]' : 'hover:bg-black/[0.03]'
                       }`}
                     >
                       <div className="flex items-start gap-3 flex-1 min-w-0">
                         {/* Checkbox */}
-                        <div className={`mt-0.5 flex-shrink-0 w-[19px] h-[19px] rounded-[5px] border-[2.5px] flex items-center justify-center transition-all ${
-                          isSelected
-                            ? 'bg-gradient-to-br from-[#c9983a] to-[#b8872f] border-[#c9983a] shadow-[0_3px_10px_rgba(201,152,58,0.4)]'
-                            : theme === 'dark'
-                            ? 'border-white/[0.3] group-hover:border-[#c9983a]/60'
-                            : 'border-[#8a7a6a]/[0.35] group-hover:border-[#c9983a]/60'
-                        }`}>
+                        <div
+                          className={`mt-0.5 flex-shrink-0 w-[19px] h-[19px] rounded-[5px] border-[2.5px] flex items-center justify-center transition-all ${
+                            isSelected
+                              ? 'bg-gradient-to-br from-[#c9983a] to-[#b8872f] border-[#c9983a] shadow-[0_3px_10px_rgba(201,152,58,0.4)]'
+                              : theme === 'dark'
+                                ? 'border-white/[0.3] group-hover:border-[#c9983a]/60'
+                                : 'border-[#8a7a6a]/[0.35] group-hover:border-[#c9983a]/60'
+                          }`}
+                        >
                           {isSelected && (
-                            <svg className="w-3.5 h-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="4">
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                            <svg
+                              className="w-3.5 h-3.5 text-white"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M5 13l4 4L19 7"
+                              />
                             </svg>
                           )}
                         </div>
@@ -167,24 +314,32 @@ export function Dropdown({
                           renderOption(option, isSelected)
                         ) : (
                           <div className="flex-1 min-w-0 text-left">
-                            <div className={`text-[14px] font-semibold transition-colors ${
-                              isSelected
-                                ? theme === 'dark' ? 'text-[#f5c563]' : 'text-[#8b6f3a]'
-                                : theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                            }`}>
+                            <div
+                              className={`text-[14px] font-semibold transition-colors ${
+                                isSelected
+                                  ? theme === 'dark'
+                                    ? 'text-[#f5c563]'
+                                    : 'text-[#8b6f3a]'
+                                  : theme === 'dark'
+                                    ? 'text-[#f5f5f5]'
+                                    : 'text-[#2d2820]'
+                              }`}
+                            >
                               {option.name}
                             </div>
                           </div>
                         )}
                       </div>
                     </button>
-                  );
+                  )
                 })}
               </div>
             ) : (
-              <div className={`px-4 py-12 text-center ${
-                theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-              }`}>
+              <div
+                className={`px-4 py-12 text-center ${
+                  theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                }`}
+              >
                 <div className="text-[14px] font-semibold">No options found</div>
                 <div className="text-[12px] mt-1 opacity-70">Try a different search term</div>
               </div>
@@ -193,5 +348,5 @@ export function Dropdown({
         </div>
       )}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- Add listbox/option ARIA semantics to the shared multi-select `Dropdown` component.
- Add keyboard navigation for Arrow Up/Down, Home/End, Enter/Space selection, and Escape close with focus restoration.
- Preserve the existing search filtering behavior and custom option rendering support.
- Add focused tests covering keyboard navigation, selection state, filtering, Escape behavior, outside-click close, custom rendering, and dark-theme semantics.

Closes #173

## Security
- No new dependencies were added.
- Option labels continue to be rendered as React text, so user-provided names are escaped instead of injected as HTML.

## Validation
- `npx vitest run src/shared/components/ui/Dropdown.test.tsx` — 11 tests passed.
- `npx vitest run --coverage src/shared/components/ui/Dropdown.test.tsx` — Dropdown coverage: 100% statements, 100% lines, 100% functions, 90.9% branches.
- `npx eslint src/shared/components/ui/Dropdown.tsx src/shared/components/ui/Dropdown.test.tsx` — passed.
- `npx prettier --check src/shared/components/ui/Dropdown.tsx src/shared/components/ui/Dropdown.test.tsx` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed; Vite still reports the existing large chunk warning.
- `git diff --check` — passed.

## Existing repo-wide checks
These broader checks still fail on the current repo for issues outside this PR's touched files:
- `npm run lint` fails on existing errors in `src/features/maintainers/components/InstallGitHubAppModal.test.tsx` and `src/features/settings/components/terms/TermsTab.tsx`.
- `npm run format:check` reports existing formatting differences across 259 files.
- `npm test -- --run` has 60 passing test files and 1 failing test file: `src/shared/hooks/useLandingStats.test.ts`, due the existing mocked `../i18n` module missing `I18nProvider`.
