### PR TITLE
feat(i18n): drive document direction from locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ provider, message catalog, and helpers live in [`src/shared/i18n/`](./src/shared
 - **Locale-aware formatting**: number/currency formatting reads the active locale
   from the provider — see [`useLandingStats`](./src/shared/hooks/useLandingStats.ts),
   which feeds `intl.locale` into `Intl.NumberFormat`.
+- **Document direction**: the provider derives `document.documentElement.dir`
+  from the active locale via `getTextDirection(locale)`. English (`en`) defaults
+  to `ltr`; RTL locales such as Arabic (`ar`) map to `rtl`.
 
 ### Usage
 
@@ -166,6 +169,9 @@ import { FormattedMessage } from 'react-intl'
    transparently falls back to its English value. `en` must therefore stay
    complete. Non-fatal `MISSING_TRANSLATION` errors are swallowed by the provider's
    error policy ([`errors.ts`](./src/shared/i18n/errors.ts)).
+4. **Direction**: add the locale to the fixed `Locale` union and update
+   `getTextDirection()` only when the locale is right-to-left. Keep direction
+   values constrained to `ltr` / `rtl`; do not read them from user-provided text.
 
 ### Security: interpolation is text-only
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
   <!DOCTYPE html>
-  <html lang="en">
+  <html lang="en" dir="ltr">
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,4 +14,4 @@
       <script type="module" src="/src/main.tsx"></script>
     </body>
   </html>
-  
+

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -206,7 +206,7 @@ export default function App() {
             <a
               href="#main"
               id="skip-target"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-black focus:shadow"
+              className="sr-only focus:not-sr-only focus:fixed focus:start-2 focus:top-2 focus:z-50 focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-black focus:shadow"
             >
               Skip to main content
             </a>

--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { Link, useNavigate, useLocation, Outlet } from "react-router-dom";
+import { useState, useEffect } from 'react'
+import { Link, useNavigate, useLocation, Outlet } from 'react-router-dom'
 import {
   Search,
   Compass,
@@ -15,234 +15,246 @@ import {
   Sun,
   Shield,
   X,
-  Menu
-} from "lucide-react";
-import { useModeAnimation } from "react-theme-switch-animation";
-import { useAuth } from "../../shared/contexts/AuthContext";
-import grainlifyLogo from "../../assets/grainlify_log.svg";
-import { useTheme } from "../../shared/contexts/ThemeContext";
-import { UserProfileDropdown } from "../../shared/components/UserProfileDropdown";
-import { NotificationsDropdown } from "../../shared/components/NotificationsDropdown";
-import { RoleSwitcher } from "../../shared/components/RoleSwitcher";
-import {
-  Modal,
-  ModalFooter,
-  ModalButton,
-  ModalInput,
-} from "../../shared/components/ui/Modal";
-import { bootstrapAdmin } from "../../shared/api/client";
-import { useTranslation } from "../../shared/i18n";
+  Menu,
+} from 'lucide-react'
+import { useModeAnimation } from 'react-theme-switch-animation'
+import { useAuth } from '../../shared/contexts/AuthContext'
+import grainlifyLogo from '../../assets/grainlify_log.svg'
+import { useTheme } from '../../shared/contexts/ThemeContext'
+import { UserProfileDropdown } from '../../shared/components/UserProfileDropdown'
+import { NotificationsDropdown } from '../../shared/components/NotificationsDropdown'
+import { RoleSwitcher } from '../../shared/components/RoleSwitcher'
+import { Modal, ModalFooter, ModalButton, ModalInput } from '../../shared/components/ui/Modal'
+import { bootstrapAdmin } from '../../shared/api/client'
+import { useTranslation } from '../../shared/i18n'
 
 export function DashboardLayout() {
-  const { login } = useAuth();
-  const { t } = useTranslation();
-  const { theme, setThemeFromAnimation } = useTheme();
-  const location = useLocation();
+  const { login } = useAuth()
+  const { t } = useTranslation()
+  const { theme, setThemeFromAnimation } = useTheme()
+  const location = useLocation()
   const { ref: themeToggleRef, toggleSwitchTheme } = useModeAnimation({
-    isDarkMode: theme === "dark",
+    isDarkMode: theme === 'dark',
     onDarkModeChange: (isDark) => setThemeFromAnimation(isDark),
-  });
-  const navigate = useNavigate();
-  
+  })
+  const navigate = useNavigate()
+
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(
-     typeof window !== 'undefined' ? window.innerWidth < 768 : false);
-  const [activeRole, setActiveRole] = useState<"contributor" | "maintainer" | "admin">("contributor");
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false
+  )
+  const [activeRole, setActiveRole] = useState<'contributor' | 'maintainer' | 'admin'>(
+    'contributor'
+  )
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [deviceWidth, setDeviceWidth] = useState(
     typeof window !== 'undefined' ? window.innerWidth : null
-  );
+  )
 
   // Admin password gating (bootstrap token)
-  const [showAdminPasswordModal, setShowAdminPasswordModal] = useState(false);
-  const [adminPassword, setAdminPassword] = useState("");
-  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [showAdminPasswordModal, setShowAdminPasswordModal] = useState(false)
+  const [adminPassword, setAdminPassword] = useState('')
+  const [isAuthenticating, setIsAuthenticating] = useState(false)
   const [adminAuthenticated, setAdminAuthenticated] = useState(() => {
-    return sessionStorage.getItem("admin_authenticated") === "true";
-  });
-  const [_pendingAdminTarget, setPendingAdminTarget] = useState<"nav" | "role" | null>(null);
+    return sessionStorage.getItem('admin_authenticated') === 'true'
+  })
+  const [_pendingAdminTarget, setPendingAdminTarget] = useState<'nav' | 'role' | null>(null)
 
-  useEffect(() => { 
+  useEffect(() => {
     const handleResize = () => {
-      setDeviceWidth(window.innerWidth);
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+      setDeviceWidth(window.innerWidth)
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   // Get current page from URL path
   const getCurrentPage = () => {
-    const path = location.pathname;
-    if (path.startsWith('/dashboard/discover')) return 'discover';
-    if (path.startsWith('/dashboard/browse')) return 'browse';
-    if (path.startsWith('/dashboard/open-source-week')) return 'osw';
-    if (path.startsWith('/dashboard/ecosystems')) return 'ecosystems';
-    if (path.startsWith('/dashboard/contributors')) return 'contributors';
-    if (path.startsWith('/dashboard/maintainers')) return 'maintainers';
-    if (path.startsWith('/dashboard/data')) return 'data';
-    if (path.startsWith('/dashboard/leaderboard')) return 'leaderboard';
-    if (path.startsWith('/dashboard/blog')) return 'blog';
-    if (path.startsWith('/dashboard/settings')) return 'settings';
-    if (path.startsWith('/dashboard/admin')) return 'admin';
-    if (path.startsWith('/dashboard/search')) return 'search';
-    if (path.startsWith('/dashboard/profile')) return 'profile';
-    return 'discover';
-  };
+    const path = location.pathname
+    if (path.startsWith('/dashboard/discover')) return 'discover'
+    if (path.startsWith('/dashboard/browse')) return 'browse'
+    if (path.startsWith('/dashboard/open-source-week')) return 'osw'
+    if (path.startsWith('/dashboard/ecosystems')) return 'ecosystems'
+    if (path.startsWith('/dashboard/contributors')) return 'contributors'
+    if (path.startsWith('/dashboard/maintainers')) return 'maintainers'
+    if (path.startsWith('/dashboard/data')) return 'data'
+    if (path.startsWith('/dashboard/leaderboard')) return 'leaderboard'
+    if (path.startsWith('/dashboard/blog')) return 'blog'
+    if (path.startsWith('/dashboard/settings')) return 'settings'
+    if (path.startsWith('/dashboard/admin')) return 'admin'
+    if (path.startsWith('/dashboard/search')) return 'search'
+    if (path.startsWith('/dashboard/profile')) return 'profile'
+    return 'discover'
+  }
 
-  const currentPage = getCurrentPage();
+  const currentPage = getCurrentPage()
 
   const handleNavigation = (page: string) => {
-    navigate(`/dashboard/${page}`);
-    setMobileMenuOpen(false);
-  };
+    navigate(`/dashboard/${page}`)
+    setMobileMenuOpen(false)
+  }
 
-
-  const openAdminAuthModal = (target: "nav" | "role") => {
-    setPendingAdminTarget(target);
-    setShowAdminPasswordModal(true);
-  };
-
+  const openAdminAuthModal = (target: 'nav' | 'role') => {
+    setPendingAdminTarget(target)
+    setShowAdminPasswordModal(true)
+  }
 
   const handleAdminPasswordSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!adminPassword.trim()) return;
-    setIsAuthenticating(true);
+    e.preventDefault()
+    if (!adminPassword.trim()) return
+    setIsAuthenticating(true)
     try {
-      const response = await bootstrapAdmin(adminPassword.trim());
-      await login(response.token);
-      setAdminAuthenticated(true);
-      sessionStorage.setItem("admin_authenticated", "true");
-      setShowAdminPasswordModal(false);
-      setAdminPassword("");
-      setActiveRole("admin");
-      handleNavigation("admin");
+      const response = await bootstrapAdmin(adminPassword.trim())
+      await login(response.token)
+      setAdminAuthenticated(true)
+      sessionStorage.setItem('admin_authenticated', 'true')
+      setShowAdminPasswordModal(false)
+      setAdminPassword('')
+      setActiveRole('admin')
+      handleNavigation('admin')
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error("Admin authentication failed:", error);
-      setAdminPassword("");
+      console.error('Admin authentication failed:', error)
+      setAdminPassword('')
     } finally {
-      setIsAuthenticating(false);
-      setPendingAdminTarget(null);
+      setIsAuthenticating(false)
+      setPendingAdminTarget(null)
     }
-  };
+  }
 
-  const handleRoleChange = (role: "contributor" | "maintainer" | "admin") => {
-    if (role === "admin") {
+  const handleRoleChange = (role: 'contributor' | 'maintainer' | 'admin') => {
+    if (role === 'admin') {
       if (adminAuthenticated) {
-        setActiveRole("admin");
-        handleNavigation("admin");
+        setActiveRole('admin')
+        handleNavigation('admin')
       } else {
-        openAdminAuthModal("role");
+        openAdminAuthModal('role')
       }
-      return;
+      return
     }
-    setActiveRole(role);
-    if (role === "maintainer") {
-      handleNavigation("maintainers");
+    setActiveRole(role)
+    if (role === 'maintainer') {
+      handleNavigation('maintainers')
     } else {
-      handleNavigation("discover");
+      handleNavigation('discover')
     }
-  };
+  }
 
   const closeMobileNav = () => {
     if (mobileMenuOpen) {
-      setMobileMenuOpen(false);
+      setMobileMenuOpen(false)
     }
-  };
+  }
 
   // Role-based navigation items
   const navItems = [
-    { id: "discover", icon: Compass, label: t("dashboardNav.discover"), path: "/dashboard/discover" },
-    { id: "browse", icon: Grid3x3, label: t("dashboardNav.browse"), path: "/dashboard/browse" },
-    { id: "osw", icon: Calendar, label: t("dashboardNav.openSourceWeek"), path: "/dashboard/open-source-week" },
-    { id: "ecosystems", icon: Globe, label: t("dashboardNav.ecosystems"), path: "/dashboard/ecosystems" },
-    activeRole === "maintainer" || activeRole === "admin"
-      ? { id: "maintainers", icon: Users, label: t("dashboardNav.maintainers"), path: "/dashboard/maintainers" }
-      : { id: "contributors", icon: Users, label: t("dashboardNav.contributors"), path: "/dashboard/contributors" },
-    ...(activeRole === "admin"
-      ? [{ id: "data", icon: Database, label: t("dashboardNav.data"), path: "/dashboard/data" }]
+    {
+      id: 'discover',
+      icon: Compass,
+      label: t('dashboardNav.discover'),
+      path: '/dashboard/discover',
+    },
+    { id: 'browse', icon: Grid3x3, label: t('dashboardNav.browse'), path: '/dashboard/browse' },
+    {
+      id: 'osw',
+      icon: Calendar,
+      label: t('dashboardNav.openSourceWeek'),
+      path: '/dashboard/open-source-week',
+    },
+    {
+      id: 'ecosystems',
+      icon: Globe,
+      label: t('dashboardNav.ecosystems'),
+      path: '/dashboard/ecosystems',
+    },
+    activeRole === 'maintainer' || activeRole === 'admin'
+      ? {
+          id: 'maintainers',
+          icon: Users,
+          label: t('dashboardNav.maintainers'),
+          path: '/dashboard/maintainers',
+        }
+      : {
+          id: 'contributors',
+          icon: Users,
+          label: t('dashboardNav.contributors'),
+          path: '/dashboard/contributors',
+        },
+    ...(activeRole === 'admin'
+      ? [{ id: 'data', icon: Database, label: t('dashboardNav.data'), path: '/dashboard/data' }]
       : []),
-    { id: "leaderboard", icon: Trophy, label: t("dashboardNav.leaderboard"), path: "/dashboard/leaderboard" },
-    { id: "blog", icon: FileText, label: t("dashboardNav.blog"), path: "/dashboard/blog" },
-  ];
+    {
+      id: 'leaderboard',
+      icon: Trophy,
+      label: t('dashboardNav.leaderboard'),
+      path: '/dashboard/leaderboard',
+    },
+    { id: 'blog', icon: FileText, label: t('dashboardNav.blog'), path: '/dashboard/blog' },
+  ]
 
-  const darkTheme = theme === "dark";
-  const isSmallDevice = deviceWidth && deviceWidth < 1024;
-  const showMobileNav = mobileMenuOpen && isSmallDevice;
+  const darkTheme = theme === 'dark'
+  const isSmallDevice = deviceWidth && deviceWidth < 1024
+  const showMobileNav = mobileMenuOpen && isSmallDevice
 
   return (
     <div
       className={`min-h-screen relative overflow-hidden transition-colors ${
         darkTheme
-          ? "bg-gradient-to-br from-[#1a1512] via-[#231c17] to-[#2d241d]"
-          : "bg-gradient-to-br from-[#c4b5a0] via-[#b8a590] to-[#a89780]"
+          ? 'bg-gradient-to-br from-[#1a1512] via-[#231c17] to-[#2d241d]'
+          : 'bg-gradient-to-br from-[#c4b5a0] via-[#b8a590] to-[#a89780]'
       }`}
     >
       {/* Subtle Background Texture */}
       <div className="fixed inset-0 opacity-40">
         <div
           className={`absolute top-0 left-0 w-[800px] h-[800px] bg-gradient-radial blur-[100px] ${
-            darkTheme
-              ? "from-[#c9983a]/10 to-transparent"
-              : "from-[#d4c4b0]/30 to-transparent"
+            darkTheme ? 'from-[#c9983a]/10 to-transparent' : 'from-[#d4c4b0]/30 to-transparent'
           }`}
         />
         <div
           className={`absolute bottom-0 right-0 w-[900px] h-[900px] bg-gradient-radial blur-[120px] ${
-            darkTheme
-              ? "from-[#c9983a]/5 to-transparent"
-              : "from-[#b8a898]/20 to-transparent"
+            darkTheme ? 'from-[#c9983a]/5 to-transparent' : 'from-[#b8a898]/20 to-transparent'
           }`}
         />
       </div>
 
       {/* Sidebar */}
       <aside
-        className={`fixed top-2 left-2 bottom-2 z-50 transition-all duration-300 ${isSidebarCollapsed ? "w-[65px] mr-2" : "w-56 mr-2"}`}
+        className={`fixed top-2 start-2 bottom-2 z-50 transition-all duration-300 ${isSidebarCollapsed ? 'w-[65px] me-2' : 'w-56 me-2'}`}
       >
         {/* Toggle Arrow Button */}
         <button
           onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
           className={`absolute z-[100] backdrop-blur-[90px] rounded-full border-[0.5px] w-6 h-6 shadow-md hover:shadow-lg transition-all flex items-center justify-center ${
-            isSidebarCollapsed ? "-right-3 top-[60px]" : "-right-3 top-[60px]"
+            isSidebarCollapsed ? '-end-3 top-[60px]' : '-end-3 top-[60px]'
           } ${
             darkTheme
-              ? "bg-[#2d2820]/[0.85] border-[rgba(201,152,58,0.2)]"
-              : "bg-white/[0.85] border-[rgba(245,239,235,0.32)]"
+              ? 'bg-[#2d2820]/[0.85] border-[rgba(201,152,58,0.2)]'
+              : 'bg-white/[0.85] border-[rgba(245,239,235,0.32)]'
           }`}
         >
           <ChevronRight
-            className={`w-3 h-3 text-[#c9983a] transition-transform duration-300 ${isSidebarCollapsed ? "" : "rotate-180"}`}
+            className={`w-3 h-3 text-[#c9983a] transition-transform duration-300 ${isSidebarCollapsed ? '' : 'rotate-180'}`}
           />
         </button>
 
         <div
           className={`h-full backdrop-blur-[90px] rounded-[29px] border shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] relative overflow-y-auto scrollbar-hide transition-colors ${
-            darkTheme
-              ? "bg-[#2d2820]/[0.4] border-white/10"
-              : "bg-white/[0.35] border-white/20"
+            darkTheme ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.35] border-white/20'
           }`}
         >
           <div className="flex flex-col h-full px-0 py-[40px]">
             {/* Logo/Avatar */}
             <div
-              className={`flex items-center mb-6 transition-all ${isSidebarCollapsed ? "px-[8px] justify-center" : "px-2 justify-start"}`}
+              className={`flex items-center mb-6 transition-all ${isSidebarCollapsed ? 'px-[8px] justify-center' : 'px-2 justify-start'}`}
             >
               {isSidebarCollapsed ? (
-                <img
-                  src={grainlifyLogo}
-                  alt="Grainlify"
-                  className="w-12 h-12 grainlify-logo"
-                />
+                <img src={grainlifyLogo} alt="Grainlify" className="w-12 h-12 grainlify-logo" />
               ) : (
-                <div className="flex items-center space-x-3">
-                  <img
-                    src={grainlifyLogo}
-                    alt="Grainlify"
-                    className="w-12 h-12 grainlify-logo"
-                  />
+                <div className="flex items-center gap-3">
+                  <img src={grainlifyLogo} alt="Grainlify" className="w-12 h-12 grainlify-logo" />
                   <span
                     className={`text-[20px] font-bold transition-colors ${
-                      darkTheme ? "text-[#f5efe5]" : "text-[#2d2820]"
+                      darkTheme ? 'text-[#f5efe5]' : 'text-[#2d2820]'
                     }`}
                   >
                     Grainlify
@@ -255,61 +267,51 @@ export function DashboardLayout() {
             <div
               className="h-[0.5px] opacity-[0.24] mb-6 mx-auto"
               style={{
-                width: isSidebarCollapsed ? "60px" : "100%",
+                width: isSidebarCollapsed ? '60px' : '100%',
                 backgroundImage:
                   'url(\'data:image/svg+xml;utf8,<svg viewBox="0 0 104 0.5" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect x="0" y="0" height="100%" width="100%" fill="url(%23grad)" opacity="1"/><defs><radialGradient id="grad" gradientUnits="userSpaceOnUse" cx="0" cy="0" r="10" gradientTransform="matrix(3.1841e-16 0.025 -5.2 1.5308e-18 52 0.25)"><stop stop-color="rgba(67,44,44,1)" offset="0"/><stop stop-color="rgba(80,28,28,0)" offset="1"/></radialGradient></defs></svg>\')',
               }}
             />
 
             {/* Main Navigation */}
-            <nav
-              className={`space-y-2 mb-auto ${isSidebarCollapsed ? "px-[8px]" : "px-2"}`}
-            >
+            <nav className={`space-y-2 mb-auto ${isSidebarCollapsed ? 'px-[8px]' : 'px-2'}`}>
               {navItems.map((item) => {
-                const isActive = currentPage === item.id;
-                const Icon = item.icon as any;
+                const isActive = currentPage === item.id
+                const Icon = item.icon as any
                 return (
                   <Link
                     key={item.id}
                     to={item.path}
-                    aria-current={isActive ? "page" : undefined}
+                    aria-current={isActive ? 'page' : undefined}
                     className={`group w-full flex items-center rounded-[12px] transition-all duration-300 ${
                       isSidebarCollapsed
-                        ? "justify-center px-0 h-[49px]"
-                        : "justify-start px-3 py-2.5"
+                        ? 'justify-center px-0 h-[49px]'
+                        : 'justify-start px-3 py-2.5'
                     } ${
                       isActive
-                        ? "bg-[#c9983a] shadow-[inset_0px_0px_4px_0px_rgba(255,255,255,0.25)] border-[0.5px] border-[rgba(245,239,235,0.16)]"
+                        ? 'bg-[#c9983a] shadow-[inset_0px_0px_4px_0px_rgba(255,255,255,0.25)] border-[0.5px] border-[rgba(245,239,235,0.16)]'
                         : darkTheme
-                          ? "hover:bg-white/[0.08]"
-                          : "hover:bg-white/[0.1]"
+                          ? 'hover:bg-white/[0.08]'
+                          : 'hover:bg-white/[0.1]'
                     }`}
-                    title={isSidebarCollapsed ? item.label : ""}
+                    title={isSidebarCollapsed ? item.label : ''}
                   >
                     <Icon
-                      className={`w-6 h-6 transition-colors ${isSidebarCollapsed ? "" : "flex-shrink-0"} ${
-                        isActive
-                          ? "text-white"
-                          : darkTheme
-                            ? "text-[#e8c77f]"
-                            : "text-[#a2792c]"
+                      className={`w-6 h-6 transition-colors ${isSidebarCollapsed ? '' : 'flex-shrink-0'} ${
+                        isActive ? 'text-white' : darkTheme ? 'text-[#e8c77f]' : 'text-[#a2792c]'
                       }`}
                     />
                     {!isSidebarCollapsed && (
                       <span
-                        className={`ml-3 font-medium text-[14px] ${
-                          isActive
-                            ? "text-white"
-                            : darkTheme
-                              ? "text-[#d4c5b0]"
-                              : "text-[#6b5d4d]"
+                        className={`ms-3 font-medium text-[14px] ${
+                          isActive ? 'text-white' : darkTheme ? 'text-[#d4c5b0]' : 'text-[#6b5d4d]'
                         }`}
                       >
                         {item.label}
                       </span>
                     )}
                   </Link>
-                );
+                )
               })}
             </nav>
           </div>
@@ -318,192 +320,177 @@ export function DashboardLayout() {
 
       {/* Main Content */}
       <main
-        className={`mr-2 my-2 relative z-10 transition-all duration-300 ${isSidebarCollapsed ? "ml-[81px]" : "ml-[240px]"}`}
+        className={`me-2 my-2 relative z-10 transition-all duration-300 ${isSidebarCollapsed ? 'ms-[81px]' : 'ms-[240px]'}`}
       >
         <div className="max-w-[1400px] mx-auto">
           {/* Header */}
           <div
-            className={`fixed top-2 right-2 left-auto z-[9999] flex items-center gap-1 md:gap-2 lg:gap-3 lg:h-[52px] py-3 rounded-[26px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] backdrop-blur-[90px] border transition-all duration-300 ${
-              isSidebarCollapsed ? "ml-[81px]" : "ml-[240px]"
+            className={`fixed top-2 end-2 z-[9999] flex items-center gap-1 md:gap-2 lg:gap-3 lg:h-[52px] py-3 rounded-[26px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] backdrop-blur-[90px] border transition-all duration-300 ${
+              isSidebarCollapsed ? 'ms-[81px]' : 'ms-[240px]'
             } ${
               darkTheme
-                ? "bg-[#2d2820]/[0.4] border-white/10 shadow-[inset_0px_0px_9px_0px_rgba(201,152,58,0.1)]"
-                : "bg-white/[0.35] border-white shadow-[inset_0px_0px_9px_0px_rgba(255,255,255,0.5)]"
-            } ${showMobileNav ? "h-screen flex-col":"" } 
+                ? 'bg-[#2d2820]/[0.4] border-white/10 shadow-[inset_0px_0px_9px_0px_rgba(201,152,58,0.1)]'
+                : 'bg-white/[0.35] border-white shadow-[inset_0px_0px_9px_0px_rgba(255,255,255,0.5)]'
+            } ${showMobileNav ? 'h-screen flex-col' : ''} 
           `}
             style={{
-              width: `calc(100vw - ${isSidebarCollapsed ? "81px" : "240px"} - 8px - 8px)`,
+              width: `calc(100vw - ${isSidebarCollapsed ? '81px' : '240px'} - 8px - 8px)`,
             }}
           >
-          
-          {/* Mobile nav view header */}
-          {showMobileNav &&  
-            <div className="flex items-center justify-between w-full px-4"> 
-            <Link to="/" className="flex items-center space-x-3 mr-auto">
-              <img src={grainlifyLogo} alt="Grainlify" className="w-8 h-8 grainlify-logo" />
-              <span className={`text-xl font-semibold transition-colors ${
-                   theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-                 }`}>Grainlify</span>
+            {/* Mobile nav view header */}
+            {showMobileNav && (
+              <div className="flex items-center justify-between w-full px-4">
+                <Link to="/" className="flex items-center gap-3 me-auto">
+                  <img src={grainlifyLogo} alt="Grainlify" className="w-8 h-8 grainlify-logo" />
+                  <span
+                    className={`text-xl font-semibold transition-colors ${
+                      theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    Grainlify
+                  </span>
+                </Link>
+
+                <button
+                  className={`lg:hidden transition-colors self-end ${showMobileNav ? 'block' : 'hidden'} ${
+                    theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                  }`}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  <X size={24} />
+                </button>
+              </div>
+            )}
+
+            {/* Search */}
+            <Link
+              to="/dashboard/search"
+              className={`relative h-[46px] lg:flex-1 rounded-[23px] overflow-visible backdrop-blur-[40px] shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ms-[3px] transition-all hover:scale-[1.01] cursor-pointer ${
+                darkTheme ? 'bg-[#2d2820]' : 'bg-[#d4c5b0]'
+              } ${showMobileNav ? 'min-h-[46px] w-[80%] max-w-[800px] block' : 'lg:block hidden'}`}
+            >
+              <div
+                className={`absolute inset-0 pointer-events-none rounded-[23px] ${
+                  darkTheme
+                    ? 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]'
+                    : 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]'
+                }`}
+              />
+              <div className="relative h-full flex items-center px-2 lg:px-5 justify-between">
+                <div className="flex items-center flex-1">
+                  <Search
+                    className={`w-4 h-4 me-3 flex-shrink-0 transition-colors ${
+                      darkTheme ? 'text-[rgba(255,255,255,0.69)]' : 'text-[rgba(45,40,32,0.75)]'
+                    }`}
+                  />
+                  <span
+                    className={`text-[13px] transition-colors ${
+                      darkTheme ? 'text-[rgba(255,255,255,0.5)]' : 'text-[rgba(45,40,32,0.5)]'
+                    }`}
+                  >
+                    <span className="sm:hidden">Search</span>
+                    <span className="hidden sm:inline md:hidden">Search projects</span>
+                    <span className="hidden md:inline lg:hidden">Search projects, issues</span>
+                    <span className="hidden lg:inline">
+                      Search projects, issues, contributors...
+                    </span>
+                  </span>
+                </div>
+
+                <div
+                  className="hidden lg:flex items-center gap-1.5 px-2 py-1 rounded border"
+                  style={{
+                    backgroundColor: darkTheme
+                      ? 'rgba(255, 255, 255, 0.08)'
+                      : 'rgba(0, 0, 0, 0.08)',
+                    borderColor: darkTheme ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.15)',
+                  }}
+                >
+                  <span
+                    className="text-[11px] font-medium"
+                    style={{
+                      color: darkTheme ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)',
+                    }}
+                  >
+                    ⌘
+                  </span>
+                  <span
+                    className="text-[11px] font-medium"
+                    style={{
+                      color: darkTheme ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)',
+                    }}
+                  >
+                    K
+                  </span>
+                </div>
+              </div>
             </Link>
 
-            <button
-              className={`lg:hidden transition-colors self-end ${showMobileNav ? 'block' : 'hidden'} ${
-                   theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-                 }`}
-                 onClick={() => setMobileMenuOpen(false)}
-                 >
-              <X size={24} />
-            </button>
-            </div>
-          }
-
-          {/* Search */}
-          <Link
-            to="/dashboard/search"
-            className={`relative h-[46px] lg:flex-1 rounded-[23px] overflow-visible backdrop-blur-[40px] shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ml-[3px] transition-all hover:scale-[1.01] cursor-pointer ${
-              darkTheme ? "bg-[#2d2820]" : "bg-[#d4c5b0]"
-            } ${showMobileNav ? 'min-h-[46px] w-[80%] max-w-[800px] block': 'lg:block hidden'}`}
-          >
-            <div
-              className={`absolute inset-0 pointer-events-none rounded-[23px] ${
-                darkTheme
-                  ? "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]"
-                  : "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]"
-              }`}
+            {/* Role Switcher */}
+            <RoleSwitcher
+              currentRole={activeRole}
+              isSmallDevice={!!isSmallDevice}
+              showMobileNav={!!showMobileNav}
+              closeMobileNav={closeMobileNav}
+              onRoleChange={handleRoleChange}
             />
-            <div className="relative h-full flex items-center px-2 lg:px-5 justify-between">
-              <div className="flex items-center flex-1">
-                <Search
-                  className={`w-4 h-4 mr-3 flex-shrink-0 transition-colors ${
-                    darkTheme
-                      ? "text-[rgba(255,255,255,0.69)]"
-                      : "text-[rgba(45,40,32,0.75)]"
+
+            {/* Theme Toggle */}
+            <button
+              ref={themeToggleRef}
+              onClick={() => {
+                toggleSwitchTheme()
+                closeMobileNav()
+              }}
+              className={`h-[46px] lg:w-[46px] overflow-clip relative items-center justify-center backdrop-blur-[40px] transition-all hover:scale-105 shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ${
+                darkTheme ? 'bg-[#2d2820] text-[#e8dfd0]' : 'bg-[#d4c5b0] text-[#2d2820]'
+              }
+            ${showMobileNav ? ' flex rounded-sm w-[80%] max-w-[800px] ' : ' hidden lg:flex rounded-full '}`}
+              title={darkTheme ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              <div
+                className={`absolute inset-0 pointer-events-none ${
+                  darkTheme
+                    ? 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]'
+                    : 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]'
+                } ${showMobileNav ? 'rounded-sm' : 'rounded-full'}`}
+              />
+              {darkTheme ? (
+                <Sun
+                  className={`w-4 h-4 relative z-10 transition-colors ${
+                    darkTheme ? 'text-[rgba(255,255,255,0.69)]' : 'text-[rgba(45,40,32,0.75)]'
                   }`}
                 />
-                <span
-                  className={`text-[13px] transition-colors ${
-                    darkTheme
-                      ? "text-[rgba(255,255,255,0.5)]"
-                      : "text-[rgba(45,40,32,0.5)]"
+              ) : (
+                <Moon
+                  className={`w-4 h-4 relative z-10 transition-colors ${
+                    darkTheme ? 'text-[rgba(255,255,255,0.69)]' : 'text-[rgba(45,40,32,0.75)]'
                   }`}
-                >
-                  <span className="sm:hidden">Search</span>
-                  <span className="hidden sm:inline md:hidden">
-                    Search projects
-                  </span>
-                  <span className="hidden md:inline lg:hidden">
-                    Search projects, issues
-                  </span>
-                  <span className="hidden lg:inline">
-                    Search projects, issues, contributors...
-                  </span>
-                </span>
-              </div>
+                />
+              )}
+              <span className="ms-2 lg:hidden">
+                {showMobileNav && darkTheme ? 'Light Mode' : 'Dark Mode'}
+              </span>
+            </button>
 
-              <div
-                className="hidden lg:flex items-center gap-1.5 px-2 py-1 rounded border"
-                style={{
-                  backgroundColor: darkTheme
-                    ? "rgba(255, 255, 255, 0.08)"
-                    : "rgba(0, 0, 0, 0.08)",
-                  borderColor: darkTheme
-                    ? "rgba(255, 255, 255, 0.2)"
-                    : "rgba(0, 0, 0, 0.15)",
-                }}
-              >
-                <span
-                  className="text-[11px] font-medium"
-                  style={{
-                    color: darkTheme
-                      ? "rgba(255, 255, 255, 0.7)"
-                      : "rgba(0, 0, 0, 0.7)",
-                  }}
-                >
-                  ⌘
-                </span>
-                <span
-                  className="text-[11px] font-medium"
-                  style={{
-                    color: darkTheme
-                      ? "rgba(255, 255, 255, 0.7)"
-                      : "rgba(0, 0, 0, 0.7)",
-                  }}
-                >
-                  K
-                </span>
-              </div>
-            </div>
-          </Link>
-               
-          {/* Role Switcher */}
-          <RoleSwitcher
-            currentRole={activeRole}
-            isSmallDevice={!!isSmallDevice}
-            showMobileNav={!!showMobileNav}
-            closeMobileNav={closeMobileNav}
-            onRoleChange={handleRoleChange}
-          />
-
-          {/* Theme Toggle */}
-          <button
-            ref={themeToggleRef}
-            onClick={() => {
-              toggleSwitchTheme();
-              closeMobileNav();
-            }}
-            className={`h-[46px] lg:w-[46px] overflow-clip relative items-center justify-center backdrop-blur-[40px] transition-all hover:scale-105 shadow-[0px_6px_6.5px_-1px_rgba(0,0,0,0.36),0px_0px_4.2px_0px_rgba(0,0,0,0.69)] ${
-              darkTheme ? "bg-[#2d2820] text-[#e8dfd0]" : "bg-[#d4c5b0] text-[#2d2820]"
-            }
-            ${showMobileNav ? ' flex rounded-sm w-[80%] max-w-[800px] ' : ' hidden lg:flex rounded-full '}`}
-            title={darkTheme ? "Switch to light mode" : "Switch to dark mode"}
-          >
-            <div
-              className={`absolute inset-0 pointer-events-none ${
-                darkTheme
-                  ? "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]"
-                  : "shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]"
-              } ${showMobileNav? 'rounded-sm': 'rounded-full'}`}
+            {/* Notifications Dropdown */}
+            <NotificationsDropdown
+              showMobileNav={!!showMobileNav}
+              closeMobileNav={closeMobileNav}
             />
-            {darkTheme ? (
-              <Sun
-                className={`w-4 h-4 relative z-10 transition-colors ${
-                  darkTheme
-                    ? "text-[rgba(255,255,255,0.69)]"
-                    : "text-[rgba(45,40,32,0.75)]"
-                }`}
-              />
-            ) : (
-              <Moon
-                className={`w-4 h-4 relative z-10 transition-colors ${
-                  darkTheme
-                    ? "text-[rgba(255,255,255,0.69)]"
-                    : "text-[rgba(45,40,32,0.75)]"
-                }`}
-              />
-            )}
-             <span className='ml-2 lg:hidden'>
-            {
 
-             showMobileNav && darkTheme ?"Light Mode" :"Dark Mode"
-             }
-             </span>
-          </button>
+            {/* User Profile Dropdown */}
+            <UserProfileDropdown onPageChange={handleNavigation} showMobileNav={!!showMobileNav} />
 
-          {/* Notifications Dropdown */}
-          <NotificationsDropdown showMobileNav={!!showMobileNav} closeMobileNav={closeMobileNav}/>
-
-          {/* User Profile Dropdown */}
-          <UserProfileDropdown onPageChange={handleNavigation} showMobileNav={!!showMobileNav} />
-          
-          {/* Mobile nav open button */}
-          <button
-            className={`lg:hidden transition-colors ml-auto mr-[8px] ${showMobileNav? 'hidden' : 'block'} ${
-              theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-            }`}
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          >
-            {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
+            {/* Mobile nav open button */}
+            <button
+              className={`lg:hidden transition-colors ms-auto me-[8px] ${showMobileNav ? 'hidden' : 'block'} ${
+                theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+              }`}
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            >
+              {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
           </div>
 
           {/* Page Content - Outlet for nested routes */}
@@ -517,9 +504,9 @@ export function DashboardLayout() {
       <Modal
         isOpen={showAdminPasswordModal}
         onClose={() => {
-          setShowAdminPasswordModal(false);
-          setAdminPassword("");
-          setPendingAdminTarget(null);
+          setShowAdminPasswordModal(false)
+          setAdminPassword('')
+          setPendingAdminTarget(null)
         }}
         title="Admin Authentication"
         icon={<Shield className="w-6 h-6 text-[#c9983a]" />}
@@ -527,21 +514,17 @@ export function DashboardLayout() {
       >
         <form onSubmit={handleAdminPasswordSubmit}>
           <div className="space-y-4">
-            <p
-              className={`text-sm ${darkTheme ? "text-[#d4d4d4]" : "text-[#7a6b5a]"}`}
-            >
+            <p className={`text-sm ${darkTheme ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
               Enter the admin password to access the admin panel.
             </p>
             <ModalInput
               type="password"
               placeholder="Enter admin password"
               value={adminPassword}
-              onChange={(value) => setAdminPassword(value || "")}
+              onChange={(value) => setAdminPassword(value || '')}
               required
             />
-            <p
-              className={`text-xs ${darkTheme ? "text-[#b8a898]" : "text-[#7a6b5a]"}`}
-            >
+            <p className={`text-xs ${darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
               Tip: This must match the backend `ADMIN_BOOTSTRAP_TOKEN`.
             </p>
           </div>
@@ -549,9 +532,9 @@ export function DashboardLayout() {
             <ModalButton
               variant="secondary"
               onClick={() => {
-                setShowAdminPasswordModal(false);
-                setAdminPassword("");
-                setPendingAdminTarget(null);
+                setShowAdminPasswordModal(false)
+                setAdminPassword('')
+                setPendingAdminTarget(null)
               }}
               disabled={isAuthenticating}
             >
@@ -562,11 +545,11 @@ export function DashboardLayout() {
               type="submit"
               disabled={isAuthenticating || !adminPassword.trim()}
             >
-              {isAuthenticating ? "Authenticating..." : "Authenticate"}
+              {isAuthenticating ? 'Authenticating...' : 'Authenticate'}
             </ModalButton>
           </ModalFooter>
         </form>
       </Modal>
     </div>
-  );
+  )
 }

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -1,33 +1,31 @@
-import { Link } from "react-router-dom";
-import { FormattedMessage } from "react-intl";
-import { Menu, X, Moon, Sun } from "lucide-react";
-import { useState } from "react";
-import { useModeAnimation } from "react-theme-switch-animation";
-import { useTheme } from "../../../shared/contexts/ThemeContext";
-import { useAuth } from "../../../shared/contexts/AuthContext";
-import grainlifyLogo from "../../../assets/grainlify_log.svg";
+import { Link } from 'react-router-dom'
+import { FormattedMessage } from 'react-intl'
+import { Menu, X, Moon, Sun } from 'lucide-react'
+import { useState } from 'react'
+import { useModeAnimation } from 'react-theme-switch-animation'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { useAuth } from '../../../shared/contexts/AuthContext'
+import grainlifyLogo from '../../../assets/grainlify_log.svg'
 
 export function Navbar() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const { theme, setThemeFromAnimation } = useTheme();
-  const { isAuthenticated, logout } = useAuth();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const { theme, setThemeFromAnimation } = useTheme()
+  const { isAuthenticated, logout } = useAuth()
   const { ref, toggleSwitchTheme } = useModeAnimation({
-    isDarkMode: theme === "dark",
+    isDarkMode: theme === 'dark',
     onDarkModeChange: (isDark) => setThemeFromAnimation(isDark),
-  });
+  })
 
   return (
     <nav
-      className={`fixed top-0 left-0 right-0 z-50 backdrop-blur-[40px] border-b shadow-[0_4px_16px_rgba(0,0,0,0.06)] transition-colors ${
-        theme === "dark"
-          ? "bg-[#1a1512]/[0.85] border-white/10"
-          : "bg-white/[0.12] border-white/25"
+      className={`fixed top-0 inset-x-0 z-50 backdrop-blur-[40px] border-b shadow-[0_4px_16px_rgba(0,0,0,0.06)] transition-colors ${
+        theme === 'dark' ? 'bg-[#1a1512]/[0.85] border-white/10' : 'bg-white/[0.12] border-white/25'
       }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-3 sm:py-4">
         <div className="flex items-center justify-between">
           {/* Logo — above-the-fold, eager load for LCP */}
-          <Link to="/" className="flex items-center space-x-3">
+          <Link to="/" className="flex items-center gap-3">
             <img
               src={grainlifyLogo}
               alt="Grainlify"
@@ -37,7 +35,7 @@ export function Navbar() {
             />
             <span
               className={`text-xl font-semibold transition-colors ${
-                theme === "dark" ? "text-[#e8dfd0]" : "text-[#2d2820]"
+                theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
               }`}
             >
               Grainlify
@@ -45,13 +43,13 @@ export function Navbar() {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
+          <div className="hidden md:flex items-center gap-8">
             <a
               href="#features"
               className={`transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
             >
               <FormattedMessage id="landingNav.features" />
@@ -59,9 +57,9 @@ export function Navbar() {
             <a
               href="#how-it-works"
               className={`transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
             >
               <FormattedMessage id="landingNav.howItWorks" />
@@ -69,9 +67,9 @@ export function Navbar() {
             <a
               href="#why-choose-us"
               className={`transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
             >
               <FormattedMessage id="landingNav.whyChooseUs" />
@@ -79,9 +77,9 @@ export function Navbar() {
             <a
               href="#testimonials"
               className={`transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
             >
               <FormattedMessage id="landingNav.testimonials" />
@@ -89,25 +87,21 @@ export function Navbar() {
           </div>
 
           {/* CTA Buttons + Theme Toggle */}
-          <div className="hidden md:flex items-center space-x-4">
+          <div className="hidden md:flex items-center gap-4">
             {/* Theme Toggle */}
             <button
               ref={ref}
               onClick={() => {
-                toggleSwitchTheme();
+                toggleSwitchTheme()
               }}
               className={`p-2.5 rounded-[12px] backdrop-blur-[30px] border transition-all ${
-                theme === "dark"
-                  ? "bg-white/[0.08] border-white/15 hover:bg-white/[0.12] text-[#e8dfd0]"
-                  : "bg-white/[0.15] border-white/25 hover:bg-white/[0.2] text-[#2d2820]"
+                theme === 'dark'
+                  ? 'bg-white/[0.08] border-white/15 hover:bg-white/[0.12] text-[#e8dfd0]'
+                  : 'bg-white/[0.15] border-white/25 hover:bg-white/[0.2] text-[#2d2820]'
               }`}
               aria-label="Toggle theme"
             >
-              {theme === "dark" ? (
-                <Sun className="w-5 h-5" />
-              ) : (
-                <Moon className="w-5 h-5" />
-              )}
+              {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
             </button>
 
             {isAuthenticated ? (
@@ -115,9 +109,9 @@ export function Navbar() {
                 <Link
                   to="/dashboard"
                   className={`px-5 py-2.5 rounded-[12px] transition-colors font-medium ${
-                    theme === "dark"
-                      ? "text-[#e8dfd0] hover:text-[#c9983a]"
-                      : "text-[#2d2820] hover:text-[#c9983a]"
+                    theme === 'dark'
+                      ? 'text-[#e8dfd0] hover:text-[#c9983a]'
+                      : 'text-[#2d2820] hover:text-[#c9983a]'
                   }`}
                 >
                   <FormattedMessage id="landingNav.dashboard" />
@@ -125,9 +119,9 @@ export function Navbar() {
                 <button
                   onClick={logout}
                   className={`px-5 py-2.5 rounded-[12px] transition-colors font-medium ${
-                    theme === "dark"
-                      ? "text-[#e8dfd0] hover:text-[#c9983a]"
-                      : "text-[#2d2820] hover:text-[#c9983a]"
+                    theme === 'dark'
+                      ? 'text-[#e8dfd0] hover:text-[#c9983a]'
+                      : 'text-[#2d2820] hover:text-[#c9983a]'
                   }`}
                 >
                   <FormattedMessage id="landingNav.signOut" />
@@ -147,14 +141,10 @@ export function Navbar() {
           <button
             className="md:hidden p-2"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={mobileMenuOpen}
           >
-            {mobileMenuOpen ? (
-              <X className="w-6 h-6" />
-            ) : (
-              <Menu className="w-6 h-6" />
-            )}
+            {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
           </button>
         </div>
 
@@ -164,9 +154,9 @@ export function Navbar() {
             <a
               href="#features"
               className={`block transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -175,9 +165,9 @@ export function Navbar() {
             <a
               href="#how-it-works"
               className={`block transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -186,9 +176,9 @@ export function Navbar() {
             <a
               href="#why-choose-us"
               className={`block transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -197,9 +187,9 @@ export function Navbar() {
             <a
               href="#testimonials"
               className={`block transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#b8a898] hover:text-[#c9983a]"
-                  : "text-[#7a6b5a] hover:text-[#c9983a]"
+                theme === 'dark'
+                  ? 'text-[#b8a898] hover:text-[#c9983a]'
+                  : 'text-[#7a6b5a] hover:text-[#c9983a]'
               }`}
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -209,15 +199,15 @@ export function Navbar() {
             {/* Theme Toggle Mobile */}
             <button
               onClick={() => {
-                toggleSwitchTheme();
+                toggleSwitchTheme()
               }}
-              className={`w-full text-left px-3 py-2 rounded-[12px] transition-colors font-medium ${
-                theme === "dark"
-                  ? "text-[#e8dfd0] hover:text-[#c9983a]"
-                  : "text-[#2d2820] hover:text-[#c9983a]"
+              className={`w-full text-start px-3 py-2 rounded-[12px] transition-colors font-medium ${
+                theme === 'dark'
+                  ? 'text-[#e8dfd0] hover:text-[#c9983a]'
+                  : 'text-[#2d2820] hover:text-[#c9983a]'
               }`}
             >
-              {theme === "dark" ? "Light Mode" : "Dark Mode"}
+              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
             </button>
 
             {isAuthenticated ? (
@@ -225,9 +215,9 @@ export function Navbar() {
                 <Link
                   to="/dashboard"
                   className={`block px-3 py-2 rounded-[12px] transition-colors font-medium ${
-                    theme === "dark"
-                      ? "text-[#e8dfd0] hover:text-[#c9983a]"
-                      : "text-[#2d2820] hover:text-[#c9983a]"
+                    theme === 'dark'
+                      ? 'text-[#e8dfd0] hover:text-[#c9983a]'
+                      : 'text-[#2d2820] hover:text-[#c9983a]'
                   }`}
                   onClick={() => setMobileMenuOpen(false)}
                 >
@@ -235,13 +225,13 @@ export function Navbar() {
                 </Link>
                 <button
                   onClick={() => {
-                    logout();
-                    setMobileMenuOpen(false);
+                    logout()
+                    setMobileMenuOpen(false)
                   }}
-                  className={`w-full text-left px-3 py-2 rounded-[12px] transition-colors font-medium ${
-                    theme === "dark"
-                      ? "text-[#e8dfd0] hover:text-[#c9983a]"
-                      : "text-[#2d2820] hover:text-[#c9983a]"
+                  className={`w-full text-start px-3 py-2 rounded-[12px] transition-colors font-medium ${
+                    theme === 'dark'
+                      ? 'text-[#e8dfd0] hover:text-[#c9983a]'
+                      : 'text-[#2d2820] hover:text-[#c9983a]'
                   }`}
                 >
                   <FormattedMessage id="landingNav.signOut" />
@@ -260,5 +250,5 @@ export function Navbar() {
         )}
       </div>
     </nav>
-  );
+  )
 }

--- a/src/shared/i18n/I18nProvider.tsx
+++ b/src/shared/i18n/I18nProvider.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { IntlProvider } from 'react-intl'
 import { DEFAULT_LOCALE, resolveMessages, type Locale } from './messages'
 import { handleIntlError } from './errors'
+import { getTextDirection } from './direction'
 
 /** Props for {@link I18nProvider}. */
 export interface I18nProviderProps {
@@ -31,6 +32,10 @@ export interface I18nProviderProps {
  * </I18nProvider>
  */
 export function I18nProvider({ locale = DEFAULT_LOCALE, messages, children }: I18nProviderProps) {
+  useEffect(() => {
+    document.documentElement.dir = getTextDirection(locale)
+  }, [locale])
+
   return (
     <IntlProvider
       locale={locale}

--- a/src/shared/i18n/direction.ts
+++ b/src/shared/i18n/direction.ts
@@ -1,0 +1,16 @@
+import type { Locale } from './messages'
+
+/** The only valid values accepted by the document `dir` attribute. */
+export type TextDirection = 'ltr' | 'rtl'
+
+const RTL_LOCALES = new Set<Locale>(['ar'])
+
+/**
+ * Maps a supported locale to its writing direction.
+ *
+ * Locale is constrained to the app's fixed {@link Locale} union, so callers
+ * cannot inject arbitrary `dir` values into the document element.
+ */
+export function getTextDirection(locale: Locale): TextDirection {
+  return RTL_LOCALES.has(locale) ? 'rtl' : 'ltr'
+}

--- a/src/shared/i18n/i18n.test.tsx
+++ b/src/shared/i18n/i18n.test.tsx
@@ -7,6 +7,7 @@ import {
   I18nProvider,
   handleIntlError,
   useTranslation,
+  getTextDirection,
   resolveMessages,
   en,
   type Locale,
@@ -49,6 +50,35 @@ describe('i18n catalog & fallback', () => {
 
   it('falls back entirely to English for an unknown locale', () => {
     expect(resolveMessages('zz' as Locale)).toEqual(en)
+  })
+})
+
+describe('locale direction', () => {
+  it('defaults English and unknown locales to ltr', () => {
+    expect(getTextDirection('en')).toBe('ltr')
+    expect(getTextDirection('zz' as Locale)).toBe('ltr')
+  })
+
+  it('maps RTL locales to rtl', () => {
+    expect(getTextDirection('ar')).toBe('rtl')
+  })
+
+  it('sets document.documentElement.dir from the active locale', async () => {
+    const { rerender } = render(
+      <I18nProvider locale="en">
+        <span>English</span>
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(document.documentElement.dir).toBe('ltr'))
+
+    rerender(
+      <I18nProvider locale="ar">
+        <span>Arabic fallback</span>
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(document.documentElement.dir).toBe('rtl'))
   })
 })
 

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -6,9 +6,11 @@
  * - {@link useTranslation} — type-checked `t(id, values?)` + active `locale`.
  * - For inline JSX, import `<FormattedMessage>` / `<FormattedNumber>` directly
  *   from `react-intl` (this module intentionally does not re-wrap them).
+ * - {@link getTextDirection} — maps supported locales to `ltr` / `rtl`.
  * - {@link resolveMessages} / {@link en} / {@link MessageId} — catalog + types.
  */
 export { I18nProvider, type I18nProviderProps } from './I18nProvider'
+export { getTextDirection, type TextDirection } from './direction'
 export { handleIntlError } from './errors'
 export { useTranslation, type TranslationValues, type UseTranslation } from './useTranslation'
 export {

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -16,10 +16,11 @@
  */
 
 /**
- * Supported locale codes. English is the base/default locale; add new codes
- * here as their catalogs are introduced.
+ * Supported locale codes. English is the base/default locale. Arabic is kept
+ * as a fallback-backed RTL locale so direction support can be tested before a
+ * full translated catalog ships.
  */
-export type Locale = 'en'
+export type Locale = 'en' | 'ar'
 
 /** The default (and base) locale used as the fallback for every key. */
 export const DEFAULT_LOCALE: Locale = 'en'
@@ -76,6 +77,7 @@ export type Messages = Record<MessageId, string>
  */
 export const catalogs: Record<Locale, Partial<Messages>> = {
   en,
+  ar: {},
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a locale-to-direction helper constrained to `ltr` / `rtl`
- set the initial HTML direction to `ltr` and update `document.documentElement.dir` from the active locale in `I18nProvider`
- add fallback-backed Arabic (`ar`) as an RTL locale for direction coverage
- update key dashboard and landing navbar spacing/positioning to use logical utilities where feasible
- document the direction policy in the i18n README section

Closes #268

## Security
Direction is derived from the fixed `Locale` union and `getTextDirection()` only returns `ltr` or `rtl`; no user-provided text is written into the `dir` attribute.

## Verification
- `npm run test -- src/shared/i18n/i18n.test.tsx src/features/dashboard/DashboardLayout.test.tsx src/features/landing/components/Navbar.test.tsx src/app/App.test.tsx`
- `npm run typecheck`
- `npm run build`

## Notes
- `npm ci` requires `--legacy-peer-deps` locally because the repo currently pins TypeScript 6 while `react-intl` declares a TypeScript 5 peer range.
- Full `npm run test` currently fails in unrelated existing suites (`BillingProfilesContext`, maintainer dashboard Recharts mock missing `LabelList`, and auth-provider setup in pull request tab tests).
- Full `npm run lint` currently fails on an unrelated existing `no-console` error in `src/features/settings/components/terms/TermsTab.tsx`; changed-file lint has no new errors.