### PR TITLE
fix(a11y): label PRRow status indicators

### DIFF
--- a/src/features/maintainers/components/pull-requests/PRRow.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PRRow.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import { PRRow } from './PRRow'
+import { renderWithTheme } from '../../../../test/renderWithTheme'
+import type { PullRequest } from '../../types'
+
+const PR: PullRequest = {
+  id: 1,
+  number: 42,
+  title: 'Improve pull request indicators',
+  status: 'open',
+  statusDetail: 'opened today',
+  url: 'https://github.com/octo-org/frontend-app/pull/42',
+  author: {
+    name: 'alice',
+    avatar: '',
+    badges: [],
+  },
+  repo: 'frontend-app',
+  org: 'octo-org',
+  indicators: ['check', 'x', 'trophy', 'eye', 'code'],
+}
+
+describe('PRRow indicators', () => {
+  it('labels status indicators for screen readers and hides the decorative icons', () => {
+    renderWithTheme(<PRRow pr={PR} />)
+
+    expect(screen.getByText('Improve pull request indicators')).toBeInTheDocument()
+
+    const labels = [
+      'Checks passing',
+      'Checks failing',
+      'Rewarded pull request',
+      'Needs review',
+      'Code changes',
+    ]
+
+    labels.forEach((label) => {
+      const indicator = screen.getByRole('img', { name: label })
+      expect(indicator.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
+})

--- a/src/features/maintainers/components/pull-requests/PRRow.tsx
+++ b/src/features/maintainers/components/pull-requests/PRRow.tsx
@@ -49,6 +49,26 @@ export function PRRow({ pr }: PRRowProps) {
     }
   }
 
+  /**
+   * Returns the screen-reader text equivalent for visual-only PR indicators.
+   */
+  const getIndicatorLabel = (indicator: string) => {
+    switch (indicator) {
+      case 'check':
+        return 'Checks passing'
+      case 'x':
+        return 'Checks failing'
+      case 'trophy':
+        return 'Rewarded pull request'
+      case 'eye':
+        return 'Needs review'
+      case 'code':
+        return 'Code changes'
+      default:
+        return 'Pull request indicator'
+    }
+  }
+
   const getPRStatusColor = () => {
     switch (pr.status) {
       case 'merged':
@@ -179,12 +199,14 @@ export function PRRow({ pr }: PRRowProps) {
           const { Icon, color } = getIndicatorIcon(indicator)
           return (
             <div
-              key={idx}
+              key={`${indicator}-${idx}`}
+              role="img"
+              aria-label={getIndicatorLabel(indicator)}
               className={`w-7 h-7 rounded-full border flex items-center justify-center hover:scale-110 transition-transform ${
                 theme === 'dark' ? 'bg-white/20 border-white/30' : 'bg-white/30 border-white/40'
               }`}
             >
-              <Icon className={`w-3.5 h-3.5 ${color}`} />
+              <Icon aria-hidden="true" className={`w-3.5 h-3.5 ${color}`} />
             </div>
           )
         })}


### PR DESCRIPTION
## Summary
- Add screen-reader labels for PRRow status indicator circles.
- Mark the underlying lucide icons as decorative once a text alternative exists.
- Add focused coverage for all existing indicator states.

## Verification
- Added `PRRow.test.tsx` assertions for the accessible names and decorative SVG hiding.
- Confirmed this API partial checkout has no `node_modules`, so Vitest was not run locally.

## Security
- UI-only accessibility change; no auth, network, storage, or user-data handling changes.

Closes #251
