### PR TITLE
fix(a11y): label dashboard sidebar toggle

### DIFF
--- a/src/features/dashboard/DashboardLayout.test.tsx
+++ b/src/features/dashboard/DashboardLayout.test.tsx
@@ -52,6 +52,11 @@ function renderLayout() {
 
 describe('DashboardLayout i18n nav labels', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    })
     sessionStorage.clear()
     vi.clearAllMocks()
   })
@@ -82,5 +87,21 @@ describe('DashboardLayout i18n nav labels', () => {
 
     expect(screen.getByText('Maintainers')).toBeInTheDocument()
     expect(screen.getByText('Data')).toBeInTheDocument()
+  })
+
+  it('labels the sidebar toggle and reflects expanded state', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    const collapseButton = screen.getByRole('button', { name: 'Collapse sidebar' })
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
+    expect(collapseButton).toHaveAttribute('title', 'Collapse sidebar')
+    expect(collapseButton.className).toMatch(/focus-visible:ring-2/)
+
+    await user.click(collapseButton)
+
+    const expandButton = screen.getByRole('button', { name: 'Expand sidebar' })
+    expect(expandButton).toHaveAttribute('aria-expanded', 'false')
+    expect(expandButton).toHaveAttribute('title', 'Expand sidebar')
   })
 })

--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -168,6 +168,7 @@ export function DashboardLayout() {
   const darkTheme = theme === "dark";
   const isSmallDevice = deviceWidth && deviceWidth < 1024;
   const showMobileNav = mobileMenuOpen && isSmallDevice;
+  const sidebarToggleLabel = isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (
     <div
@@ -202,12 +203,15 @@ export function DashboardLayout() {
         {/* Toggle Arrow Button */}
         <button
           onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-          className={`absolute z-[100] backdrop-blur-[90px] rounded-full border-[0.5px] w-6 h-6 shadow-md hover:shadow-lg transition-all flex items-center justify-center ${
+          aria-label={sidebarToggleLabel}
+          aria-expanded={!isSidebarCollapsed}
+          title={sidebarToggleLabel}
+          className={`absolute z-[100] backdrop-blur-[90px] rounded-full border-[0.5px] w-6 h-6 shadow-md hover:shadow-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 ${
             isSidebarCollapsed ? "-right-3 top-[60px]" : "-right-3 top-[60px]"
           } ${
             darkTheme
-              ? "bg-[#2d2820]/[0.85] border-[rgba(201,152,58,0.2)]"
-              : "bg-white/[0.85] border-[rgba(245,239,235,0.32)]"
+              ? "bg-[#2d2820]/[0.85] border-[rgba(201,152,58,0.2)] focus-visible:ring-offset-[#2d2820]"
+              : "bg-white/[0.85] border-[rgba(245,239,235,0.32)] focus-visible:ring-offset-white"
           }`}
         >
           <ChevronRight


### PR DESCRIPTION
## Summary
- Add a dynamic accessible name to the DashboardLayout sidebar collapse/expand toggle.
- Reflect the sidebar state with `aria-expanded` and keep the matching `title` tooltip.
- Add visible focus ring classes and cover expanded/collapsed states in the existing DashboardLayout test.

Closes #246

## Tests
- `npm test -- src/features/dashboard/DashboardLayout.test.tsx` (3 passed)
- `npx eslint src/features/dashboard/DashboardLayout.tsx src/features/dashboard/DashboardLayout.test.tsx` (0 errors; existing warnings remain for `_pendingAdminTarget` and `any` in DashboardLayout)

## Security notes
- No user-controlled content is rendered or exposed by this change.