### PR TITLE
fix(a11y): label filter chip remove buttons

### DIFF
--- a/src/features/dashboard/pages/BrowsePage.test.tsx
+++ b/src/features/dashboard/pages/BrowsePage.test.tsx
@@ -395,7 +395,7 @@ describe("BrowsePage filters", () => {
     );
   });
 
-  it("removes an active-filter chip when its X is clicked", async () => {
+  it("labels and removes an active-filter chip when its remove button is clicked", async () => {
     getPublicProjects.mockResolvedValue(makeResponse(2, 2));
     renderPage();
     await waitFor(() => expect(cards()).toBe(2));
@@ -405,10 +405,13 @@ describe("BrowsePage filters", () => {
     const chip = await screen.findByText("TypeScript");
     expect(chip).toBeInTheDocument();
 
-    // The chip's X button is the last button rendered inside the chip.
-    const xButton = chip.closest("span")?.querySelector("button");
-    expect(xButton).toBeTruthy();
-    await userEvent.click(xButton as HTMLButtonElement);
+    const removeButton = screen.getByRole("button", {
+      name: "Remove filter: TypeScript",
+    });
+    expect(removeButton.className).toMatch(/focus-visible:ring-2/);
+    expect(removeButton.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+
+    await userEvent.click(removeButton);
 
     await waitFor(() =>
       expect(screen.queryByText("TypeScript")).not.toBeInTheDocument(),

--- a/src/features/dashboard/pages/BrowsePage.tsx
+++ b/src/features/dashboard/pages/BrowsePage.tsx
@@ -38,7 +38,7 @@ const formatNumber = (num: number): string => {
 // Helper function to get project icon/avatar
 const getProjectIcon = (githubFullName: string): string => {
   const [owner] = githubFullName.split("/");
-  // Use higher‑resolution owner avatar so cards look crisp
+  // Use higher-resolution owner avatar so cards look crisp
   return `https://github.com/${owner}.png?size=200`;
 };
 
@@ -393,9 +393,10 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
                 {value}
                 <button
                   onClick={() => clearFilter(filterType, value)}
-                  className="hover:text-red-200 transition-colors"
+                  aria-label={`Remove filter: ${value}`}
+                  className="rounded-sm hover:text-red-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-[#a17932]"
                 >
-                  <X className="w-3.5 h-3.5" />
+                  <X aria-hidden="true" className="w-3.5 h-3.5" />
                 </button>
               </span>
             )),


### PR DESCRIPTION
## Summary
- Adds descriptive `aria-label` text to BrowsePage active-filter chip remove buttons
- Marks the decorative X icon as `aria-hidden`
- Keeps visible focus styling by adding a focus-visible ring to the remove control
- Updates the focused BrowsePage test to assert the accessible remove label, hidden icon, and chip removal flow

## Verification
- Static source check confirms the remove button now renders `aria-label="Remove filter: {value}"`
- Static source check confirms the X icon has `aria-hidden="true"`
- Static source check confirms the remove button includes `focus-visible:ring-2`
- Vitest was not executed locally because this API-based partial checkout has no usable `node_modules`; dependency installation was already attempted in the sibling Grainlify checkout and timed out before test dependencies were available

## Security notes
- Label text is derived from the existing selected filter value rendered visibly in the same chip; no new data flow or sensitive handling is introduced

Closes #250