### PR TITLE
A11y/osw cards

### DIFF
--- a/src/features/dashboard/pages/OpenSourceWeekPage.test.tsx
+++ b/src/features/dashboard/pages/OpenSourceWeekPage.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenSourceWeekPage } from './OpenSourceWeekPage';
+import { getOpenSourceWeekEvents } from '../../../shared/api/client';
+
+vi.mock('../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('../../../shared/api/client', () => ({
+  getOpenSourceWeekEvents: vi.fn(),
+}));
+
+const mockGetEvents = vi.mocked(getOpenSourceWeekEvents);
+
+const MOCK_EVENTS = [
+  {
+    id: 'evt-1',
+    title: 'Hackathon 2024',
+    description: 'A week of open source contributions.',
+    location: 'Online',
+    status: 'upcoming',
+    start_at: '2024-07-01T09:00:00Z',
+    end_at: '2024-07-07T18:00:00Z',
+  },
+  {
+    id: 'evt-2',
+    title: 'Code Sprint',
+    description: null,
+    location: null,
+    status: 'completed',
+    start_at: '2024-06-01T09:00:00Z',
+    end_at: '2024-06-07T18:00:00Z',
+  },
+];
+
+describe('OpenSourceWeekPage', () => {
+  const onEventClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rendering states
+  // ---------------------------------------------------------------------------
+
+  it('renders the page heading', async () => {
+    mockGetEvents.mockResolvedValue({ events: [] });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    expect(screen.getByRole('heading', { name: 'Open-Source Week' })).toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton while events are being fetched', () => {
+    // Never resolves — simulates an in-flight request
+    mockGetEvents.mockImplementation(() => new Promise(() => {}));
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    // Event cards must not appear yet
+    expect(screen.queryByRole('button', { name: /hackathon/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the empty-state message when the API returns no events', async () => {
+    mockGetEvents.mockResolvedValue({ events: [] });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() =>
+      expect(screen.getByText(/no open-source week events yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the empty-state message when the fetch throws', async () => {
+    mockGetEvents.mockRejectedValue(new Error('Network error'));
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() =>
+      expect(screen.getByText(/no open-source week events yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders a card for each event after loading', async () => {
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /hackathon 2024/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /code sprint/i })).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to "TBA" when a location is null', async () => {
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /code sprint/i }));
+    expect(screen.getByText('TBA')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pointer interaction
+  // ---------------------------------------------------------------------------
+
+  it('calls onEventClick with id and title when a card is clicked', async () => {
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    await userEvent.click(screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith('evt-1', 'Hackathon 2024');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Keyboard accessibility (acceptance criteria)
+  // ---------------------------------------------------------------------------
+
+  it('event cards are keyboard-focusable (tabIndex=0)', async () => {
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    expect(screen.getByRole('button', { name: /hackathon 2024/i })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('button', { name: /code sprint/i })).toHaveAttribute('tabindex', '0');
+  });
+
+  it('activates a card when Enter is pressed while the card is focused', async () => {
+    const user = userEvent.setup();
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    const card = screen.getByRole('button', { name: /hackathon 2024/i });
+    card.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith('evt-1', 'Hackathon 2024');
+  });
+
+  it('activates a card when Space is pressed while the card is focused', async () => {
+    const user = userEvent.setup();
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    const card = screen.getByRole('button', { name: /hackathon 2024/i });
+    card.focus();
+    await user.keyboard(' ');
+
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+    expect(onEventClick).toHaveBeenCalledWith('evt-1', 'Hackathon 2024');
+  });
+
+  it('does not double-fire onEventClick when a key event bubbles from the nested Join Event button', async () => {
+    const user = userEvent.setup();
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getAllByRole('button', { name: /join event/i }));
+
+    const joinBtn = screen.getAllByRole('button', { name: /join event/i })[0];
+    joinBtn.focus();
+    // Pressing Enter on the inner button fires a synthetic click that bubbles
+    // to the card's onClick — that is one call and is intentional.
+    // The card's onKeyDown guard (currentTarget === target) must NOT add a
+    // second call.
+    await user.keyboard('{Enter}');
+
+    expect(onEventClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows keyboard navigation between multiple cards via Tab', async () => {
+    const user = userEvent.setup();
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByRole('button', { name: /hackathon 2024/i }));
+
+    // Tab into the first card
+    await user.tab();
+    // At least one of the event cards (or the Join Event button) must be focused
+    const focused = document.activeElement;
+    expect(focused).not.toBeNull();
+    expect(focused?.getAttribute('tabindex') === '0' || focused?.tagName === 'BUTTON').toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessible status badge
+  // ---------------------------------------------------------------------------
+
+  it('status badge includes a visually-hidden "Event status:" prefix', async () => {
+    mockGetEvents.mockResolvedValue({ events: MOCK_EVENTS });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByText(/hackathon 2024/i));
+
+    // sr-only spans are in the DOM even though they are visually hidden
+    const srLabels = screen.getAllByText(/event status:/i);
+    expect(srLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('status badge shows human-readable label for each status value', async () => {
+    const events = [
+      { ...MOCK_EVENTS[0], id: 'e1', status: 'upcoming', title: 'Upcoming Event' },
+      { ...MOCK_EVENTS[0], id: 'e2', status: 'running', title: 'Running Event' },
+      { ...MOCK_EVENTS[0], id: 'e3', status: 'completed', title: 'Completed Event' },
+      { ...MOCK_EVENTS[0], id: 'e4', status: 'draft', title: 'Draft Event' },
+    ];
+    mockGetEvents.mockResolvedValue({ events });
+    render(<OpenSourceWeekPage onEventClick={onEventClick} />);
+    await waitFor(() => screen.getByText('Upcoming Event'));
+
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/pages/OpenSourceWeekPage.tsx
+++ b/src/features/dashboard/pages/OpenSourceWeekPage.tsx
@@ -3,10 +3,24 @@ import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { Calendar } from 'lucide-react';
 import { getOpenSourceWeekEvents } from '../../../shared/api/client';
 
+/** Props for {@link OpenSourceWeekPage}. */
 interface OpenSourceWeekPageProps {
+  /** Callback invoked when the user activates an event card (click or keyboard). */
   onEventClick: (id: string, name: string) => void;
 }
 
+/**
+ * Displays Open-Source Week events fetched from the API.
+ *
+ * Each event card is keyboard-accessible: it carries `role="button"` and
+ * `tabIndex={0}` so keyboard users can focus and activate it with Enter or
+ * Space. A visible focus ring appears via `focus-visible` Tailwind utilities.
+ * The status badge prefixes a visually-hidden "Event status:" label so screen
+ * readers announce its meaning rather than a bare word.
+ *
+ * @param onEventClick - Invoked with the event `id` and `title` when a card is
+ *   activated via pointer or keyboard.
+ */
 export function OpenSourceWeekPage({ onEventClick }: OpenSourceWeekPageProps) {
   const { theme } = useTheme();
 
@@ -130,11 +144,22 @@ export function OpenSourceWeekPage({ onEventClick }: OpenSourceWeekPageProps) {
           formattedEvents.map((event) => (
           <div
             key={event.id}
+            role="button"
+            tabIndex={0}
+            aria-label={`${event.title}, status: ${event.statusLabel}`}
             onClick={() => onEventClick(event.id, event.title)}
-            className={`backdrop-blur-[40px] rounded-[24px] border p-6 sm:p-8 shadow-[0_8px_32px_rgba(0,0,0,0.08)] transition-all cursor-pointer ${
+            onKeyDown={(e) => {
+              // Only handle keys originating on this element, not bubbling from
+              // the nested "Join Event" button, which has its own click handler.
+              if (e.currentTarget === e.target && (e.key === 'Enter' || e.key === ' ')) {
+                e.preventDefault();
+                onEventClick(event.id, event.title);
+              }
+            }}
+            className={`backdrop-blur-[40px] rounded-[24px] border p-6 sm:p-8 shadow-[0_8px_32px_rgba(0,0,0,0.08)] transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a]/70 focus-visible:ring-offset-2 ${
               theme === 'dark'
-                ? 'bg-white/[0.08] border-white/10 hover:bg-white/[0.12] hover:shadow-[0_8px_24px_rgba(201,152,58,0.15)]'
-                : 'bg-white/[0.15] border-white/25 hover:bg-white/[0.2] hover:shadow-[0_8px_24px_rgba(0,0,0,0.12)]'
+                ? 'bg-white/[0.08] border-white/10 hover:bg-white/[0.12] hover:shadow-[0_8px_24px_rgba(201,152,58,0.15)] focus-visible:ring-offset-[#1a1a1a]'
+                : 'bg-white/[0.15] border-white/25 hover:bg-white/[0.2] hover:shadow-[0_8px_24px_rgba(0,0,0,0.12)] focus-visible:ring-offset-white'
             }`}
           >
             <div className="flex flex-col sm:flex-row items-start justify-between mb-6 gap-4 sm:gap-0">
@@ -151,6 +176,7 @@ export function OpenSourceWeekPage({ onEventClick }: OpenSourceWeekPageProps) {
                       ? 'bg-[#c9983a]/20 border border-[#c9983a]/40 text-[#e8c77f]'
                       : 'bg-[#c9983a]/15 border border-[#c9983a]/30 text-[#6d5530]'
                   }`}>
+                    <span className="sr-only">Event status: </span>
                     {event.statusLabel}
                   </span>
                 </div>


### PR DESCRIPTION
Each event card now carries role="button", tabIndex={0}, and an onKeyDown handler so keyboard users can focus and activate cards with Enter or Space

A focus-visible Tailwind ring provides a visible focus indicator without affecting mouse interactions

The status badge prefixes a visually-hidden "Event status: " span so screen readers announce meaning instead of a bare word

An aria-label on each card gives a clean accessible name (e.g. "Hackathon 2024, status: Upcoming")

A currentTarget === target guard in onKeyDown prevents double-firing when key events bubble up from the nested Join Event button

TSDoc added to the component and its props interface

closes #172 