### PR TITLE
feat(ux): separate avatar upload pending state

### DIFF
--- a/src/features/settings/components/profile/ProfileTab.test.tsx
+++ b/src/features/settings/components/profile/ProfileTab.test.tsx
@@ -51,6 +51,16 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 describe('ProfileTab', () => {
   it('renders heading and loads data', async () => {
     mockGetCurrentUser.mockResolvedValue(mockUser)
@@ -156,6 +166,69 @@ describe('ProfileTab', () => {
       expect(toast.error).toHaveBeenCalledWith(
         'Failed to update profile. Please try again.',
       )
+    })
+  })
+
+  it('keeps form save idle while the avatar upload is pending', async () => {
+    const avatarSave = deferred<void>()
+    mockGetCurrentUser.mockResolvedValue({
+      ...mockUser,
+      avatar_url: 'data:image/png;base64,new-avatar',
+    })
+    mockUpdateAvatar.mockReturnValue(avatarSave.promise)
+
+    renderWithTheme(<ProfileTab />)
+
+    const savePicture = await screen.findByRole('button', { name: 'Save Picture' })
+    await userEvent.click(savePicture)
+
+    expect(mockUpdateAvatar).toHaveBeenCalledWith('data:image/png;base64,new-avatar')
+    expect(screen.getByRole('button', { name: /saving picture/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /saving picture/i })).toHaveAttribute(
+      'aria-busy',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: /uploading/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^save$/i })).toHaveTextContent('Save')
+    expect(screen.queryByRole('button', { name: /^saving\.\.\.$/i })).not.toBeInTheDocument()
+
+    avatarSave.resolve()
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Profile picture updated successfully!')
+    })
+  })
+
+  it('keeps avatar controls idle while the profile form save is pending', async () => {
+    const user = userEvent.setup()
+    const profileSave = deferred<void>()
+    mockGetCurrentUser.mockResolvedValue({
+      ...mockUser,
+      avatar_url: 'data:image/png;base64,new-avatar',
+    })
+    mockUpdateProfile.mockReturnValue(profileSave.promise)
+
+    renderWithTheme(<ProfileTab />)
+
+    const firstNameInput = await screen.findByDisplayValue('John')
+    await user.clear(firstNameInput)
+    await user.type(firstNameInput, 'Jane')
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(screen.getByRole('button', { name: /^saving\.\.\.$/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save Picture' })).not.toHaveAttribute(
+      'aria-busy',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: 'Update' })).not.toHaveAttribute(
+      'aria-busy',
+      'true',
+    )
+    expect(screen.queryByRole('button', { name: /saving picture/i })).not.toBeInTheDocument()
+
+    profileSave.resolve()
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Profile updated successfully!')
     })
   })
 })

--- a/src/features/settings/components/profile/ProfileTab.tsx
+++ b/src/features/settings/components/profile/ProfileTab.tsx
@@ -1,7 +1,7 @@
 import { logger } from '../../../../shared/utils/logger';
 import { useState, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
-import { Github, User, Upload, Link as LinkIcon } from 'lucide-react';
+import { Github, Loader2, User, Upload, Link as LinkIcon } from 'lucide-react';
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
 import { getCurrentUser, updateProfile, updateAvatar, resyncGitHubProfile } from '../../../../shared/api/client';
 import { toast } from 'sonner';
@@ -50,6 +50,7 @@ export function ProfileTab() {
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isSavingAvatar, setIsSavingAvatar] = useState(false);
   const [isResyncing, setIsResyncing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -199,7 +200,7 @@ export function ProfileTab() {
   const handleSaveAvatar = async () => {
     if (!avatarUrl) return;
 
-    setIsSaving(true);
+    setIsSavingAvatar(true);
     try {
       await updateAvatar(avatarUrl);
       // Refetch user data to get updated avatar
@@ -213,7 +214,7 @@ export function ProfileTab() {
       logger.error('Failed to update avatar:', error);
       toast.error('Failed to update avatar. Please try again.');
     } finally {
-      setIsSaving(false);
+      setIsSavingAvatar(false);
     }
   };
 
@@ -367,21 +368,29 @@ export function ProfileTab() {
           />
           <button
             onClick={() => fileInputRef.current?.click()}
+            disabled={isSavingAvatar}
+            aria-busy={isSavingAvatar}
             className={`px-5 py-2.5 rounded-[12px] backdrop-blur-[30px] border font-medium text-[14px] hover:bg-white/[0.2] transition-all flex items-center gap-2 ${theme === 'dark'
               ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#d4c5b0]'
               : 'bg-white/[0.15] border-white/25 text-[#2d2820]'
-              }`}
+              } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
-            <Upload className="w-4 h-4" />
-            Update
+            {isSavingAvatar ? (
+              <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Upload className="w-4 h-4" />
+            )}
+            {isSavingAvatar ? 'Uploading...' : 'Update'}
           </button>
           {avatarUrl && avatarUrl !== currentUser?.github?.avatar_url && (
             <button
               onClick={handleSaveAvatar}
-              disabled={isSaving}
-              className={`px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-medium text-[14px] shadow-[0_4px_16px_rgba(162,121,44,0.3)] hover:shadow-[0_6px_20px_rgba(162,121,44,0.4)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed`}
+              disabled={isSavingAvatar}
+              aria-busy={isSavingAvatar}
+              className={`px-5 py-2.5 rounded-[12px] bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white font-medium text-[14px] shadow-[0_4px_16px_rgba(162,121,44,0.3)] hover:shadow-[0_6px_20px_rgba(162,121,44,0.4)] transition-all border border-white/10 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2`}
             >
-              {isSaving ? 'Saving...' : 'Save Picture'}
+              {isSavingAvatar && <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />}
+              {isSavingAvatar ? 'Saving picture...' : 'Save Picture'}
             </button>
           )}
         </div>


### PR DESCRIPTION
Closes #270

## Summary
- Add a dedicated `isSavingAvatar` pending state for avatar upload/save actions.
- Keep avatar buttons disabled/busy only while avatar upload is pending, including spinner and `aria-busy` feedback.
- Keep the profile form Save button tied to the existing profile save state so profile edits and avatar uploads no longer block each other unnecessarily.

## Verification
- `npm test -- src/features/settings/components/profile/ProfileTab.test.tsx` passed, 8 tests.
- `npm run typecheck` passed.
- `npx eslint src/features/settings/components/profile/ProfileTab.tsx src/features/settings/components/profile/ProfileTab.test.tsx` passed.
- `npm run build` passed.
- `npm run lint` still fails on existing unrelated baseline issues in `src/features/maintainers/components/InstallGitHubAppModal.test.tsx` (`@ts-ignore`) and `src/features/settings/components/terms/TermsTab.tsx` (`no-console`).