### PR TITLE
Exponential backoff

### DIFF
--- a/src/shared/hooks/useOptimisticData.test.ts
+++ b/src/shared/hooks/useOptimisticData.test.ts
@@ -307,9 +307,538 @@ describe('useOptimisticData', () => {
     expect(result.current.hasError).toBe(false)
   })
 
-  it('retries with the latest fetch function', async () => {
-    const { result } = renderHook(() => useOptimisticData('initial'))
+  it('keeps fetchData stable after data changes and non-memoized initial data rerenders', async () => {
+    const { result, rerender } = renderHook(({ seed }) => useOptimisticData({ value: seed }), {
+      initialProps: { seed: 'initial' },
+    })
+    const firstFetchData = result.current.fetchData
+
+    await act(async () => {
+      await result.current.fetchData(vi.fn().mockResolvedValue({ value: 'loaded' }))
+    })
+
+    rerender({ seed: 'new-inline-object' })
+
+    expect(result.current.data).toEqual({ value: 'loaded' })
+    expect(result.current.fetchData).toBe(firstFetchData)
+  })
+
+  // ─── Exponential Backoff Tests ────────────────────────────────────────────────
+
+  describe('exponential backoff', () => {
+    it('retries with a delay instead of immediately', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 1000 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      expect(result.current.hasError).toBe(true)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      // Trigger retry — should NOT call immediately
+      act(() => {
+        result.current.retry()
+      })
+
+      expect(result.current.isRetrying).toBe(true)
+      expect(result.current.retryCount).toBe(1)
+      expect(fetchFn).toHaveBeenCalledTimes(1) // not yet called
+
+      // Advance past max possible delay for first retry (baseDelay * 2^0 = 1000ms)
+      await act(async () => {
+        vi.advanceTimersByTime(1100)
+        await Promise.resolve()
+      })
+
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+
+      consoleSpy.mockRestore()
+    })
+
+    it('increases delay exponentially with each retry', async () => {
+      // Use a fixed Math.random to make delays predictable (always max)
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 100, maxRetries: 5 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      // Retry 1: delay = 100 * 2^0 * 1 = 100ms
+      act(() => {
+        result.current.retry()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+
+      // Retry 2: delay = 100 * 2^1 * 1 = 200ms
+      act(() => {
+        result.current.retry()
+      })
+
+      await act(async () => {
+        vi.advanceTimersByTime(150)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(2) // not yet
+
+      await act(async () => {
+        vi.advanceTimersByTime(50)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(3)
+
+      // Retry 3: delay = 100 * 2^2 * 1 = 400ms
+      act(() => {
+        result.current.retry()
+      })
+
+      await act(async () => {
+        vi.advanceTimersByTime(350)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(3) // not yet
+
+      await act(async () => {
+        vi.advanceTimersByTime(50)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(4)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('applies jitter so delay is randomized', () => {
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 1000 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      act(() => {
+        result.current.fetchData(fetchFn)
+      })
+
+      // Wait for fetch to complete
+      vi.advanceTimersByTime(0)
+
+      act(() => {
+        result.current.retry()
+      })
+
+      // With random=0.5, attempt 0: delay = 0.5 * 1000 * 2^0 = 500ms
+      // fetchFn should not have been called yet at 400ms
+      vi.advanceTimersByTime(400)
+      // After 500ms it should fire
+      vi.advanceTimersByTime(100)
+
+      expect(randomSpy).toHaveBeenCalled()
+      randomSpy.mockRestore()
+      consoleSpy.mockRestore()
+    })
+
+    it('caps backoff delay at 30 seconds', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 10000, maxRetries: 10 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      act(() => {
+        result.current.fetchData(fetchFn)
+      })
+
+      vi.advanceTimersByTime(0)
+
+      // Simulate having already retried 4 times (retryCountRef = 4)
+      // Attempt 4: 10000 * 2^4 = 160000, but capped at 30000
+      // With random=1: delay = 30000
+      for (let i = 0; i < 4; i++) {
+        act(() => {
+          result.current.retry()
+        })
+        vi.advanceTimersByTime(30001)
+      }
+
+      // 5th retry: still capped at 30s
+      act(() => {
+        result.current.retry()
+      })
+
+      vi.advanceTimersByTime(29999)
+      // Should not have fired yet at 29999 for attempt with max cap
+      vi.advanceTimersByTime(2)
+      // Should have fired at 30000
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+  })
+
+  // ─── Configurable Max Retries Tests ───────────────────────────────────────────
+
+  describe('configurable max retries', () => {
+    it('defaults to 5 retries', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useOptimisticData('initial'))
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      for (let i = 0; i < 5; i++) {
+        act(() => {
+          result.current.retry()
+        })
+        await act(async () => {
+          vi.advanceTimersByTime(1)
+          await Promise.resolve()
+        })
+      }
+
+      expect(fetchFn).toHaveBeenCalledTimes(6) // 1 initial + 5 retries
+
+      // 6th retry should be ignored
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(100000)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(6)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('respects custom maxRetries option', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { maxRetries: 2 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      // Retry 1
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      // Retry 2
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      expect(fetchFn).toHaveBeenCalledTimes(3) // 1 initial + 2 retries
+
+      // Retry 3 should be ignored
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(100000)
+        await Promise.resolve()
+      })
+      expect(fetchFn).toHaveBeenCalledTimes(3)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('resets retry count after a successful fetch', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { maxRetries: 2 })
+      )
+
+      const failingFetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(failingFetchFn)
+      })
+
+      // Use up both retries
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      expect(result.current.retryCount).toBe(2)
+
+      // Now do a successful fetch — resets the counter
+      const successFetchFn = vi.fn().mockResolvedValue('success')
+      await act(async () => {
+        await result.current.fetchData(successFetchFn)
+      })
+
+      expect(result.current.retryCount).toBe(0)
+      expect(result.current.isRetrying).toBe(false)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+  })
+
+  // ─── retryCount / isRetrying Exposure Tests ───────────────────────────────────
+
+  describe('retryCount and isRetrying', () => {
+    it('exposes retryCount=0 and isRetrying=false initially', () => {
+      const { result } = renderHook(() => useOptimisticData('initial'))
+
+      expect(result.current.retryCount).toBe(0)
+      expect(result.current.isRetrying).toBe(false)
+    })
+
+    it('updates retryCount and isRetrying during backoff', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 1000 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+
+      expect(result.current.retryCount).toBe(1)
+      expect(result.current.isRetrying).toBe(true)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('increments retryCount with each retry', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { maxRetries: 3, baseDelay: 100 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+      expect(result.current.retryCount).toBe(1)
+
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+      expect(result.current.retryCount).toBe(2)
+
+      await act(async () => {
+        vi.advanceTimersByTime(1)
+        await Promise.resolve()
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+      expect(result.current.retryCount).toBe(3)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+  })
+
+  // ─── Abort / Unmount Cleanup Tests ────────────────────────────────────────────
+
+  describe('abort and unmount cleanup', () => {
+    it('clears backoff timer on unmount', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result, unmount } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 5000 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      act(() => {
+        result.current.retry()
+      })
+
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      // Unmount before timer fires
+      unmount()
+
+      // Advance timer — fetchFn should NOT be called again
+      vi.advanceTimersByTime(10000)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('clears backoff timer when fetchData is called again', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 5000 })
+      )
+
+      const failingFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(failingFn)
+      })
+
+      // Start a retry with backoff
+      act(() => {
+        result.current.retry()
+      })
+
+      expect(failingFn).toHaveBeenCalledTimes(1)
+
+      // Before the backoff timer fires, call fetchData with a new function
+      const successFn = vi.fn().mockResolvedValue('fresh data')
+      await act(async () => {
+        await result.current.fetchData(successFn)
+      })
+
+      // Advance past the original backoff timer
+      await act(async () => {
+        vi.advanceTimersByTime(10000)
+        await Promise.resolve()
+      })
+
+      // The failing fn should not have been called again
+      expect(failingFn).toHaveBeenCalledTimes(1)
+      expect(result.current.data).toBe('fresh data')
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+
+    it('does not retry if abort controller was aborted during backoff', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(1)
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() =>
+        useOptimisticData('initial', { baseDelay: 2000 })
+      )
+
+      const fetchFn = vi.fn().mockRejectedValue(new Error('fail'))
+
+      await act(async () => {
+        await result.current.fetchData(fetchFn)
+      })
+
+      // Start retry
+      act(() => {
+        result.current.retry()
+      })
+
+      // Abort by calling fetchData again (which aborts the previous controller)
+      const abortingFn = vi.fn().mockResolvedValue('aborted path')
+      await act(async () => {
+        await result.current.fetchData(abortingFn)
+      })
+
+      // Advance past backoff
+      await act(async () => {
+        vi.advanceTimersByTime(3000)
+        await Promise.resolve()
+      })
+
+      // fetchFn should not be retried — only the aborting call should succeed
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      expect(abortingFn).toHaveBeenCalledTimes(1)
+      expect(result.current.data).toBe('aborted path')
+
+      consoleSpy.mockRestore()
+      vi.spyOn(Math, 'random').mockRestore()
+    })
+  })
+
+  // ─── Retries with latest fetch function ───────────────────────────────────────
+
+  it('retries with the latest fetch function using backoff', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result } = renderHook(() =>
+      useOptimisticData('initial', { baseDelay: 100 })
+    )
 
     const staleFetchFn = vi.fn().mockRejectedValue(new Error('stale request failed'))
     await act(async () => {
@@ -325,9 +854,13 @@ describe('useOptimisticData', () => {
       await result.current.fetchData(latestFetchFn)
     })
 
-    await act(async () => {
+    act(() => {
       result.current.retry()
-      await Promise.resolve()
+    })
+
+    // Advance past backoff (random=0 means delay=0, but setTimeout(fn, 0) still needs advancing)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
       await Promise.resolve()
     })
 
@@ -337,21 +870,6 @@ describe('useOptimisticData', () => {
     expect(result.current.hasError).toBe(false)
 
     consoleSpy.mockRestore()
-  })
-
-  it('keeps fetchData stable after data changes and non-memoized initial data rerenders', async () => {
-    const { result, rerender } = renderHook(({ seed }) => useOptimisticData({ value: seed }), {
-      initialProps: { seed: 'initial' },
-    })
-    const firstFetchData = result.current.fetchData
-
-    await act(async () => {
-      await result.current.fetchData(vi.fn().mockResolvedValue({ value: 'loaded' }))
-    })
-
-    rerender({ seed: 'new-inline-object' })
-
-    expect(result.current.data).toEqual({ value: 'loaded' })
-    expect(result.current.fetchData).toBe(firstFetchData)
+    vi.spyOn(Math, 'random').mockRestore()
   })
 })

--- a/src/shared/hooks/useOptimisticData.ts
+++ b/src/shared/hooks/useOptimisticData.ts
@@ -1,8 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { logger } from '../../shared/utils/logger'
 
-const MAX_RETRIES = 5
-
 /** Cache entry for optimistic data */
 interface CacheEntry<T> {
   data: T
@@ -17,6 +15,10 @@ interface UseOptimisticDataOptions<T> {
   cacheKey?: string
   /** Custom empty-state predicate for domain-specific data shapes */
   isEmpty?: (data: T) => boolean
+  /** Maximum number of retry attempts, default 5 */
+  maxRetries?: number
+  /** Base delay in ms for exponential backoff, default 1000 */
+  baseDelay?: number
 }
 
 /** Return type of the hook */
@@ -29,7 +31,7 @@ export interface UseOptimisticDataReturn<T> {
   hasError: boolean
   /** Raw error object (if any) */
   error: unknown
-  /** Retry the last fetch (max 5 attempts) */
+  /** Retry the last fetch with exponential backoff */
   retry: () => void
   /** Whether the data is empty */
   isEmpty: boolean
@@ -37,6 +39,10 @@ export interface UseOptimisticDataReturn<T> {
   fetchData: (fetchFn: (signal: AbortSignal) => Promise<T>, forceRefresh?: boolean) => Promise<void>
   /** Clear cached data */
   clearCache: () => void
+  /** Current retry attempt count */
+  retryCount: number
+  /** Whether a backoff-delayed retry is pending */
+  isRetrying: boolean
 }
 
 /**
@@ -72,27 +78,70 @@ function isAbortError(error: unknown): boolean {
 }
 
 /**
- * Optimistic data hook with caching, abort support, retry and empty‑state handling.
+ * Compute backoff delay with full jitter.
  *
- * @param initialData – The initial value displayed before any fetch.
- * @param options – Configuration of cache duration, cache key, and empty-state detection.
+ * @param attempt - Zero-based retry attempt index (0 = first retry).
+ * @param baseDelay - Base delay in ms.
+ * @returns Randomized delay between 0 and `baseDelay * 2^attempt`, capped at 30 s.
+ *
+ * @example
+ * ```ts
+ * // First retry: random delay in [0, 1000]
+ * // Second retry: random delay in [0, 2000]
+ * // Third retry: random delay in [0, 4000]
+ * const delay = computeBackoffDelay(0, 1000)
+ * ```
+ */
+function computeBackoffDelay(attempt: number, baseDelay: number): number {
+  const maxDelay = 30_000
+  const exponential = Math.min(baseDelay * Math.pow(2, attempt), maxDelay)
+  return Math.random() * exponential
+}
+
+/**
+ * Optimistic data hook with caching, abort support, exponential backoff retry and empty-state handling.
+ *
+ * @param initialData - The initial value displayed before any fetch.
+ * @param options - Configuration of cache duration, cache key, empty-state detection, retries and backoff.
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, hasError, retry, retryCount, isRetrying, fetchData } =
+ *   useOptimisticData<User[]>([], { maxRetries: 3, baseDelay: 500 })
+ *
+ * useEffect(() => {
+ *   fetchData((signal) => api.getUsers(signal))
+ * }, [fetchData])
+ *
+ * if (isRetrying) return <p>Retrying (attempt {retryCount})...</p>
+ * ```
  */
 export function useOptimisticData<T>(
   initialData: T,
   options: UseOptimisticDataOptions<T> = {}
 ): UseOptimisticDataReturn<T> {
-  const { cacheDuration = 30000, cacheKey = 'default', isEmpty: isEmptyOption } = options
+  const {
+    cacheDuration = 30000,
+    cacheKey = 'default',
+    isEmpty: isEmptyOption,
+    maxRetries = 5,
+    baseDelay = 1000,
+  } = options
 
   const [data, setData] = useState<T>(initialData)
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [hasError, setHasError] = useState<boolean>(false)
   const [error, setError] = useState<unknown>(null)
+  const [retryCount, setRetryCount] = useState<number>(0)
+  const [isRetrying, setIsRetrying] = useState<boolean>(false)
 
   const cacheRef = useRef<Map<string, CacheEntry<T>>>(new Map())
   const abortControllerRef = useRef<AbortController | null>(null)
   const lastFetchFnRef = useRef<((signal: AbortSignal) => Promise<T>) | null>(null)
   const dataRef = useRef<T>(initialData)
   const retryCountRef = useRef<number>(0)
+  const isRetryCallRef = useRef<boolean>(false)
+  const backoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const emptyPredicate = isEmptyOption ?? defaultIsEmptyValue
   const emptyPredicateRef = useRef<(data: T) => boolean>(emptyPredicate)
 
@@ -109,20 +158,29 @@ export function useOptimisticData<T>(
     setData(nextData)
   }, [])
 
-  // Abort any in‑flight request when the component unmounts
+  const clearBackoffTimer = useCallback(() => {
+    if (backoffTimerRef.current !== null) {
+      clearTimeout(backoffTimerRef.current)
+      backoffTimerRef.current = null
+    }
+  }, [])
+
+  // Abort any in-flight request and clear timers when the component unmounts
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort()
+      clearBackoffTimer()
     }
-  }, [])
+  }, [clearBackoffTimer])
 
   const fetchData = useCallback(
     async (fetchFn: (signal: AbortSignal) => Promise<T>, forceRefresh = false) => {
       const now = Date.now()
       lastFetchFnRef.current = fetchFn
 
-      // Cancel any previous request
+      // Cancel any previous request and pending backoff
       abortControllerRef.current?.abort()
+      clearBackoffTimer()
       const controller = new AbortController()
       abortControllerRef.current = controller
       const signal = controller.signal
@@ -162,20 +220,41 @@ export function useOptimisticData<T>(
       } finally {
         if (!signal.aborted) {
           setIsLoading(false)
-          retryCountRef.current = 0
+          if (!isRetryCallRef.current) {
+            retryCountRef.current = 0
+            setRetryCount(0)
+          }
+          setIsRetrying(false)
+          isRetryCallRef.current = false
         }
       }
     },
-    [cacheDuration, cacheKey, updateData]
+    [cacheDuration, cacheKey, updateData, clearBackoffTimer]
   )
 
   const retry = useCallback(() => {
     const latestFetchFn = lastFetchFnRef.current
-    if (retryCountRef.current < MAX_RETRIES && latestFetchFn) {
-      retryCountRef.current += 1
+    if (retryCountRef.current >= maxRetries || !latestFetchFn) return
+
+    retryCountRef.current += 1
+    const currentAttempt = retryCountRef.current
+    setRetryCount(currentAttempt)
+    setIsRetrying(true)
+
+    const delay = computeBackoffDelay(currentAttempt - 1, baseDelay)
+
+    clearBackoffTimer()
+    backoffTimerRef.current = setTimeout(() => {
+      backoffTimerRef.current = null
+      // If the controller was aborted while waiting, do not retry
+      if (abortControllerRef.current?.signal.aborted) {
+        setIsRetrying(false)
+        return
+      }
+      isRetryCallRef.current = true
       void fetchData(latestFetchFn, true)
-    }
-  }, [fetchData])
+    }, delay)
+  }, [fetchData, maxRetries, baseDelay, clearBackoffTimer])
 
   const clearCache = useCallback(() => {
     cacheRef.current.clear()
@@ -185,5 +264,5 @@ export function useOptimisticData<T>(
     return emptyPredicate(data)
   }, [data, emptyPredicate])
 
-  return { data, isLoading, hasError, error, retry, isEmpty, fetchData, clearCache }
+  return { data, isLoading, hasError, error, retry, isEmpty, fetchData, clearCache, retryCount, isRetrying }
 }


### PR DESCRIPTION
## Summary

Replaces the immediate full-speed retry loop in `useOptimisticData` with exponential backoff + full jitter, and makes retry behavior configurable.

**Key changes:**

```ts
// New options (backward-compatible defaults)
interface UseOptimisticDataOptions<T> {
  maxRetries?: number   // default 5
  baseDelay?: number    // default 1000ms
  // ... existing options unchanged
}

// New return values
interface UseOptimisticDataReturn<T> {
  retryCount: number    // current attempt (0 when idle)
  isRetrying: boolean   // true while backoff timer is pending
  // ... existing returns unchanged
}
```

**Backoff formula:** `delay = random() * min(baseDelay * 2^attempt, 30_000)` — full jitter prevents thundering herd, capped at 30s.

**Safety:** backoff timers are cleared on unmount, on abort, and when a new `fetchData` call supersedes a pending retry. Retry count resets only on direct (non-retry) `fetchData` calls succeeding.

Closes #178