### PR TITLE
fix: validate route-level params before fetching in detail pages (#307)

### DIFF
--- a/src/features/dashboard/routeWrappers.test.tsx
+++ b/src/features/dashboard/routeWrappers.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { validateIdParam, validateSlugParam } from './routeWrappers';
+import { NotFoundPage } from '../../shared/components/NotFoundPage';
+import { OpenSourceWeekDetailPageRoute } from './routeWrappers';
+import { ProjectDetailPageRoute } from './routeWrappers';
+import { IssueDetailPageRoute } from './routeWrappers';
+import { EcosystemDetailPageRoute } from './routeWrappers';
+
+// ─── Unit tests for validateIdParam ──────────────────────────────────────────
+
+describe('validateIdParam', () => {
+  it('accepts valid UUID strings', () => {
+    expect(validateIdParam('550e8400-e29b-41d4-a716-446655440000')).toBe(
+      '550e8400-e29b-41d4-a716-446655440000'
+    );
+  });
+
+  it('accepts numeric IDs', () => {
+    expect(validateIdParam('12345')).toBe('12345');
+  });
+
+  it('accepts slug-format strings', () => {
+    expect(validateIdParam('my-project-slug')).toBe('my-project-slug');
+  });
+
+  it('rejects strings with special characters', () => {
+    expect(validateIdParam('abc<script>')).toBeNull();
+    expect(validateIdParam('foo;drop table')).toBeNull();
+    expect(validateIdParam('../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects empty strings', () => {
+    expect(validateIdParam('')).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(validateIdParam(undefined)).toBeNull();
+  });
+
+  it('rejects overly long strings', () => {
+    const longStr = 'a'.repeat(129);
+    expect(validateIdParam(longStr)).toBeNull();
+  });
+
+  it('accepts strings at the max length boundary', () => {
+    const boundaryStr = 'a'.repeat(128);
+    expect(validateIdParam(boundaryStr)).toBe(boundaryStr);
+  });
+
+  it('rejects SQL injection attempts', () => {
+    expect(validateIdParam("1' OR '1'='1")).toBeNull();
+    expect(validateIdParam('1; DROP TABLE users')).toBeNull();
+  });
+
+  it('rejects XSS payloads', () => {
+    expect(validateIdParam('<script>alert(1)</script>')).toBeNull();
+    expect(validateIdParam('javascript:alert(1)')).toBeNull();
+  });
+});
+
+// ─── Unit tests for validateSlugParam ────────────────────────────────────────
+
+describe('validateSlugParam', () => {
+  it('accepts valid slugs', () => {
+    expect(validateSlugParam('hello-world')).toBe('hello-world');
+    expect(validateSlugParam('blog-post-2024')).toBe('blog-post-2024');
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(validateSlugParam('MyProject')).toBeNull();
+  });
+
+  it('rejects slugs with spaces', () => {
+    expect(validateSlugParam('hello world')).toBeNull();
+  });
+
+  it('rejects empty strings', () => {
+    expect(validateSlugParam('')).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(validateSlugParam(undefined)).toBeNull();
+  });
+});
+
+// ─── Integration tests for route wrappers with invalid params ────────────────
+
+describe('Route wrappers with invalid params', () => {
+  it('renders NotFoundPage for invalid ecosystemId', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/ecosystems/<script>']}>
+        <EcosystemDetailPageRoute />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('renders NotFoundPage for invalid projectId', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/projects/foo;drop']}>
+        <ProjectDetailPageRoute />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('renders NotFoundPage for invalid issueId', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/projects/123/issues/<img>']}>
+        <IssueDetailPageRoute />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+});

--- a/src/features/dashboard/routeWrappers.tsx
+++ b/src/features/dashboard/routeWrappers.tsx
@@ -7,6 +7,38 @@ import { MaintainersPage } from '../maintainers/pages/MaintainersPage';
 import { ProjectDetailPage } from './pages/ProjectDetailPage';
 import { IssueDetailPage } from './pages/IssueDetailPage';
 import { SearchPage } from './pages/SearchPage';
+import { NotFoundPage } from '../../shared/components/NotFoundPage';
+
+// ─── Param Validation ──────────────────────────────────────────────────────
+// Validates route params before they reach detail pages, preventing malformed
+// IDs from being forwarded to API endpoints.
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const NUMERIC_RE = /^\d+$/;
+const MAX_PARAM_LENGTH = 128;
+
+/**
+ * Validate a path parameter.
+ * Accepts: UUID format, numeric IDs, or URL-safe slugs (lowercase alphanumeric + hyphens).
+ * Returns null if invalid.
+ */
+export function validateIdParam(value: string | undefined): string | null {
+  if (!value || value.length > MAX_PARAM_LENGTH) return null;
+  if (UUID_RE.test(value)) return value;
+  if (NUMERIC_RE.test(value)) return value;
+  if (SLUG_RE.test(value)) return value;
+  return null;
+}
+
+/**
+ * Validate a slug param (stricter — only lowercase alphanumeric + hyphens).
+ */
+export function validateSlugParam(value: string | undefined): string | null {
+  if (!value || value.length > MAX_PARAM_LENGTH) return null;
+  if (SLUG_RE.test(value)) return value;
+  return null;
+}
 
 // Open Source Week Page Wrapper
 export function OpenSourceWeekPageRoute() {
@@ -27,7 +59,8 @@ export function OpenSourceWeekDetailPageRoute() {
   const state = location.state as { eventName?: string } || {};
   const eventName = state.eventName || 'Event';
 
-  if (!eventId) return null;
+  const validatedEventId = validateIdParam(eventId);
+  if (!validatedEventId) return <NotFoundPage />;
 
   const handleBack = () => {
     navigate('/dashboard/open-source-week');
@@ -35,7 +68,7 @@ export function OpenSourceWeekDetailPageRoute() {
 
   return (
     <OpenSourceWeekDetailPage
-      eventId={eventId}
+      eventId={validatedEventId}
       eventName={eventName}
       onBack={handleBack}
     />
@@ -71,7 +104,8 @@ export function EcosystemDetailPageRoute() {
     logoUrl?: string | null;
   } || {};
 
-  if (!ecosystemId) return null;
+  const validatedEcosystemId = validateIdParam(ecosystemId);
+  if (!validatedEcosystemId) return <NotFoundPage />;
 
   const handleBack = () => {
     navigate('/dashboard/ecosystems');
@@ -85,7 +119,7 @@ export function EcosystemDetailPageRoute() {
 
   return (
     <EcosystemDetailPage
-      ecosystemId={ecosystemId}
+      ecosystemId={validatedEcosystemId}
       ecosystemName={state.ecosystemName || ''}
       initialDescription={state.description || null}
       initialLogoUrl={state.logoUrl || null}
@@ -113,7 +147,8 @@ export function ProjectDetailPageRoute() {
   const location = useLocation();
   const state = location.state as { backTarget?: string } || {};
 
-  if (!projectId) return null;
+  const validatedProjectId = validateIdParam(projectId);
+  if (!validatedProjectId) return <NotFoundPage />;
 
   const handleBack = () => {
     if (state.backTarget) {
@@ -140,7 +175,7 @@ export function ProjectDetailPageRoute() {
 
   return (
     <ProjectDetailPage
-      projectId={projectId}
+      projectId={validatedProjectId}
       backLabel={getBackLabel()}
       onBack={handleBack}
       onIssueClick={handleIssueClick}
@@ -153,7 +188,9 @@ export function IssueDetailPageRoute() {
   const { projectId, issueId } = useParams<{ projectId: string; issueId: string }>();
   const navigate = useNavigate();
 
-  if (!projectId || !issueId) return null;
+  const validatedProjectId = validateIdParam(projectId);
+  const validatedIssueId = validateIdParam(issueId);
+  if (!validatedProjectId || !validatedIssueId) return <NotFoundPage />;
 
   const handleClose = () => {
     navigate(`/dashboard/projects/${projectId}`);
@@ -161,8 +198,8 @@ export function IssueDetailPageRoute() {
 
   return (
     <IssueDetailPage
-      issueId={issueId}
-      projectId={projectId}
+      issueId={validatedIssueId}
+      projectId={validatedProjectId}
       onClose={handleClose}
     />
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_FRONTEND_BASE_URL?: string;
+  readonly VITE_USE_MOCK_DATA: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Adds lightweight param-shape validation to all detail page route wrappers, preventing malformed path segments from being forwarded to API endpoints.

## Changes

- **src/features/dashboard/routeWrappers.tsx**: Added `validateIdParam()` and `validateSlugParam()` validators that accept UUID, numeric, or slug-format strings (bounded to 128 chars). Invalid params now render `NotFoundPage` instead of passing bad data to API calls.
- **Updated routes**: `OpenSourceWeekDetailPageRoute`, `EcosystemDetailPageRoute`, `ProjectDetailPageRoute`, `IssueDetailPageRoute` all validate their params before rendering.
- **src/features/dashboard/routeWrappers.test.tsx**: Unit tests for validator functions + integration tests confirming `NotFoundPage` renders for invalid params.

## Why it matters

Previously, arbitrary path segments like `<script>` or `; DROP TABLE` would be interpolated directly into API URLs like `/projects/${projectId}`, wasting requests and enabling backend probing.

Closes #307