### PR TITLE
fix(a11y): use h1 for NotFoundPage heading

### DIFF
--- a/src/shared/components/NotFoundPage.test.tsx
+++ b/src/shared/components/NotFoundPage.test.tsx
@@ -1,18 +1,22 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { ThemeProvider } from '../contexts/ThemeContext';
 import { NotFoundPage } from './NotFoundPage';
 
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => vi.fn(),
-}));
-
-vi.mock('../contexts/ThemeContext', () => ({
-  useTheme: () => ({ theme: 'light' }),
-}));
+function renderNotFoundPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <NotFoundPage />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
 
 describe('NotFoundPage', () => {
   it('renders Page Not Found as the single top-level heading', () => {
-    render(<NotFoundPage />);
+    renderNotFoundPage();
 
     const heading = screen.getByRole('heading', {
       level: 1,
@@ -25,7 +29,7 @@ describe('NotFoundPage', () => {
   });
 
   it('keeps the recovery actions available', () => {
-    render(<NotFoundPage />);
+    renderNotFoundPage();
 
     expect(screen.getByRole('button', { name: 'Go Back' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();

--- a/src/shared/components/NotFoundPage.test.tsx
+++ b/src/shared/components/NotFoundPage.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NotFoundPage } from './NotFoundPage';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+describe('NotFoundPage', () => {
+  it('renders Page Not Found as the single top-level heading', () => {
+    render(<NotFoundPage />);
+
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Page Not Found',
+    });
+
+    expect(heading).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('keeps the recovery actions available', () => {
+    render(<NotFoundPage />);
+
+    expect(screen.getByRole('button', { name: 'Go Back' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to Dashboard' })).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/NotFoundPage.tsx
+++ b/src/shared/components/NotFoundPage.tsx
@@ -35,11 +35,11 @@ export function NotFoundPage() {
 
         {/* Error Message */}
         <div className="text-center mb-8">
-          <h2 className={`text-2xl font-bold mb-2 transition-colors ${
+          <h1 className={`text-2xl font-bold mb-2 transition-colors ${
             theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
           }`}>
             Page Not Found
-          </h2>
+          </h1>
           <p className={`text-sm transition-colors ${
             theme === 'dark' ? 'text-[#d4c5b0]' : 'text-[#7a6b5a]'
           }`}>


### PR DESCRIPTION
## Summary

Closes #254.

- Promotes the visible `Page Not Found` heading from `h2` to `h1` while preserving the existing visual styling.
- Adds focused Vitest coverage for the page heading hierarchy and recovery actions.

## Accessibility impact

The NotFoundPage now exposes a single top-level heading, avoiding the skipped heading hierarchy that was called out in the issue.

## Validation

- Compared branch against `main`: 2 files changed, no unrelated files.
- Added `src/shared/components/NotFoundPage.test.tsx` covering the `h1`, absence of `h2`, and visible action buttons.
- Not run locally: full repository clone stalled on network transfer in this environment, so I submitted the focused test and will rely on CI for the full suite.

## Security notes

No security-sensitive behavior or data handling changed.