### PR TITLE
fix(a11y): announce Toast messages via live regions

### DIFF
--- a/src/shared/components/Toast.test.tsx
+++ b/src/shared/components/Toast.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import Toast from './Toast';
+
+const toasterProps: Record<string, unknown>[] = [];
+
+vi.mock('sonner', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    Toaster: React.forwardRef<HTMLElement, Record<string, unknown>>((props, ref) => {
+      toasterProps.push(props);
+
+      return (
+        <section ref={ref} aria-label="Notifications Alt+T">
+          <ol>
+            <li data-sonner-toast="" data-type="success">
+              <div data-title="">Saved successfully</div>
+              <button data-close-button="">x</button>
+            </li>
+            <li data-sonner-toast="" data-type="info">
+              <div data-title="">Copied to clipboard</div>
+              <button data-close-button="">x</button>
+            </li>
+            <li data-sonner-toast="" data-type="error">
+              <div data-title="">Save failed</div>
+              <button data-close-button="">x</button>
+            </li>
+          </ol>
+        </section>
+      );
+    }),
+  };
+});
+
+function renderToast() {
+  return render(
+    <ThemeProvider>
+      <Toast />
+    </ThemeProvider>,
+  );
+}
+
+describe('Toast accessibility', () => {
+  it('marks success and info toasts as polite status live regions', async () => {
+    renderToast();
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved successfully').closest('[data-sonner-toast]')).toHaveAttribute(
+        'role',
+        'status',
+      );
+    });
+
+    expect(screen.getByText('Saved successfully').closest('[data-sonner-toast]')).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+    expect(screen.getByText('Copied to clipboard').closest('[data-sonner-toast]')).toHaveAttribute(
+      'role',
+      'status',
+    );
+    expect(screen.getByText('Copied to clipboard').closest('[data-sonner-toast]')).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+  });
+
+  it('marks error toasts as assertive alert live regions', async () => {
+    renderToast();
+
+    const errorToast = screen.getByText('Save failed').closest('[data-sonner-toast]');
+
+    await waitFor(() => {
+      expect(errorToast).toHaveAttribute('role', 'alert');
+    });
+
+    expect(errorToast).toHaveAttribute('aria-live', 'assertive');
+    expect(errorToast).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('labels dismiss buttons and keeps Sonner auto-dismiss configuration', async () => {
+    renderToast();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Dismiss notification' })).toHaveLength(3);
+    });
+
+    expect(toasterProps.at(-1)).toMatchObject({
+      closeButton: true,
+      duration: 3000,
+      containerAriaLabel: 'Notifications',
+      toastOptions: expect.objectContaining({
+        closeButtonAriaLabel: 'Dismiss notification',
+      }),
+    });
+  });
+});

--- a/src/shared/components/Toast.tsx
+++ b/src/shared/components/Toast.tsx
@@ -1,17 +1,67 @@
 import { Toaster } from 'sonner'
+import { useEffect, useRef } from 'react'
 import { useTheme } from '../contexts/ThemeContext'
+
+const DISMISS_LABEL = 'Dismiss notification';
+
+/**
+ * Sonner does not expose per-toast ARIA roles, so enhance the rendered toast
+ * nodes after insertion while preserving Sonner's timing and interaction logic.
+ */
+function useToastLiveRegionRoles() {
+  const toasterRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = toasterRef.current;
+    if (!root || typeof MutationObserver === 'undefined') return;
+
+    const enhanceToasts = () => {
+      root.querySelectorAll<HTMLElement>('[data-sonner-toast]').forEach((toast) => {
+        const isError = toast.dataset.type === 'error';
+        toast.setAttribute('role', isError ? 'alert' : 'status');
+        toast.setAttribute('aria-live', isError ? 'assertive' : 'polite');
+        toast.setAttribute('aria-atomic', 'true');
+      });
+
+      root
+        .querySelectorAll<HTMLButtonElement>('[data-close-button]')
+        .forEach((button) => {
+          button.setAttribute('aria-label', DISMISS_LABEL);
+        });
+    };
+
+    enhanceToasts();
+
+    const observer = new MutationObserver(enhanceToasts);
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-type'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return toasterRef;
+}
 
 const Toast = () => {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const toasterRef = useToastLiveRegionRoles();
+
   return (
     <Toaster
+      ref={toasterRef}
       richColors={false}
       position="top-right"
       closeButton={true}
       duration={3000}
+      containerAriaLabel="Notifications"
       toastOptions={{
         unstyled: true,
+        closeButtonAriaLabel: DISMISS_LABEL,
         className: `${isDark ? 'bg-[#2d2820] text-[#e8dfd0] border-white/15' : 'bg-[#ede3d0] text-[#2d2820] border-[#c9983a]/30'} backdrop-blur-[40px] w-[340px] flex flex-row text-md py-3 px-4 rounded-[14px] border-2 shadow-lg`,
         classNames: {
           closeButton: "order-last ml-auto cursor-pointer rounded-[10px] p-1 hover:opacity-80 transition-opacity",


### PR DESCRIPTION
## Summary
- Adds a Toast DOM enhancement pass that marks success/info notifications as `role="status"` with polite live announcements
- Marks error notifications as `role="alert"` with assertive live announcements
- Labels dismiss controls consistently as `Dismiss notification`
- Keeps the existing Sonner position, styling, and 3000ms auto-dismiss duration
- Adds focused tests for success/info roles, error role, dismiss labels, and auto-dismiss configuration

## Verification
- Static source check confirms `role`, `aria-live`, and `aria-atomic` are applied to rendered `[data-sonner-toast]` nodes
- Static source check confirms close buttons receive `aria-label="Dismiss notification"`
- Static source check confirms the existing `duration={3000}` behavior is preserved
- Vitest was not executed locally because this API-based partial checkout has no usable `node_modules`; the earlier dependency install attempt in a sibling Grainlify checkout timed out before test dependencies were available

## Security notes
- Toast message rendering remains owned by Sonner/React; this change only sets ARIA attributes on already-rendered notification nodes
- No markup interpolation, auth, payment, or sensitive data handling changes

Closes #256