### PR TITLE
fix(a11y): enlarge landing navbar mobile toggle target

### DIFF
--- a/src/features/landing/components/Navbar.test.tsx
+++ b/src/features/landing/components/Navbar.test.tsx
@@ -70,6 +70,22 @@ describe('Navbar i18n strings', () => {
     expect(screen.getAllByText('Get Started').length).toBeGreaterThanOrEqual(2)
   })
 
+  it('keeps the mobile menu toggle accessible with a 44px touch target', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, logout: vi.fn() })
+    renderNavbar()
+
+    const toggle = screen.getByRole('button', { name: 'Open menu' })
+    expect(toggle).toHaveClass('h-11', 'w-11', 'items-center', 'justify-center')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(toggle)
+
+    const closeToggle = screen.getByRole('button', { name: 'Close menu' })
+    expect(closeToggle).toHaveClass('h-11', 'w-11', 'items-center', 'justify-center')
+    expect(closeToggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
   it('renders the authenticated CTAs inside the mobile menu when opened', async () => {
     const user = userEvent.setup()
     mockUseAuth.mockReturnValue({ isAuthenticated: true, logout: vi.fn() })
@@ -81,3 +97,4 @@ describe('Navbar i18n strings', () => {
     expect(screen.getAllByText('Sign Out').length).toBeGreaterThanOrEqual(2)
   })
 })
+

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -7,6 +7,13 @@ import { useTheme } from "../../../shared/contexts/ThemeContext";
 import { useAuth } from "../../../shared/contexts/AuthContext";
 import grainlifyLogo from "../../../assets/grainlify_log.svg";
 
+/**
+ * Keeps the mobile menu trigger at the WCAG-recommended 44px minimum
+ * touch target while preserving the existing 24px icon size.
+ */
+const MOBILE_MENU_TRIGGER_CLASSES =
+  "md:hidden inline-flex h-11 w-11 items-center justify-center rounded-[12px]";
+
 export function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { theme, setThemeFromAnimation } = useTheme();
@@ -145,7 +152,7 @@ export function Navbar() {
 
           {/* Mobile Menu Button */}
           <button
-            className="md:hidden p-2"
+            className={MOBILE_MENU_TRIGGER_CLASSES}
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={mobileMenuOpen}


### PR DESCRIPTION
Closes #255

## Summary
- Enlarges the landing Navbar mobile menu trigger from the previous small padding-only button to a fixed `h-11 w-11` 44x44px touch target.
- Keeps the 24px menu/close icons centered with `inline-flex`, `items-center`, and `justify-center`.
- Adds focused Navbar coverage for the mobile toggle `aria-label`, `aria-expanded`, and 44px touch-target classes across closed/open states.

## User-visible impact
Mobile users get a larger, easier-to-tap menu button without changing the navbar layout or icon size. This mitigates mis-taps on touch devices and addresses the accessibility concern in the issue.

## Security notes
No auth, storage, network, or data-handling behavior changed.

## Validation
- Static review of `src/features/landing/components/Navbar.tsx` confirms `aria-label` and `aria-expanded` remain on the toggle.
- Static review confirms the trigger uses `h-11 w-11`, which maps to Tailwind's 44px target size.
- Added focused regression coverage in `src/features/landing/components/Navbar.test.tsx`.
- Local test execution was not completed because the full repository checkout repeatedly timed out/corrupted during download in this environment; this PR was created through the GitHub Git Data API using the two targeted source files fetched from `main`.