### PR TITLE
i18n: extract maintainers page strings

### DIFF
--- a/src/features/maintainers/pages/MaintainersPage.test.tsx
+++ b/src/features/maintainers/pages/MaintainersPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MaintainersPage } from './MaintainersPage';
+import { getMyProjects, getPendingSetupProjects } from '../../../shared/api/client';
+import { I18nProvider, resolveMessages } from '../../../shared/i18n';
+
+vi.mock('../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('../../../shared/api/client', () => ({
+  getMyProjects: vi.fn(),
+  getPendingSetupProjects: vi.fn(),
+}));
+
+vi.mock('../components/dashboard/DashboardTab', () => ({
+  DashboardTab: () => <div>Dashboard panel</div>,
+}));
+
+vi.mock('../components/issues/IssuesTab', () => ({
+  IssuesTab: () => <div>Issues panel</div>,
+}));
+
+vi.mock('../components/pull-requests/PullRequestsTab', () => ({
+  PullRequestsTab: () => <div>Pull requests panel</div>,
+}));
+
+vi.mock('../components/InstallGitHubAppModal', () => ({
+  InstallGitHubAppModal: () => null,
+}));
+
+vi.mock('../components/NewProjectSetupModal', () => ({
+  NewProjectSetupModal: () => null,
+}));
+
+const mockGetMyProjects = vi.mocked(getMyProjects);
+const mockGetPendingSetupProjects = vi.mocked(getPendingSetupProjects);
+
+function renderPage(messages = resolveMessages('en')) {
+  return render(
+    <I18nProvider messages={messages}>
+      <MaintainersPage onNavigate={vi.fn()} />
+    </I18nProvider>
+  );
+}
+
+async function openRepositorySelector() {
+  fireEvent.click(screen.getByRole('button', { name: /select repositories/i }));
+}
+
+describe('MaintainersPage i18n', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMyProjects.mockResolvedValue([]);
+    mockGetPendingSetupProjects.mockResolvedValue([]);
+  });
+
+  it('renders tab labels from the message catalog', () => {
+    renderPage({
+      ...resolveMessages('en'),
+      'maintainers.tabs.dashboard': 'Maintainer Home',
+      'maintainers.tabs.issues': 'Maintainer Issues',
+      'maintainers.tabs.pullRequests': 'Maintainer Pulls',
+    });
+
+    expect(screen.getByRole('button', { name: 'Maintainer Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Maintainer Issues' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Maintainer Pulls' })).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'auth failures',
+      new Error('Authentication failed: token expired'),
+      'Please sign in to view your repositories',
+    ],
+    [
+      'network failures',
+      new Error('Network error while fetching repositories'),
+      'Unable to connect to the server. Please check your connection and try again.',
+    ],
+    ['non-Error fallbacks', 'bad response', 'Failed to load repositories'],
+  ])('renders catalog-backed repository error text for %s', async (_name, rejection, expected) => {
+    mockGetMyProjects.mockRejectedValueOnce(rejection);
+
+    renderPage();
+    await openRepositorySelector();
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/maintainers/pages/MaintainersPage.tsx
+++ b/src/features/maintainers/pages/MaintainersPage.tsx
@@ -9,6 +9,7 @@ import { TabType } from '../types';
 import { getMyProjects, getPendingSetupProjects, type PendingSetupProject } from '../../../shared/api/client';
 import { InstallGitHubAppModal } from '../components/InstallGitHubAppModal';
 import { NewProjectSetupModal } from '../components/NewProjectSetupModal';
+import { useTranslation } from '../../../shared/i18n';
 
 interface MaintainersPageProps {
   onNavigate: (page: string) => void;
@@ -44,6 +45,7 @@ interface GroupedRepository {
 
 export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
   const { theme } = useTheme();
+  const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<TabType>('Dashboard');
   const [isRepoDropdownOpen, setIsRepoDropdownOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -80,6 +82,11 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
   };
 
   const tabs: TabType[] = ['Dashboard', 'Issues', 'Pull Requests'];
+  const tabLabels: Record<TabType, string> = {
+    Dashboard: t('maintainers.tabs.dashboard'),
+    Issues: t('maintainers.tabs.issues'),
+    'Pull Requests': t('maintainers.tabs.pullRequests'),
+  };
 
   // Fetch pending setup projects (for New Project Setup modal after GitHub App install)
   const loadPendingSetup = async () => {
@@ -132,16 +139,16 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
     setError(null);
   } catch (err) {
     const errorMessage =
-      err instanceof Error ? err.message : 'Failed to load repositories';
+      err instanceof Error ? err.message : t('maintainers.errors.loadRepositories');
 
     if (
       errorMessage.includes('Authentication failed') ||
       errorMessage.includes('401')
     ) {
-      setError('Please sign in to view your repositories');
+      setError(t('maintainers.errors.signInRequired'));
     } else if (errorMessage.includes('Network error')) {
       setError(
-        'Unable to connect to the server. Please check your connection and try again.'
+        t('maintainers.errors.network')
       );
     } else {
       setError(errorMessage);
@@ -522,7 +529,7 @@ export function MaintainersPage({ onNavigate }: MaintainersPageProps) {
                     : 'text-[#7a6b5a] hover:text-[#2d2820] hover:bg-white/[0.1] border-2 border-transparent'
                   }`}
               >
-                {tab}
+                {tabLabels[tab]}
               </button>
             ))}
           </div>

--- a/src/shared/i18n/i18n.test.tsx
+++ b/src/shared/i18n/i18n.test.tsx
@@ -74,6 +74,10 @@ describe('useTranslation', () => {
   it('resolves typed keys to their English strings and exposes the locale', () => {
     const { result } = renderHook(() => useTranslation(), { wrapper })
     expect(result.current.t('dashboardNav.discover')).toBe('Discover')
+    expect(result.current.t('maintainers.tabs.dashboard')).toBe('Dashboard')
+    expect(result.current.t('maintainers.errors.loadRepositories')).toBe(
+      'Failed to load repositories'
+    )
     expect(result.current.t('landingNav.getStarted')).toBe('Get Started')
     expect(result.current.locale).toBe('en')
   })

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -33,6 +33,8 @@ export const DEFAULT_LOCALE: Locale = 'en'
  *   extracted from `src/features/landing/components/Navbar.tsx`.
  * - `dashboardNav.*` — the authenticated dashboard sidebar navigation,
  *   extracted from `src/features/dashboard/DashboardLayout.tsx`.
+ * - `maintainers.*` — maintainer workspace navigation and repository-load
+ *   errors from `src/features/maintainers/pages/MaintainersPage.tsx`.
  *
  * `as const` keeps every value a string literal so {@link MessageId} can be
  * derived from the keys with full type-safety.
@@ -57,6 +59,15 @@ export const en = {
   'dashboardNav.data': 'Data',
   'dashboardNav.leaderboard': 'Leaderboard',
   'dashboardNav.blog': 'Grainlify Blog',
+
+  // ── Maintainers page — src/features/maintainers/pages/MaintainersPage.tsx ──
+  'maintainers.tabs.dashboard': 'Dashboard',
+  'maintainers.tabs.issues': 'Issues',
+  'maintainers.tabs.pullRequests': 'Pull Requests',
+  'maintainers.errors.loadRepositories': 'Failed to load repositories',
+  'maintainers.errors.signInRequired': 'Please sign in to view your repositories',
+  'maintainers.errors.network':
+    'Unable to connect to the server. Please check your connection and try again.',
 } as const
 
 /**


### PR DESCRIPTION
Closes #263

Summary:
- Added maintainer page tab labels and repository loading error messages to the shared i18n catalog.
- Updated MaintainersPage to resolve those user-facing strings through useTranslation while preserving the existing TabType values.
- Added page-level coverage for catalog-backed tab labels and auth/network/fallback repository errors, plus catalog assertions in i18n tests.

Verification:
- npm test -- src/features/maintainers/pages/MaintainersPage.test.tsx src/shared/i18n/i18n.test.tsx (16 tests passed)
- npm run typecheck
- npx eslint src/features/maintainers/pages/MaintainersPage.tsx src/features/maintainers/pages/MaintainersPage.test.tsx src/shared/i18n/messages.ts src/shared/i18n/i18n.test.tsx (passes; existing warnings remain in MaintainersPage)
- npm run build