### PR TITLE
fix(a11y): enlarge mobile navbar menu touch target

### DIFF
--- a/src/features/landing/components/Navbar.test.tsx
+++ b/src/features/landing/components/Navbar.test.tsx
@@ -80,4 +80,22 @@ describe('Navbar i18n strings', () => {
     expect(screen.getAllByText('Dashboard').length).toBeGreaterThanOrEqual(2)
     expect(screen.getAllByText('Sign Out').length).toBeGreaterThanOrEqual(2)
   })
+
+  it('keeps the mobile menu button at a 44px touch target and updates expanded state', async () => {
+    const user = userEvent.setup()
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, logout: vi.fn() })
+    renderNavbar()
+
+    const menuButton = screen.getByRole('button', { name: 'Open menu' })
+
+    expect(menuButton).toHaveClass('h-11', 'w-11', 'items-center', 'justify-center')
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(menuButton)
+
+    expect(screen.getByRole('button', { name: 'Close menu' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+  })
 })

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -145,7 +145,7 @@ export function Navbar() {
 
           {/* Mobile Menu Button */}
           <button
-            className="md:hidden p-2"
+            className="md:hidden flex h-11 w-11 items-center justify-center rounded-[12px]"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={mobileMenuOpen}


### PR DESCRIPTION
## Summary

Closes #255.

- Enlarges the landing navbar mobile menu toggle from padding-only sizing to a fixed `h-11 w-11` touch target.
- Keeps the menu icon centered with flex alignment and preserves the existing `aria-label` / `aria-expanded` behavior.
- Extends the existing Navbar test coverage to assert the 44px Tailwind sizing classes and expanded-state transition.

## Accessibility impact

The mobile menu toggle now meets the 44x44px touch target guidance while preserving its visible icon size and navbar layout.

## Validation

- Compared branch against `main`: 2 files changed, no unrelated files.
- Added focused coverage in `src/features/landing/components/Navbar.test.tsx`.
- Not run locally: full repository clone stalled on network transfer in this environment, so I submitted the focused test and will rely on CI for the full suite.

## Security notes

No security-sensitive behavior or data handling changed.