### PR TITLE
feat(ux): add delayed TermsTab loading skeleton

### DIFF
--- a/src/features/settings/components/terms/TermsTab.test.tsx
+++ b/src/features/settings/components/terms/TermsTab.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { TermsTab, CURRENT_TERMS_VERSION } from './TermsTab';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TermsTab, CURRENT_TERMS_VERSION, TERMS_STATUS_SKELETON_DELAY_MS } from './TermsTab';
 import { getTermsStatus, acceptTerms } from '../../../../shared/api/client';
 import { ThemeProvider } from '../../../../shared/contexts/ThemeContext';
 
@@ -23,13 +23,41 @@ describe('TermsTab', () => {
     vi.clearAllMocks();
   });
 
-  it('renders loading state initially', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a skeleton only after the delayed loading threshold', async () => {
+    vi.useFakeTimers();
     vi.mocked(getTermsStatus).mockImplementation(() => new Promise(() => {}));
+
     renderWithTheme(<TermsTab />);
-    
-    const button = screen.getByRole('button', { name: /loading/i });
+
+    const button = screen.getByRole('button', { name: /checking/i });
     expect(button).toBeInTheDocument();
     expect(button).toBeDisabled();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(TERMS_STATUS_SKELETON_DELAY_MS);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Checking terms status...');
+    expect(screen.getByText('Checking terms status...').closest('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('does not flash the skeleton for fast status loads', async () => {
+    vi.mocked(getTermsStatus).mockResolvedValue({
+      accepted: false,
+      version: null,
+      accepted_at: null,
+    });
+
+    renderWithTheme(<TermsTab />);
+
+    const button = await screen.findByRole('button', { name: 'Accept' });
+    expect(button).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('renders terms content and accept button when not accepted', async () => {
@@ -130,9 +158,6 @@ describe('TermsTab', () => {
   });
 
   it('handles error when getting status', async () => {
-    // Should suppress console.error for this test
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    
     vi.mocked(getTermsStatus).mockRejectedValue(new Error('Fetch failed'));
 
     renderWithTheme(<TermsTab />);
@@ -140,8 +165,8 @@ describe('TermsTab', () => {
     const button = await screen.findByRole('button', { name: 'Accept' });
     expect(button).toBeInTheDocument();
     expect(button).not.toBeDisabled();
-    
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch terms status:', expect.any(Error));
-    consoleSpy.mockRestore();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Unable to load your terms status. You can still review the terms and try accepting again.'
+    );
   });
 });

--- a/src/features/settings/components/terms/TermsTab.tsx
+++ b/src/features/settings/components/terms/TermsTab.tsx
@@ -9,20 +9,57 @@ import { getTermsStatus, acceptTerms } from '../../../../shared/api/client';
 export const CURRENT_TERMS_VERSION = '1.0.0';
 
 /**
+ * Delay before showing the loading skeleton so fast status checks do not flash.
+ */
+export const TERMS_STATUS_SKELETON_DELAY_MS = 200;
+
+function TermsStatusSkeleton({ theme }: { theme: string }) {
+  const shimmer = theme === 'dark' ? 'bg-white/10' : 'bg-black/10';
+  const textColor = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]';
+
+  return (
+    <div role="status" aria-live="polite" className="w-full">
+      <p className={`text-[13px] font-medium mb-4 ${textColor}`}>
+        Checking terms status...
+      </p>
+      <div className="flex items-center justify-between gap-6">
+        <div className="flex-1 space-y-3" aria-hidden="true">
+          <div className={`h-4 w-40 rounded-full animate-pulse ${shimmer}`} />
+          <div className={`h-3 w-full max-w-[520px] rounded-full animate-pulse ${shimmer}`} />
+          <div className={`h-3 w-72 rounded-full animate-pulse ${shimmer}`} />
+        </div>
+        <div
+          aria-hidden="true"
+          className={`h-12 w-28 rounded-[16px] animate-pulse flex-shrink-0 ${shimmer}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
  * TermsTab component
  * Displays terms of service, privacy policy, and handles user consent.
  */
 export function TermsTab() {
   const { theme } = useTheme();
   const [isLoading, setIsLoading] = useState(true);
+  const [showStatusSkeleton, setShowStatusSkeleton] = useState(false);
   const [isAccepting, setIsAccepting] = useState(false);
   const [isAccepted, setIsAccepted] = useState(false);
   const [acceptedVersion, setAcceptedVersion] = useState<string | null>(null);
   const [acceptedDate, setAcceptedDate] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
+    const skeletonTimer = window.setTimeout(() => {
+      if (mounted) {
+        setShowStatusSkeleton(true);
+      }
+    }, TERMS_STATUS_SKELETON_DELAY_MS);
+
     const fetchStatus = async () => {
       try {
         const status = await getTermsStatus();
@@ -30,11 +67,16 @@ export function TermsTab() {
           setIsAccepted(status.accepted);
           setAcceptedVersion(status.version);
           setAcceptedDate(status.accepted_at);
+          setStatusError(null);
         }
-      } catch (err) {
-        console.error('Failed to fetch terms status:', err);
+      } catch {
+        if (mounted) {
+          setStatusError('Unable to load your terms status. You can still review the terms and try accepting again.');
+        }
       } finally {
         if (mounted) {
+          window.clearTimeout(skeletonTimer);
+          setShowStatusSkeleton(false);
           setIsLoading(false);
         }
       }
@@ -42,6 +84,7 @@ export function TermsTab() {
     fetchStatus();
     return () => {
       mounted = false;
+      window.clearTimeout(skeletonTimer);
     };
   }, []);
 
@@ -53,8 +96,9 @@ export function TermsTab() {
       setIsAccepted(true);
       setAcceptedVersion(res.version);
       setAcceptedDate(res.accepted_at);
-    } catch (err: any) {
-      setError(err.message || 'Failed to accept terms. Please try again.');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to accept terms. Please try again.';
+      setError(message);
     } finally {
       setIsAccepting(false);
     }
@@ -122,44 +166,59 @@ export function TermsTab() {
       </div>
 
       {/* Acceptance */}
-      <div className={`flex items-center justify-between backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
+      <div
+        aria-busy={isLoading}
+        aria-live="polite"
+        className={`flex items-center justify-between backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
         theme === 'dark'
           ? 'bg-[#2d2820]/[0.4] border-white/10'
           : 'bg-white/[0.12] border-white/20'
-      }`}>
-        <div>
-          <h3 className={`text-[16px] font-bold mb-1 transition-colors ${
-            theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-          }`}>Accept Terms</h3>
-          <p className={`text-[13px] transition-colors ${
-            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-          }`}>
-            By clicking accept, you agree to our <a href="/terms" className="underline hover:opacity-80">terms of service</a> and <a href="/privacy" className="underline hover:opacity-80">privacy policy</a>.
-          </p>
-          {isAccepted && acceptedVersion && acceptedDate && (
-            <p className="text-[12px] text-green-500 mt-2 font-medium">
-              ✓ Accepted version {acceptedVersion} on {new Date(acceptedDate).toLocaleDateString()}
-            </p>
-          )}
-          {error && (
-            <p className="text-[12px] text-red-500 mt-2 font-medium">
-              {error}
-            </p>
-          )}
-        </div>
-        <button
-          onClick={handleAccept}
-          disabled={isLoading || isAccepting || isAccepted}
-          className={`px-8 py-3 rounded-[16px] font-semibold text-[15px] transition-all border border-white/10 ${
-            isAccepted
-              ? 'bg-green-600/20 text-green-500 cursor-not-allowed border-green-500/20 shadow-none'
-              : isLoading
-              ? 'bg-gray-500/50 text-gray-300 cursor-wait shadow-none'
-              : 'bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] disabled:opacity-50 disabled:cursor-not-allowed'
-          }`}
-        >
-          {isLoading ? 'Loading...' : isAccepting ? 'Accepting...' : isAccepted ? 'Accepted' : 'Accept'}
-        </button>
+      }`}
+      >
+        {isLoading && showStatusSkeleton ? (
+          <TermsStatusSkeleton theme={theme} />
+        ) : (
+          <>
+            <div>
+              <h3 className={`text-[16px] font-bold mb-1 transition-colors ${
+                theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+              }`}>Accept Terms</h3>
+              <p className={`text-[13px] transition-colors ${
+                theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+              }`}>
+                By clicking accept, you agree to our <a href="/terms" className="underline hover:opacity-80">terms of service</a> and <a href="/privacy" className="underline hover:opacity-80">privacy policy</a>.
+              </p>
+              {statusError && (
+                <p role="alert" className="text-[12px] text-red-500 mt-2 font-medium">
+                  {statusError}
+                </p>
+              )}
+              {isAccepted && acceptedVersion && acceptedDate && (
+                <p className="text-[12px] text-green-500 mt-2 font-medium">
+                  ✓ Accepted version {acceptedVersion} on {new Date(acceptedDate).toLocaleDateString()}
+                </p>
+              )}
+              {error && (
+                <p className="text-[12px] text-red-500 mt-2 font-medium">
+                  {error}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={handleAccept}
+              disabled={isLoading || isAccepting || isAccepted}
+              className={`px-8 py-3 rounded-[16px] font-semibold text-[15px] transition-all border border-white/10 ${
+                isAccepted
+                  ? 'bg-green-600/20 text-green-500 cursor-not-allowed border-green-500/20 shadow-none'
+                  : isLoading
+                  ? 'bg-gray-500/50 text-gray-300 cursor-wait shadow-none'
+                  : 'bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] disabled:opacity-50 disabled:cursor-not-allowed'
+              }`}
+            >
+              {isLoading ? 'Checking...' : isAccepting ? 'Accepting...' : isAccepted ? 'Accepted' : 'Accept'}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #269

Summary:
- Added a delayed TermsTab status skeleton with a 200ms threshold so fast status checks do not flash placeholder UI.
- Added aria-busy/aria-live status announcement while the terms status is being fetched.
- Added a visible fetch-status error message while keeping the normal accept flow available after a status fetch failure.
- Replaced the raw console error path and unknown-cast acceptance error handling with user-facing state.
- Expanded TermsTab tests for slow loading, fast loading, and fetch-error paths.

Security notes:
- No sensitive data handling changed; this only improves status-fetch UX and avoids oversized/unhandled UI states.

Verification:
- npm test -- src/features/settings/components/terms/TermsTab.test.tsx (7 tests passed)
- npm run typecheck
- npx eslint src/features/settings/components/terms/TermsTab.tsx src/features/settings/components/terms/TermsTab.test.tsx
- npm run build
- npm run lint still fails on an existing unrelated repository baseline error in src/features/maintainers/components/InstallGitHubAppModal.test.tsx (@ts-ignore); this PR removes the previous TermsTab no-console error from the baseline.