### PR TITLE
fix(a11y): hide decorative ProjectsPodium graphics

### DIFF
--- a/src/features/leaderboard/components/ProjectsPodium.test.tsx
+++ b/src/features/leaderboard/components/ProjectsPodium.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ProjectsPodium } from './ProjectsPodium';
+import { renderWithTheme } from '../../../test/renderWithTheme';
+import { ProjectData } from '../types';
+
+const topThree: ProjectData[] = [
+  {
+    rank: 1,
+    name: 'Alpha Vault',
+    logo: 'https://example.com/alpha.png',
+    score: 980,
+    trend: 'up',
+    trendValue: 12,
+  },
+  {
+    rank: 2,
+    name: 'Beta Finance',
+    logo: 'https://example.com/beta.png',
+    score: 870,
+    trend: 'same',
+    trendValue: 0,
+  },
+  {
+    rank: 3,
+    name: 'Gamma Labs',
+    logo: 'https://example.com/gamma.png',
+    score: 760,
+    trend: 'down',
+    trendValue: 3,
+  },
+];
+
+function renderPodium() {
+  return renderWithTheme(<ProjectsPodium topThree={topThree} isLoaded />);
+}
+
+describe('ProjectsPodium accessibility', () => {
+  it('keeps project logos accessible with project-specific alt text', () => {
+    renderPodium();
+
+    expect(screen.getByRole('img', { name: 'Alpha Vault logo' })).toHaveAttribute(
+      'src',
+      topThree[0].logo,
+    );
+    expect(screen.getByRole('img', { name: 'Beta Finance logo' })).toHaveAttribute(
+      'src',
+      topThree[1].logo,
+    );
+    expect(screen.getByRole('img', { name: 'Gamma Labs logo' })).toHaveAttribute(
+      'src',
+      topThree[2].logo,
+    );
+  });
+
+  it('conveys podium ranks as visible text', () => {
+    renderPodium();
+
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.getByText('#3')).toBeInTheDocument();
+  });
+
+  it('hides decorative podium icons and animation overlays from assistive tech', () => {
+    renderPodium();
+
+    [
+      'projects-podium-sparkles-second',
+      'projects-podium-medal-second',
+      'projects-podium-golden-glow',
+      'projects-podium-rays',
+      'projects-podium-particles',
+      'projects-podium-ping-ring',
+      'projects-podium-crown',
+      'projects-podium-trophy',
+      'projects-podium-sparkles-third',
+      'projects-podium-medal-third',
+    ].forEach((testId) => {
+      expect(screen.getByTestId(testId)).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+});

--- a/src/features/leaderboard/components/ProjectsPodium.tsx
+++ b/src/features/leaderboard/components/ProjectsPodium.tsx
@@ -11,6 +11,7 @@ interface ProjectsPodiumProps {
   isLoaded: boolean;
 }
 
+/** Renders the visual top-three project podium while keeping decorative effects hidden from assistive tech. */
 export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
   const { theme } = useTheme();
 
@@ -24,12 +25,20 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#c9983a]/80 to-[#a67c2e]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl overflow-hidden group-hover:rotate-12 transition-transform duration-300">
               {isLogoUrl(topThree[1].logo) ? (
-                <img src={topThree[1].logo} alt="" className="w-full h-full object-cover" />
+                <img
+                  src={topThree[1].logo}
+                  alt={`${topThree[1].name} logo`}
+                  className="w-full h-full object-cover"
+                />
               ) : (
                 topThree[1].logo
               )}
             </div>
-            <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 transition-opacity" />
+            <Sparkles
+              aria-hidden="true"
+              data-testid="projects-podium-sparkles-second"
+              className="absolute -top-1 -right-1 w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 transition-opacity"
+            />
           </div>
           <div className="text-center">
             <div className={`text-[13px] font-bold mb-1 transition-colors ${
@@ -42,7 +51,11 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
           </div>
         </div>
         <div className="flex items-center justify-center gap-1.5 backdrop-blur-[20px] bg-white/[0.2] border border-white/30 rounded-[10px] px-3 py-1.5 shadow-sm animate-slide-up-delayed">
-          <Medal className="w-5 h-5 text-[#a89780]" />
+          <Medal
+            aria-hidden="true"
+            data-testid="projects-podium-medal-second"
+            className="w-5 h-5 text-[#a89780]"
+          />
           <span className={`text-[16px] font-bold transition-colors ${
             theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
           }`}>#2</span>
@@ -54,9 +67,17 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
         isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-12'
       }`}>
         <div className="relative backdrop-blur-[30px] bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border-2 border-[#c9983a]/60 rounded-[20px] p-7 w-[170px] shadow-[0_8px_32px_rgba(201,152,58,0.35)] mb-3 hover:shadow-[0_12px_40px_rgba(201,152,58,0.5)] hover:scale-110 transition-all duration-300 group">
-          <div className="absolute inset-0 bg-gradient-to-br from-[#c9983a]/10 to-transparent rounded-[20px] animate-pulse-glow" />
+          <div
+            aria-hidden="true"
+            data-testid="projects-podium-golden-glow"
+            className="absolute inset-0 bg-gradient-to-br from-[#c9983a]/10 to-transparent rounded-[20px] animate-pulse-glow"
+          />
           
-          <div className="absolute inset-0 overflow-hidden rounded-[20px]">
+          <div
+            aria-hidden="true"
+            data-testid="projects-podium-rays"
+            className="absolute inset-0 overflow-hidden rounded-[20px]"
+          >
             {[...Array(8)].map((_, i) => (
               <div
                 key={i}
@@ -69,7 +90,11 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
             ))}
           </div>
           
-          <div className="absolute inset-0 overflow-hidden rounded-[20px]">
+          <div
+            aria-hidden="true"
+            data-testid="projects-podium-particles"
+            className="absolute inset-0 overflow-hidden rounded-[20px]"
+          >
             {[...Array(12)].map((_, i) => (
               <div
                 key={i}
@@ -84,16 +109,28 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
             ))}
           </div>
           
-          <div className="absolute -inset-3 border-2 border-[#c9983a]/20 rounded-[24px] animate-ping-gentle" />
+          <div
+            aria-hidden="true"
+            data-testid="projects-podium-ping-ring"
+            className="absolute -inset-3 border-2 border-[#c9983a]/20 rounded-[24px] animate-ping-gentle"
+          />
           
           <div className="relative">
             <div className="relative w-20 h-20 rounded-full bg-gradient-to-br from-[#c9983a] to-[#a67c2e] flex items-center justify-center mx-auto mb-3 border-2 border-[#d4af37] shadow-xl text-3xl overflow-hidden group-hover:rotate-[360deg] transition-transform duration-700">
               {isLogoUrl(topThree[0].logo) ? (
-                <img src={topThree[0].logo} alt="" className="w-full h-full object-cover" />
+                <img
+                  src={topThree[0].logo}
+                  alt={`${topThree[0].name} logo`}
+                  className="w-full h-full object-cover"
+                />
               ) : (
                 topThree[0].logo
               )}
-              <Crown className="absolute -top-6 left-1/2 -translate-x-1/2 w-6 h-6 text-[#d4af37] animate-float" />
+              <Crown
+                aria-hidden="true"
+                data-testid="projects-podium-crown"
+                className="absolute -top-6 left-1/2 -translate-x-1/2 w-6 h-6 text-[#d4af37] animate-float"
+              />
             </div>
             <div className="text-center">
               <div className={`text-[14px] font-bold mb-1 transition-colors ${
@@ -107,7 +144,11 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
           </div>
         </div>
         <div className="flex items-center justify-center gap-1.5 backdrop-blur-[20px] bg-gradient-to-br from-[#c9983a]/40 to-[#d4af37]/30 border-2 border-[#c9983a]/70 rounded-[12px] px-4 py-2 shadow-md animate-slide-up">
-          <Trophy className="w-6 h-6 text-[#c9983a] animate-bounce-gentle" />
+          <Trophy
+            aria-hidden="true"
+            data-testid="projects-podium-trophy"
+            className="w-6 h-6 text-[#c9983a] animate-bounce-gentle"
+          />
           <span className={`text-[18px] font-bold transition-colors ${
             theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
           }`}>#1</span>
@@ -122,12 +163,20 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
           <div className="relative">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[#b89968]/80 to-[#9a7d4f]/70 flex items-center justify-center mx-auto mb-3 border-2 border-white/30 shadow-lg text-2xl overflow-hidden group-hover:rotate-12 transition-transform duration-300">
               {isLogoUrl(topThree[2].logo) ? (
-                <img src={topThree[2].logo} alt="" className="w-full h-full object-cover" />
+                <img
+                  src={topThree[2].logo}
+                  alt={`${topThree[2].name} logo`}
+                  className="w-full h-full object-cover"
+                />
               ) : (
                 topThree[2].logo
               )}
             </div>
-            <Sparkles className="absolute -top-1 -right-1 w-4 h-4 text-[#b89968] opacity-0 group-hover:opacity-100 transition-opacity" />
+            <Sparkles
+              aria-hidden="true"
+              data-testid="projects-podium-sparkles-third"
+              className="absolute -top-1 -right-1 w-4 h-4 text-[#b89968] opacity-0 group-hover:opacity-100 transition-opacity"
+            />
           </div>
           <div className="text-center">
             <div className={`text-[13px] font-bold mb-1 transition-colors ${
@@ -140,7 +189,11 @@ export function ProjectsPodium({ topThree, isLoaded }: ProjectsPodiumProps) {
           </div>
         </div>
         <div className="flex items-center justify-center gap-1.5 backdrop-blur-[20px] bg-white/[0.2] border border-white/30 rounded-[10px] px-3 py-1.5 shadow-sm animate-slide-up-more-delayed">
-          <Medal className="w-5 h-5 text-[#b89968]" />
+          <Medal
+            aria-hidden="true"
+            data-testid="projects-podium-medal-third"
+            className="w-5 h-5 text-[#b89968]"
+          />
           <span className={`text-[16px] font-bold transition-colors ${
             theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
           }`}>#3</span>


### PR DESCRIPTION
## Summary
- Adds project-specific alt text for URL logos in `ProjectsPodium`
- Marks decorative podium icons and first-place animation overlays as `aria-hidden`
- Adds focused component coverage for logo names, textual ranks, and decorative hidden markers

## Verification
- Static source check confirms all podium URL logos now use project-specific `alt` text
- Static source check confirms decorative icons/overlays have `aria-hidden="true"`
- Added `ProjectsPodium.test.tsx` for the acceptance criteria
- `npm install --cache E:\.npm-cache --prefer-offline --no-audit --no-fund` was attempted in the partial API checkout but timed out before dependencies were available, so I could not execute Vitest locally in this workspace

## Security notes
- No security-sensitive behavior or data handling changes

Closes #253