### PR TITLE
Chore/eslint no raw fetch

### DIFF
--- a/API_INTEGRATION.md
+++ b/API_INTEGRATION.md
@@ -146,6 +146,31 @@ const projects = await getPublicProjects({
 });
 ```
 
+### Correlation ID (`X-Request-Id`)
+
+Every outgoing API request automatically includes an `X-Request-Id` header containing a random UUID (v4). This allows support and backend teams to correlate a frontend error report with a specific request in the server logs.
+
+**Behaviour:**
+- A fresh UUID is generated per request via `crypto.randomUUID()` (with a cryptographic fallback for older environments).
+- If the caller already supplies an `X-Request-Id` header (e.g. when retrying), that value is **preserved** and not overwritten.
+- The request ID is attached to the thrown `ApiError` as `error.requestId` so error handlers can surface it in UI or telemetry.
+- The same request ID is forwarded to `logger.error(...)` on every failure path for local debugging.
+
+```typescript
+import { apiRequest, ApiError } from '@/shared/api/client';
+
+try {
+  const data = await apiRequest('/some-endpoint');
+} catch (error) {
+  if (error instanceof ApiError) {
+    console.error(`Request ${error.requestId} failed:`, error.message);
+    // Show "If this keeps happening, please provide this code: <requestId>"
+  }
+}
+```
+
+**Security:** The ID is purely random and contains no PII (no JWTs, emails, or user identifiers are embedded). It is safe to log and safe to share with end users as a support reference.
+
 ### Available Endpoints
 
 #### Authentication
@@ -175,7 +200,7 @@ const projects = await getPublicProjects({
 
 ## Error Handling
 
-The API client automatically handles errors:
+The API client automatically handles errors. All non-2xx responses and network failures throw an `ApiError` (subclass of `Error`) that carries the request's correlation ID as `.requestId`.
 
 **401 Unauthorized** - Token expired/invalid
 ```typescript
@@ -184,13 +209,17 @@ localStorage.removeItem('patchwork_jwt');
 window.location.href = '/auth/signin';
 ```
 
-**Other Errors** - Throws error with backend message
+**Other Errors** - Throws `ApiError` with backend message
 ```typescript
+import { ApiError } from '@/shared/api/client';
+
 try {
   const profile = await getUserProfile();
 } catch (error) {
-  console.error(error.message); // Backend error message
-  // Handle error (show toast, etc.)
+  if (error instanceof ApiError) {
+    console.error(`Request ${error.requestId} failed:`, error.message);
+    // Handle error (show toast, etc.)
+  }
 }
 ```
 
@@ -256,6 +285,8 @@ export const FRONTEND_BASE_URL = import.meta.env.VITE_FRONTEND_BASE_URL || windo
 - Never log tokens to console
 - Use HTTPS in production
 - Validate token presence before authenticated requests
+- Include `X-Request-Id` on every API request for end-to-end tracing
+- Surface `error.requestId` to users so support can look up the failing request
 
 ⚠️ **Security Considerations:**
 - localStorage is vulnerable to XSS attacks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,19 @@ All backend API requests are centralized and handled by the client helper in [sr
    - If an API call fails with status `401 Unauthorized`, the client automatically removes the token from `localStorage` via `removeAuthToken()` and triggers a `patchwork-auth-token` event to alert active contexts.
    - 403 Forbidden responses automatically parse detailed server error feedback and throw descriptive, user-friendly errors.
 
+### ESLint Enforcement — Centralised Network & Token Access
+
+Two ESLint rules (`no-restricted-syntax`) prevent accidental drift from the centralised API layer:
+
+| Rule | Selector | Rationale |
+| :--- | :------- | :-------- |
+| **No raw `fetch()`** | `CallExpression[callee.name="fetch"]` | Bypassing `apiRequest` skips auth headers, X-Request-Id, error normalization, and the 401 clear-redirect flow. Every request must use the centralised client. |
+| **No direct `patchwork_jwt` access** | `CallExpression[callee.object.name="localStorage"] … [arguments.0.value="patchwork_jwt"]` | Reads and writes to the JWT key must go through `getAuthToken` / `setAuthToken` / `removeAuthToken` so token storage strategy can be changed (e.g. to httpOnly cookies) without hunting down ad‑hoc `localStorage` calls. |
+
+**Exempt files** — `src/shared/api/client.ts` and `src/shared/config/api.ts` are allowed because they _define_ the centralised accessors.
+
+**Adding a new endpoint:** Always add it as a named function in `client.ts` that calls `apiRequest`. Never write `fetch(url, …)` in a component or hook. If the endpoint returns binary data, add the function to `client.ts` and apply an inline `// eslint-disable-next-line no-restricted-syntax` with a short justification for the raw fetch.
+
 ---
 
 ## Testing Setup

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,36 @@ export default tseslint.config(
       'no-unsafe-finally': 'warn',
       // Keep PII-safe logging guard: disallow direct console usage (use guarded logger)
       'no-console': 'error',
+      // Disallow raw fetch() outside the centralised API client.
+      // Every request must go through apiRequest() so auth headers,
+      // error handling, correlation IDs, and the 401 clear-redirect
+      // flow are applied consistently.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'CallExpression[callee.name="fetch"]',
+          message:
+            'Use apiRequest() from src/shared/api/client.ts instead of raw fetch().',
+        },
+        {
+          selector:
+            'CallExpression[callee.object.name="localStorage"][callee.property.name="getItem"][arguments.0.value="patchwork_jwt"]',
+          message:
+            'Use getAuthToken() from src/shared/api/client.ts to read the JWT.',
+        },
+        {
+          selector:
+            'CallExpression[callee.object.name="localStorage"][callee.property.name="setItem"][arguments.0.value="patchwork_jwt"]',
+          message:
+            'Use setAuthToken() from src/shared/api/client.ts to store the JWT.',
+        },
+        {
+          selector:
+            'CallExpression[callee.object.name="localStorage"][callee.property.name="removeItem"][arguments.0.value="patchwork_jwt"]',
+          message:
+            'Use removeAuthToken() from src/shared/api/client.ts to clear the JWT.',
+        },
+      ],
     },
   },
   {
@@ -31,6 +61,22 @@ export default tseslint.config(
     files: ['src/shared/utils/logger.ts'],
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    // The centralised API client and config are allowed to call fetch
+    // and to read/store the JWT token directly.
+    files: ['src/shared/api/client.ts', 'src/shared/config/api.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
+  },
+  {
+    // Test files mock the API client and need to set up token state
+    // directly in localStorage to verify AuthContext behaviour.
+    files: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   prettier,

--- a/src/features/maintainers/components/InstallGitHubAppModal.tsx
+++ b/src/features/maintainers/components/InstallGitHubAppModal.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { X, FileText, Code, GitBranch, Users, Loader2 } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
-import { API_BASE_URL } from '../../../shared/config/api'
-import { getAuthToken } from '../../../shared/api/client'
+import { apiRequest } from '../../../shared/api/client'
 import { logger } from '../../../shared/utils/logger'
 
 /**
@@ -61,30 +60,13 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
     setIsInstalling(true)
 
     try {
-      const token = getAuthToken()
-      if (!token) {
-        throw new Error('Please sign in to install the GitHub App')
-      }
-
       // Get installation URL from backend
-      const response = await fetch(`${API_BASE_URL}/auth/github/app/install/start`, {
+      const data = await apiRequest<{ install_url: string }>('/auth/github/app/install/start', {
         method: 'POST',
+        requiresAuth: true,
         signal: abortController.signal,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
       })
 
-      if (abortController.signal.aborted) return
-
-      if (!response.ok) {
-        const error = await response.json()
-        if (abortController.signal.aborted) return
-        throw new Error(error.message || error.error || 'Failed to start installation')
-      }
-
-      const data = await response.json()
       if (abortController.signal.aborted) return
 
       // Store "don't show again" preference

--- a/src/shared/api/client.test.ts
+++ b/src/shared/api/client.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   apiRequest,
+  ApiError,
+  generateRequestId,
   getAuthToken,
   setAuthToken,
   removeAuthToken,
@@ -546,6 +548,185 @@ describe('apiRequest - Core Request Helper', () => {
       const callArgs = mockFetch.mock.calls[0];
       const headers = callArgs[1].headers;
       expect(headers['Content-Type']).toBeUndefined();
+    });
+  });
+
+  describe('X-Request-Id / Correlation ID', () => {
+    it('should generate a valid-looking identifier', () => {
+      const id = generateRequestId();
+      expect(id).toEqual(expect.any(String));
+      expect(id.length).toBeGreaterThanOrEqual(32);
+    });
+
+    it('should attach an X-Request-Id header to every request', async () => {
+      await apiRequest('/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_BASE_URL}/test`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Request-Id': expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    it('should generate a fresh UUID on each request', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      });
+
+      await apiRequest('/a');
+      await apiRequest('/b');
+
+      const idA = mockFetch.mock.calls[0][1].headers['X-Request-Id'];
+      const idB = mockFetch.mock.calls[1][1].headers['X-Request-Id'];
+      expect(idA).not.toBe(idB);
+    });
+
+    it('should preserve a caller-supplied X-Request-Id', async () => {
+      await apiRequest('/test', {
+        headers: { 'X-Request-Id': 'caller-id-001' },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_BASE_URL}/test`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Request-Id': 'caller-id-001',
+          }),
+        }),
+      );
+    });
+
+    it('should throw ApiError with the requestId on network errors', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      let error: unknown;
+      try {
+        await apiRequest('/test');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).requestId).toEqual(expect.any(String));
+    });
+
+    it('should throw ApiError with the requestId on HTTP 401', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      });
+
+      let error: unknown;
+      try {
+        await apiRequest('/test');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).requestId).toEqual(expect.any(String));
+    });
+
+    it('should throw ApiError with the requestId on HTTP 403', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({}),
+      });
+
+      let error: unknown;
+      try {
+        await apiRequest('/test');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).requestId).toEqual(expect.any(String));
+    });
+
+    it('should throw ApiError with the requestId on general HTTP error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: 'Server error' }),
+      });
+
+      let error: unknown;
+      try {
+        await apiRequest('/test');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).requestId).toEqual(expect.any(String));
+    });
+
+    it('should throw ApiError with the requestId on JSON parse failure', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      let error: unknown;
+      try {
+        await apiRequest('/user');
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).requestId).toEqual(expect.any(String));
+    });
+
+    it('should fall back to a hex string when crypto.randomUUID is unavailable', async () => {
+      const original = crypto.randomUUID;
+      // @ts-expect-error removing randomUUID to test fallback
+      crypto.randomUUID = undefined;
+
+      await apiRequest('/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_BASE_URL}/test`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Request-Id': expect.any(String),
+          }),
+        }),
+      );
+
+      const headerValue: string = mockFetch.mock.calls[0][1].headers['X-Request-Id'];
+      expect(headerValue.length).toBeGreaterThanOrEqual(32);
+
+      crypto.randomUUID = original;
+    });
+
+    it('should include requestId in logger.error calls on failure', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      try {
+        await apiRequest('/test');
+      } catch {
+        // expected
+      }
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Network error: Unable to connect to the server. Please check your connection.',
+        expect.objectContaining({ requestId: expect.any(String) }),
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -5,6 +5,29 @@
 import { API_BASE_URL } from '../config/api'
 import { BillingProfile } from '../../features/settings/types'
 import { BlogPost } from '../../features/blog/types'
+import { logger } from '../utils/logger'
+
+/**
+ * Generate a v4 UUID for request correlation.
+ *
+ * Uses `crypto.randomUUID()` when available (modern browsers, Node 19+).
+ * Falls back to a random hex string for environments where the API is
+ * unavailable (e.g. older browsers, non-secure contexts).
+ *
+ * @returns A random, PII‑free identifier suitable for X-Request-Id.
+ */
+export function generateRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  // Fallback: 32 hex chars (128 bits) matching UUID hex length.
+  const hex = '0123456789abcdef'
+  let id = ''
+  for (let i = 0; i < 32; i++) {
+    id += hex[Math.floor(Math.random() * 16)]
+  }
+  return id
+}
 
 // Token management
 export const getAuthToken = (): string | null => {
@@ -38,12 +61,29 @@ export interface ApiRequestOptions extends RequestInit {
 }
 
 /**
+ * Error subclass that carries the request correlation ID so callers can
+ * surface it to support for backend log lookups.
+ */
+export class ApiError extends Error {
+  /**
+   * @param message - Human‑readable error description.
+   * @param requestId - The X-Request-Id sent with the failing request.
+   */
+  constructor(message: string, public readonly requestId: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+/**
  * Core API request helper that handles authentication, headers, and error handling
  * @template T - The expected response type
  * @param {string} endpoint - API endpoint path (will be prefixed with API_BASE_URL)
  * @param {ApiRequestOptions} options - Request options including auth requirements
  * @returns {Promise<T>} Parsed JSON response
- * @throws {Error} On network failures, authentication errors, or non-2xx responses
+ * @throws {ApiError} On network failures, authentication errors, or non-2xx responses.
+ *   The thrown error includes a `.requestId` property for correlating with
+ *   backend logs.
  * @internal This function is exported for testing purposes
  */
 export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions = {}): Promise<T> {
@@ -53,6 +93,13 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
   const requestHeaders: Record<string, string> = {
     ...(headers as Record<string, string>),
   }
+
+  // Attach or preserve a correlation ID so every request can be traced in
+  // backend logs. The caller may supply one (e.g. when retrying), otherwise
+  // we generate a fresh UUID.
+  const requestId =
+    (headers as Record<string, string>)['X-Request-Id'] || generateRequestId()
+  requestHeaders['X-Request-Id'] = requestId
 
   // Avoid forcing CORS preflight for simple GET/HEAD requests by only setting
   // Content-Type when we actually send a JSON body.
@@ -84,10 +131,11 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
   } catch (err) {
     // Network error (CORS, connection refused, etc.)
     if (err instanceof TypeError && err.message.includes('fetch')) {
-      throw new Error(
-        'Network error: Unable to connect to the server. Please check your connection.'
-      )
+      const msg = 'Network error: Unable to connect to the server. Please check your connection.'
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
+    logger.error('Unhandled fetch error', { requestId, error: err })
     throw err
   }
 
@@ -96,7 +144,9 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
     if (response.status === 401) {
       // Token expired or invalid - clear it
       removeAuthToken()
-      throw new Error('Authentication failed. Please sign in again.')
+      const msg = 'Authentication failed. Please sign in again.'
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
 
     if (response.status === 403) {
@@ -107,9 +157,9 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
       } catch {
         errorMsg = 'Access forbidden'
       }
-      throw new Error(
-        `Permission denied: ${errorMsg}. You may need admin privileges to perform this action.`
-      )
+      const msg = `Permission denied: ${errorMsg}. You may need admin privileges to perform this action.`
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
 
     // Try to parse error response
@@ -118,9 +168,12 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
       const errorData = await response.json()
       apiErrorMsg = errorData.message || errorData.error || 'API request failed'
     } catch {
-      throw new Error(`API request failed with status ${response.status}`)
+      const msg = `API request failed with status ${response.status}`
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
-    throw new Error(apiErrorMsg)
+    logger.error(apiErrorMsg, { requestId })
+    throw new ApiError(apiErrorMsg, requestId)
   }
 
   // Parse JSON response
@@ -132,7 +185,9 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
     if (endpoint.includes('/projects/mine') || endpoint.includes('/projects')) {
       return [] as T
     }
-    throw new Error('Invalid response from server')
+    const msg = 'Invalid response from server'
+    logger.error(msg, { requestId, error: err })
+    throw new ApiError(msg, requestId)
   }
 }
 
@@ -1210,6 +1265,9 @@ export async function downloadInvoice(invoiceId: string): Promise<Blob> {
   const url = `${API_BASE_URL}/billing/invoices/${invoiceId}/download`
   const headers: Record<string, string> = {}
 
+  const requestId = generateRequestId()
+  headers['X-Request-Id'] = requestId
+
   const token = getAuthToken()
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
@@ -1220,17 +1278,24 @@ export async function downloadInvoice(invoiceId: string): Promise<Blob> {
     response = await fetch(url, { headers })
   } catch (err) {
     if (err instanceof TypeError && err.message.includes('fetch')) {
-      throw new Error('Network error: Unable to connect to the server. Please check your connection.')
+      const msg = 'Network error: Unable to connect to the server. Please check your connection.'
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
+    logger.error('Unhandled fetch error', { requestId, error: err })
     throw err
   }
 
   if (!response.ok) {
     if (response.status === 401) {
       removeAuthToken()
-      throw new Error('Authentication failed. Please sign in again.')
+      const msg = 'Authentication failed. Please sign in again.'
+      logger.error(msg, { requestId })
+      throw new ApiError(msg, requestId)
     }
-    throw new Error(`Failed to download invoice (${response.status}).`)
+    const msg = `Failed to download invoice (${response.status}).`
+    logger.error(msg, { requestId })
+    throw new ApiError(msg, requestId)
   }
 
   return response.blob()


### PR DESCRIPTION

Addexd no restricted-syntax rules banning raw fetch() and direct patchwork-jwt localstorage access outside client.ts/config/api.ts
Exempted test files 
refactored InstallGitHubAppModal.tsx to use apiRequest instead of raw fetch
Documented both rules in CONTRIBUTING.md
closes #312