### PR TITLE
feat(i18n): sync html lang with active locale

### DIFF
--- a/src/shared/i18n/I18nProvider.tsx
+++ b/src/shared/i18n/I18nProvider.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { IntlProvider } from 'react-intl'
 import { DEFAULT_LOCALE, resolveMessages, type Locale } from './messages'
 import { handleIntlError } from './errors'
@@ -21,7 +21,10 @@ export interface I18nProviderProps {
  * project's message catalog, guaranteed English fallback, and error policy
  * ({@link handleIntlError}).
  *
- * Mounted once at the very top of the tree — above the router — in
+ * It also keeps `<html lang>` synchronized with the active locale so assistive
+ * technologies and translation tools can interpret every route correctly.
+ *
+ * Mounted once at the very top of the tree - above the router - in
  * `src/app/App.tsx`, so every route can call `useTranslation()` or render
  * `<FormattedMessage>`.
  *
@@ -31,6 +34,12 @@ export interface I18nProviderProps {
  * </I18nProvider>
  */
 export function I18nProvider({ locale = DEFAULT_LOCALE, messages, children }: I18nProviderProps) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    document.documentElement.lang = locale
+  }, [locale])
+
   return (
     <IntlProvider
       locale={locale}

--- a/src/shared/i18n/i18n.test.tsx
+++ b/src/shared/i18n/i18n.test.tsx
@@ -40,9 +40,9 @@ describe('i18n catalog & fallback', () => {
     const partial: Partial<Messages> = { 'dashboardNav.discover': 'Descubrir' }
     const msgs = resolveMessages('es' as Locale, { es: partial })
 
-    // Provided key uses the locale value…
+    // Provided key uses the locale value.
     expect(msgs['dashboardNav.discover']).toBe('Descubrir')
-    // …every other key falls back to its English value.
+    // .every other key falls back to its English value.
     expect(msgs['dashboardNav.browse']).toBe('Browse')
     expect(msgs['landingNav.features']).toBe('Features')
   })
@@ -76,6 +76,40 @@ describe('useTranslation', () => {
     expect(result.current.t('dashboardNav.discover')).toBe('Discover')
     expect(result.current.t('landingNav.getStarted')).toBe('Get Started')
     expect(result.current.locale).toBe('en')
+  })
+})
+
+describe('html lang synchronization', () => {
+  it('defaults document.documentElement.lang to en', async () => {
+    document.documentElement.lang = ''
+
+    render(
+      <I18nProvider>
+        <div>App content</div>
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+  })
+
+  it('updates document.documentElement.lang when the active locale changes', async () => {
+    document.documentElement.lang = 'en'
+
+    const { rerender } = render(
+      <I18nProvider locale={'en' as Locale}>
+        <div>App content</div>
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+
+    rerender(
+      <I18nProvider locale={'es' as Locale} messages={resolveMessages('es' as Locale)}>
+        <div>App content</div>
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(document.documentElement.lang).toBe('es'))
   })
 })
 
@@ -129,8 +163,8 @@ describe('number formatting', () => {
     const { result } = renderHook(() => useLandingStats(), { wrapper })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    expect(result.current.display.activeProjects).toBe('—')
-    expect(result.current.display.grantsDistributed).toBe('—')
+    expect(result.current.display.activeProjects).toBe('-')
+    expect(result.current.display.grantsDistributed).toBe('-')
     expect(result.current.error).toBe('boom')
   })
 })
@@ -163,7 +197,7 @@ describe('plural formatting', () => {
   })
 })
 
-describe('security — interpolation is text-only', () => {
+describe('security - interpolation is text-only', () => {
   it('renders interpolated untrusted markup as inert text, never as DOM', () => {
     const evil = '<img src=x onerror="window.__pwned = true">'
 
@@ -177,7 +211,7 @@ describe('security — interpolation is text-only', () => {
       </I18nProvider>
     )
 
-    // No element was injected — the payload never became part of the DOM tree.
+    // No element was injected - the payload never became part of the DOM tree.
     expect(container.querySelector('img')).toBeNull()
     expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
     // The raw markup is present verbatim, as a text node.


### PR DESCRIPTION
## Summary
- Synchronizes `document.documentElement.lang` from the active `I18nProvider` locale
- Keeps the default behavior as `en`, matching the static `index.html` initial value
- Documents the provider-level `<html lang>` behavior in the i18n provider TSDoc
- Adds focused i18n tests for default `en` and locale-change updates

## Verification
- Static source check confirms `document.documentElement.lang = locale` runs in an effect keyed by `locale`
- Static source check confirms tests cover default `en` and rerendered locale changes
- Vitest was not executed locally because this API-based partial checkout has no usable `node_modules`

## Security notes
- The written value comes from the typed `Locale` value supplied to `I18nProvider`
- No auth, payment, wallet, or sensitive data handling changes

Closes #257