### PR TITLE
feat(logger): add pluggable error sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ translations. Untrusted input passed as a placeholder can therefore only ever
 become inert text. This is verified by an anti-injection test in
 [`i18n.test.tsx`](./src/shared/i18n/i18n.test.tsx).
 
+## Observability
+
+The guarded logger in [`src/shared/utils/logger.ts`](./src/shared/utils/logger.ts)
+supports an optional remote sink for warning and error telemetry:
+
+```ts
+setErrorSink((level, message, params) => {
+  // Forward only non-sensitive metadata to a collector.
+})
+```
+
+Use `clearErrorSink()` during teardown or tests. Sink implementations must remain
+PII-safe: do not forward JWTs, credentials, full user profiles, email addresses,
+or other sensitive user data. Sink failures are caught so remote telemetry cannot
+crash application code.
+
 ## Available Scripts
 
 | Command                     | Description                          |

--- a/src/shared/utils/logger.test.ts
+++ b/src/shared/utils/logger.test.ts
@@ -1,77 +1,150 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { logger } from './logger';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { clearErrorSink, logger, setErrorSink } from './logger'
 
 describe('Guarded Logger', () => {
-  let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
-  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleDebugSpy: ReturnType<typeof vi.spyOn>
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
+    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    clearErrorSink()
+    vi.restoreAllMocks()
     // Restore env stubs. `import.meta.env.PROD` is a read-only data descriptor in
     // this Vitest version, so it must be overridden via `vi.stubEnv` rather than
     // `Object.defineProperty` (which throws on the non-configurable property).
-    vi.unstubAllEnvs();
-  });
+    vi.unstubAllEnvs()
+  })
 
   describe('when in development (PROD is false)', () => {
     beforeEach(() => {
-      vi.stubEnv('PROD', false);
-    });
+      vi.stubEnv('PROD', false)
+    })
 
     it('should call console.debug when logger.debug is called', () => {
-      logger.debug('test debug', { data: 123 });
-      expect(consoleDebugSpy).toHaveBeenCalledWith('test debug', { data: 123 });
-    });
+      logger.debug('test debug', { data: 123 })
+      expect(consoleDebugSpy).toHaveBeenCalledWith('test debug', { data: 123 })
+    })
 
     it('should call console.info when logger.info is called', () => {
-      logger.info('test info', 'extra');
-      expect(consoleInfoSpy).toHaveBeenCalledWith('test info', 'extra');
-    });
+      logger.info('test info', 'extra')
+      expect(consoleInfoSpy).toHaveBeenCalledWith('test info', 'extra')
+    })
 
     it('should call console.warn when logger.warn is called', () => {
-      logger.warn('test warn');
-      expect(consoleWarnSpy).toHaveBeenCalledWith('test warn');
-    });
+      logger.warn('test warn')
+      expect(consoleWarnSpy).toHaveBeenCalledWith('test warn')
+    })
 
     it('should call console.error when logger.error is called', () => {
-      logger.error('test error');
-      expect(consoleErrorSpy).toHaveBeenCalledWith('test error');
-    });
-  });
+      logger.error('test error')
+      expect(consoleErrorSpy).toHaveBeenCalledWith('test error')
+    })
+
+    it('should notify the registered sink for warnings with explicit metadata only', () => {
+      const sink = vi.fn()
+      const metadata = { issueId: 279, component: 'logger' }
+
+      setErrorSink(sink)
+      logger.warn('test warn', metadata)
+
+      expect(sink).toHaveBeenCalledTimes(1)
+      expect(sink).toHaveBeenCalledWith('warn', 'test warn', [metadata])
+    })
+
+    it('should notify the registered sink for errors', () => {
+      const sink = vi.fn()
+      const metadata = { route: '/dashboard', recoverable: false }
+
+      setErrorSink(sink)
+      logger.error('test error', metadata)
+
+      expect(sink).toHaveBeenCalledTimes(1)
+      expect(sink).toHaveBeenCalledWith('error', 'test error', [metadata])
+    })
+
+    it('should not notify the sink for debug or info logs', () => {
+      const sink = vi.fn()
+
+      setErrorSink(sink)
+      logger.debug('test debug', { component: 'logger' })
+      logger.info('test info', { component: 'logger' })
+
+      expect(sink).not.toHaveBeenCalled()
+    })
+
+    it('should not throw when no sink is registered', () => {
+      expect(() => logger.warn('test warn without sink')).not.toThrow()
+      expect(() => logger.error('test error without sink')).not.toThrow()
+    })
+
+    it('should swallow errors thrown by the registered sink', () => {
+      const sink = vi.fn(() => {
+        throw new Error('remote collector failed')
+      })
+
+      setErrorSink(sink)
+
+      expect(() => logger.error('test error', { component: 'logger' })).not.toThrow()
+      expect(sink).toHaveBeenCalledTimes(1)
+      expect(consoleErrorSpy).toHaveBeenCalledWith('test error', { component: 'logger' })
+    })
+
+    it('should stop notifying the sink after clearErrorSink is called', () => {
+      const sink = vi.fn()
+
+      setErrorSink(sink)
+      clearErrorSink()
+      logger.warn('test warn')
+
+      expect(sink).not.toHaveBeenCalled()
+    })
+  })
 
   describe('when in production (PROD is true)', () => {
     beforeEach(() => {
-      vi.stubEnv('PROD', true);
-    });
+      vi.stubEnv('PROD', true)
+    })
 
     it('should NOT call console.debug when logger.debug is called', () => {
-      logger.debug('test debug');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
+      logger.debug('test debug')
+      expect(consoleDebugSpy).not.toHaveBeenCalled()
+    })
 
     it('should NOT call console.info when logger.info is called', () => {
-      logger.info('test info');
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-    });
+      logger.info('test info')
+      expect(consoleInfoSpy).not.toHaveBeenCalled()
+    })
 
     it('should NOT call console.warn when logger.warn is called', () => {
-      logger.warn('test warn');
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-    });
+      logger.warn('test warn')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    })
 
     it('should NOT call console.error when logger.error is called', () => {
-      logger.error('test error');
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-    });
-  });
-});
+      logger.error('test error')
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('should still notify the registered sink for warnings and errors', () => {
+      const sink = vi.fn()
+
+      setErrorSink(sink)
+      logger.warn('test warn', { component: 'logger' })
+      logger.error('test error', { component: 'logger' })
+
+      expect(sink).toHaveBeenNthCalledWith(1, 'warn', 'test warn', [{ component: 'logger' }])
+      expect(sink).toHaveBeenNthCalledWith(2, 'error', 'test error', [{ component: 'logger' }])
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,59 +1,114 @@
-/* eslint-disable no-console */
 /**
  * Guarded logger utility for the Grainlify application.
- * 
+ *
  * @remarks
  * - All log statements are silenced (no-op) in production environments (`import.meta.env.PROD` is true).
  * - CRITICAL SECURITY RULE: Under no circumstances should this logger be used to print sensitive
  *   personally identifiable information (PII), credentials, full user profiles, or JSON Web Tokens (JWTs).
  *   Only log non-sensitive metadata, booleans, or IDs when debugging is required.
  */
+export type ErrorSinkLevel = 'warn' | 'error'
+
+/**
+ * Optional remote sink for warn/error telemetry.
+ *
+ * @remarks
+ * Implementations must only forward PII-safe metadata. Do not send JWTs,
+ * credentials, full user profiles, email addresses, or other sensitive user
+ * data through this sink.
+ */
+export type ErrorSink = (
+  level: ErrorSinkLevel,
+  message: unknown,
+  params: readonly unknown[]
+) => void
+
+let errorSink: ErrorSink | undefined
+
+/**
+ * Registers a remote sink for warning and error logs.
+ *
+ * @remarks
+ * The sink is invoked in addition to the guarded console logger and is wrapped
+ * in try/catch so telemetry failures cannot crash application code.
+ */
+export function setErrorSink(sink: ErrorSink): void {
+  errorSink = sink
+}
+
+/**
+ * Clears the registered remote sink.
+ */
+export function clearErrorSink(): void {
+  errorSink = undefined
+}
+
+function notifyErrorSink(
+  level: ErrorSinkLevel,
+  message: unknown,
+  params: readonly unknown[]
+): void {
+  if (!errorSink) {
+    return
+  }
+
+  try {
+    errorSink(level, message, params)
+  } catch {
+    // Sink failures are intentionally swallowed so telemetry cannot break callers.
+  }
+}
+
 export const logger = {
   /**
    * Logs a debug message to the console. Silenced in production.
-   * 
+   *
    * @param message - The message or data to log.
    * @param optionalParams - Additional parameters or context to log.
    */
-  debug(message?: any, ...optionalParams: any[]): void {
+  debug(message?: unknown, ...optionalParams: unknown[]): void {
     if (!import.meta.env.PROD) {
-      console.debug(message, ...optionalParams);
+      console.debug(message, ...optionalParams)
     }
   },
 
   /**
    * Logs an info message to the console. Silenced in production.
-   * 
+   *
    * @param message - The message or data to log.
    * @param optionalParams - Additional parameters or context to log.
    */
-  info(message?: any, ...optionalParams: any[]): void {
+  info(message?: unknown, ...optionalParams: unknown[]): void {
     if (!import.meta.env.PROD) {
-      console.info(message, ...optionalParams);
+      console.info(message, ...optionalParams)
     }
   },
 
   /**
-   * Logs a warning message to the console. Silenced in production.
-   * 
+   * Logs a warning message to the console and the registered sink.
+   *
    * @param message - The message or data to log.
    * @param optionalParams - Additional parameters or context to log.
    */
-  warn(message?: any, ...optionalParams: any[]): void {
+  warn(message?: unknown, ...optionalParams: unknown[]): void {
     if (!import.meta.env.PROD) {
-      console.warn(message, ...optionalParams);
+      console.warn(message, ...optionalParams)
     }
+
+    notifyErrorSink('warn', message, optionalParams)
   },
 
   /**
-   * Logs an error message to the console. Silenced in production.
-   * 
+   * Logs an error message to the console and the registered sink.
+   *
    * @param message - The message or data to log.
    * @param optionalParams - Additional parameters or context to log.
    */
-  error(message?: any, ...optionalParams: any[]): void {
+  error(message?: unknown, ...optionalParams: unknown[]): void {
     if (!import.meta.env.PROD) {
-      console.error(message, ...optionalParams);
+      console.error(message, ...optionalParams)
     }
-  }
-};
+
+    notifyErrorSink('error', message, optionalParams)
+  },
+}


### PR DESCRIPTION
## Summary
- add exported `setErrorSink` and `clearErrorSink` APIs for warn/error telemetry
- keep default guarded console behavior unchanged when no sink is registered
- wrap sink calls so telemetry failures cannot throw, and document the PII-safe sink contract
- cover no-sink, clear, throwing-sink, warn/error, production sink, and metadata-only cases in logger tests

Closes #279

## Security
- sink TSDoc and README documentation forbid forwarding JWTs, credentials, full user profiles, email addresses, or other PII
- tests verify the sink receives only the explicit message and metadata passed to the logger

## Verification
- `npm run test -- src/shared/utils/logger.test.ts` 15 tests passed
- `npx eslint src/shared/utils/logger.ts src/shared/utils/logger.test.ts`
- `npm run typecheck`
- `npm run build`