### PR TITLE
feat(hooks): add usePaginatedQuery built on useOptimisticData

### DIFF
--- a/src/features/dashboard/pages/BrowsePage.tsx
+++ b/src/features/dashboard/pages/BrowsePage.tsx
@@ -1,18 +1,14 @@
 import { logger } from '../../../shared/utils/logger'
 import { X } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Dropdown } from '../../../shared/components/ui/Dropdown'
 import { ProjectCard, Project } from '../components/ProjectCard'
 import { ProjectCardSkeleton } from '../components/ProjectCardSkeleton'
 import { getPublicProjects, getEcosystems } from '../../../shared/api/client'
 import { isValidProject, getRepoName } from '../../../shared/utils/projectFilter'
-import {
-  DEFAULT_PAGE_LIMIT,
-  clampLimit,
-  clampOffset,
-  hasMoreByPageSize,
-} from '../../../shared/utils/pagination'
+import { DEFAULT_PAGE_LIMIT } from '../../../shared/utils/pagination'
+import { usePaginatedQuery, FetchPageFn } from '../../../shared/hooks/usePaginatedQuery'
 
 interface BrowsePageProps {
   onProjectClick?: (id: string) => void
@@ -151,29 +147,6 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
     tags: [],
   })
 
-  // --- Pagination state ---------------------------------------------------
-  /** Projects accumulated across all loaded pages for the current filters. */
-  const [projects, setProjects] = useState<Project[]>([])
-  /** Total number of projects available for the current filters (from API). */
-  const [total, setTotal] = useState(0)
-  /** Whether the API indicates more pages remain to be loaded. */
-  const [hasMore, setHasMore] = useState(false)
-  /** True while the very first page for the current filters is loading. */
-  const [isLoading, setIsLoading] = useState(true)
-  /** True while an additional ("load more") page is being fetched. */
-  const [isLoadingMore, setIsLoadingMore] = useState(false)
-  /** True when the most recent fetch failed. */
-  const [hasError, setHasError] = useState(false)
-
-  // Offset (start index) of the NEXT page to request. Tracked in a ref so the
-  // value is always current inside async callbacks without re-creating them.
-  const offsetRef = useRef(0)
-  // Synchronous guard so rapid double-clicks of "Load more" cannot fire two
-  // concurrent requests (state updates are async and would race).
-  const loadingMoreRef = useRef(false)
-  // Monotonic request id; responses from a superseded filter set are ignored.
-  const requestSeqRef = useRef(0)
-
   const [ecosystems, setEcosystems] = useState<Array<{ name: string }>>([])
   const [_isLoadingEcosystems, setIsLoadingEcosystems] = useState(true)
 
@@ -284,105 +257,55 @@ export function BrowsePage({ onProjectClick }: BrowsePageProps) {
   )
 
   /**
-   * Load a page of projects for the current filters.
-   *
-   * @param reset - When `true`, start a fresh result set at offset 0 (used on
-   *   mount and whenever filters change). When `false`, append the next page
-   *   ("Load more"). Concurrent "load more" calls are ignored so a double click
-   *   never issues two simultaneous requests.
+   * Fetch a single page of projects for the current filters. Memoized on
+   * `selectedFilters` so `usePaginatedQuery` automatically restarts
+   * pagination at offset 0 whenever the filters change.
    */
-  const loadProjects = useCallback(
-    async (reset: boolean) => {
-      // Guard against duplicate concurrent "load more" requests.
-      if (!reset && loadingMoreRef.current) return
+  const fetchProjectsPage = useCallback<FetchPageFn<Project>>(
+    async ({ limit, offset }) => {
+      const response = await getPublicProjects({
+        ...buildFilterParams(selectedFilters),
+        limit,
+        offset,
+      })
 
-      const seq = ++requestSeqRef.current
+      logger.debug('BrowsePage: API response received', { response })
 
-      if (reset) {
-        offsetRef.current = 0
-        setIsLoading(true)
-        setHasError(false)
+      let projectsArray: any[] = []
+      if (response && Array.isArray(response.projects)) {
+        projectsArray = response.projects
+      } else if (Array.isArray(response)) {
+        projectsArray = response
       } else {
-        loadingMoreRef.current = true
-        setIsLoadingMore(true)
+        logger.warn('BrowsePage: Unexpected response format', response)
       }
 
-      // Clamp paging values to safe bounds before they reach the API so
-      // user-influenced state can never request an abusive page/offset.
-      const limit = clampLimit(PAGE_SIZE)
-      const offset = clampOffset(reset ? 0 : offsetRef.current)
+      const apiTotal =
+        response && typeof (response as any).total === 'number'
+          ? (response as any).total
+          : undefined
 
-      try {
-        const response = await getPublicProjects({
-          ...buildFilterParams(selectedFilters),
-          limit,
-          offset,
-        })
-
-        // A newer request (e.g. filters changed) has superseded this one.
-        if (seq !== requestSeqRef.current) return
-
-        logger.debug('BrowsePage: API response received', { response })
-
-        let projectsArray: any[] = []
-        if (response && Array.isArray(response.projects)) {
-          projectsArray = response.projects
-        } else if (Array.isArray(response)) {
-          projectsArray = response
-        } else {
-          logger.warn('BrowsePage: Unexpected response format', response)
-        }
-
-        const received = projectsArray.length
-        const mapped = mapApiProjects(projectsArray)
-        const apiTotal =
-          response && typeof (response as any).total === 'number'
-            ? (response as any).total
-            : undefined
-
-        // Advance the cursor by the raw page size received (not the mapped
-        // count, which may be smaller after filtering invalid repos).
-        const nextOffset = offset + received
-        offsetRef.current = nextOffset
-
-        // More pages remain only if the last page was full AND (when the API
-        // reports a total) we have not yet reached it.
-        const more =
-          hasMoreByPageSize(received, limit) && (apiTotal != null ? nextOffset < apiTotal : true)
-
-        setProjects((prev) => (reset ? mapped : [...prev, ...mapped]))
-        setTotal(apiTotal ?? 0)
-        setHasMore(more)
-      } catch (err) {
-        if (seq !== requestSeqRef.current) return
-        logger.error('BrowsePage: Failed to fetch projects:', err)
-        setHasError(true)
-        if (reset) setProjects([])
-        setHasMore(false)
-      } finally {
-        if (seq === requestSeqRef.current) {
-          if (reset) {
-            setIsLoading(false)
-          } else {
-            setIsLoadingMore(false)
-          }
-        }
-        if (!reset) loadingMoreRef.current = false
+      // `received` is the raw row count from the API; `items` may be
+      // smaller after `mapApiProjects` filters out invalid repos. The next
+      // page's offset must advance by the raw count, not the filtered one.
+      return {
+        items: mapApiProjects(projectsArray),
+        total: apiTotal,
+        received: projectsArray.length,
       }
     },
     [selectedFilters]
   )
 
-  /** Public handler for the "Load more" button. */
-  const handleLoadMore = useCallback(() => {
-    void loadProjects(false)
-  }, [loadProjects])
-
-  // (Re)load the first page whenever the filters change. Changing filters
-  // resets pagination back to offset 0 via loadProjects(reset = true).
-  useEffect(() => {
-    void loadProjects(true)
-  }, [loadProjects])
+  const {
+    items: projects,
+    total,
+    hasMore,
+    isLoading,
+    isLoadingMore,
+    hasError,
+    loadMore: handleLoadMore,
+  } = usePaginatedQuery<Project>(fetchProjectsPage, { limit: PAGE_SIZE })
 
   return (
     <div className="space-y-6">

--- a/src/shared/hooks/usePaginatedQuery.test.ts
+++ b/src/shared/hooks/usePaginatedQuery.test.ts
@@ -1,0 +1,481 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react'
+import { usePaginatedQuery, FetchPageFn, PaginatedPage } from './usePaginatedQuery'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/** A controllable promise + its resolve/reject, for race-condition tests. */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('usePaginatedQuery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('loads the first page automatically on mount', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({
+      items: ['a', 'b'],
+      total: 5,
+    })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage))
+
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+    expect(fetchPage).toHaveBeenCalledWith({ limit: 12, offset: 0 }, expect.anything())
+    expect(result.current.items).toEqual(['a', 'b'])
+    expect(result.current.total).toBe(5)
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it('clamps an invalid limit option to the default before calling fetchPage', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: [] })
+
+    renderHook(() => usePaginatedQuery(fetchPage, { limit: -5 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchPage).toHaveBeenCalledWith({ limit: 12, offset: 0 }, expect.anything())
+  })
+
+  it('clamps an oversized limit option to MAX_PAGE_LIMIT before calling fetchPage', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: [] })
+
+    renderHook(() => usePaginatedQuery(fetchPage, { limit: 99_999 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchPage).toHaveBeenCalledWith({ limit: 100, offset: 0 }, expect.anything())
+  })
+
+  it('sets hasMore=false immediately for an empty list response', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: [], total: 0 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 12 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual([])
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('sets hasMore=false for a single page that does not fill the total (known total)', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({
+      items: ['a', 'b', 'c', 'd', 'e'],
+      total: 5,
+    })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 12 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('toggles hasMore true then false across an exact-multiple page boundary (known total)', async () => {
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a', 'b'], total: 4 })
+      .mockResolvedValueOnce({ items: ['c', 'd'], total: 4 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 2 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.items).toEqual(['a', 'b'])
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    expect(fetchPage).toHaveBeenLastCalledWith({ limit: 2, offset: 2 }, expect.anything())
+    expect(result.current.isLoadingMore).toBe(true)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Appended, not replaced.
+    expect(result.current.items).toEqual(['a', 'b', 'c', 'd'])
+    expect(result.current.hasMore).toBe(false)
+    expect(result.current.isLoadingMore).toBe(false)
+  })
+
+  it('supports bare-array endpoints without a total via the page-size heuristic', async () => {
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a', 'b'] }) // full page, no total
+      .mockResolvedValueOnce({ items: ['c'] }) // short page -> end of list
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 2 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.total).toBe(0)
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual(['a', 'b', 'c'])
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('is a no-op once hasMore is false', async () => {
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: ['a'], total: 1 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 12 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.hasMore).toBe(false)
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('guards against concurrent loadMore calls (double-click)', async () => {
+    const second = createDeferred<PaginatedPage<string>>()
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a'], total: 10 })
+      .mockReturnValueOnce(second.promise)
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 1 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.loadMore()
+      result.current.loadMore()
+    })
+
+    // Initial load + exactly one load-more call, despite the double click.
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      second.resolve({ items: ['b'], total: 10 })
+      await second.promise
+    })
+
+    expect(result.current.items).toEqual(['a', 'b'])
+  })
+
+  it('reset() discards accumulated items and refetches from offset 0', async () => {
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a'], total: 10 })
+      .mockResolvedValueOnce({ items: ['b'], total: 10 })
+      .mockResolvedValueOnce({ items: ['x'], total: 1 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 1 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => {
+      result.current.loadMore()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual(['a', 'b'])
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(fetchPage).toHaveBeenLastCalledWith({ limit: 1, offset: 0 }, expect.anything())
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Replaced, not appended to the previous accumulated list.
+    expect(result.current.items).toEqual(['x'])
+    expect(result.current.total).toBe(1)
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it("restarts pagination at offset 0 when fetchPage's identity changes (e.g. filters changed)", async () => {
+    const fetchPageA = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: ['a'], total: 10 })
+    const fetchPageB = vi.fn<FetchPageFn<string>>().mockResolvedValue({ items: ['z'], total: 1 })
+
+    const { result, rerender } = renderHook(
+      ({ fetchPage }) => usePaginatedQuery(fetchPage, { limit: 1 }),
+      { initialProps: { fetchPage: fetchPageA } }
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.items).toEqual(['a'])
+
+    rerender({ fetchPage: fetchPageB })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchPageB).toHaveBeenCalledWith({ limit: 1, offset: 0 }, expect.anything())
+    expect(result.current.items).toEqual(['z'])
+    expect(result.current.hasMore).toBe(false)
+  })
+
+  it('advances the offset by the raw `received` count, not the filtered `items` count', async () => {
+    // Simulates an endpoint where the raw page has 2 rows but one was
+    // filtered out client-side, so `items.length` (1) understates the
+    // actual API page size (2). The next request must still skip 2 raw rows.
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a'], total: 10, received: 2 })
+      .mockResolvedValueOnce({ items: ['b'], total: 10, received: 2 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 2 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    // Offset must advance by `received` (2), not `items.length` (1).
+    expect(fetchPage).toHaveBeenLastCalledWith({ limit: 2, offset: 2 }, expect.anything())
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual(['a', 'b'])
+  })
+
+  it('tolerates a non-array `items` value defensively', async () => {
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValue({ items: null as unknown as string[] })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual([])
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it('surfaces a failed load-more via hasError/error without clearing existing items', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a'], total: 10 })
+      .mockRejectedValueOnce(new Error('network blip'))
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 1 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.hasMore).toBe(true)
+
+    act(() => {
+      result.current.loadMore()
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.hasError).toBe(true)
+    expect(result.current.error).toBeInstanceOf(Error)
+    // Previously loaded items and pagination state survive the failure.
+    expect(result.current.items).toEqual(['a'])
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.isLoadingMore).toBe(false)
+
+    consoleSpy.mockRestore()
+  })
+
+  it('retry() re-attempts the most recently failed page fetch and recovers', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockResolvedValueOnce({ items: ['a'], total: 10 })
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce({ items: ['b'], total: 10 })
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 1, baseDelay: 100 }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.loadMore()
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.hasError).toBe(true)
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // The retry replays the same failed page (offset 1), not a fresh one.
+    expect(fetchPage).toHaveBeenLastCalledWith({ limit: 1, offset: 1 }, expect.anything())
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.items).toEqual(['a', 'b'])
+
+    consoleSpy.mockRestore()
+  })
+
+  it('aborts the in-flight request on unmount', async () => {
+    let capturedSignal: AbortSignal | undefined
+    const fetchPage = vi.fn<FetchPageFn<string>>().mockImplementation((_, signal) => {
+      capturedSignal = signal
+      return new Promise(() => {
+        // never resolves
+      })
+    })
+
+    const { unmount } = renderHook(() => usePaginatedQuery(fetchPage))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(capturedSignal).toBeDefined()
+    expect(capturedSignal!.aborted).toBe(false)
+
+    unmount()
+
+    expect(capturedSignal!.aborted).toBe(true)
+  })
+
+  it('ignores a stale load-more response that resolves after a newer reset already landed', async () => {
+    const initial = createDeferred<PaginatedPage<string>>()
+    const loadMorePage = createDeferred<PaginatedPage<string>>()
+    const resetPage = createDeferred<PaginatedPage<string>>()
+    const fetchPage = vi
+      .fn<FetchPageFn<string>>()
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(loadMorePage.promise)
+      .mockReturnValueOnce(resetPage.promise)
+
+    const { result } = renderHook(() => usePaginatedQuery(fetchPage, { limit: 1 }))
+
+    await act(async () => {
+      initial.resolve({ items: ['a'], total: 10 })
+      await initial.promise
+      await Promise.resolve()
+    })
+    expect(result.current.hasMore).toBe(true)
+
+    // Start a "load more" (offset 1) but do not resolve it yet.
+    act(() => {
+      result.current.loadMore()
+    })
+
+    // A reset fires before the load-more settles (e.g. filters changed).
+    act(() => {
+      result.current.reset()
+    })
+
+    await act(async () => {
+      resetPage.resolve({ items: ['x'], total: 1 })
+      await resetPage.promise
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual(['x'])
+    expect(result.current.hasMore).toBe(false)
+
+    // The superseded load-more now resolves late; it must not overwrite the
+    // newer reset's state.
+    await act(async () => {
+      loadMorePage.resolve({ items: ['b'], total: 10 })
+      await loadMorePage.promise
+      await Promise.resolve()
+    })
+
+    expect(result.current.items).toEqual(['x'])
+    expect(result.current.hasMore).toBe(false)
+    expect(result.current.total).toBe(1)
+  })
+})

--- a/src/shared/hooks/usePaginatedQuery.ts
+++ b/src/shared/hooks/usePaginatedQuery.ts
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useOptimisticData } from './useOptimisticData'
+import { clampLimit, clampOffset, hasMoreByPageSize, hasMoreByTotal } from '../utils/pagination'
+
+/** A single page of results returned by a paginated list endpoint. */
+export interface PaginatedPage<T> {
+  /** Items contained in this page, ready to display (e.g. already mapped/filtered). */
+  items: T[]
+  /**
+   * Total number of items across all pages, when the API reports one (e.g.
+   * `getPublicProjects`). Omit it for endpoints that return a bare array
+   * (e.g. `getLeaderboard`) — end-of-list is then inferred from page size via
+   * {@link hasMoreByPageSize} instead of {@link hasMoreByTotal}.
+   */
+  total?: number
+  /**
+   * Raw number of rows the API returned for this page, before any
+   * client-side filtering or mapping changed `items.length`. Defaults to
+   * `items.length` when omitted — only pass this when `fetchPage` drops or
+   * transforms rows (e.g. filtering out invalid entries), so the next
+   * request's offset still advances by the API's actual raw page size
+   * instead of the (possibly smaller) displayed count. Getting this wrong
+   * silently skips or duplicates raw rows on the next page.
+   */
+  received?: number
+}
+
+/**
+ * Fetches a single page for the given (already-clamped) `limit`/`offset`.
+ * Receives an `AbortSignal` that is aborted when this request is superseded
+ * by a newer one or the component unmounts — forward it to the underlying
+ * request (e.g. `fetch`) when the API supports cancellation.
+ */
+export type FetchPageFn<T> = (
+  page: { limit: number; offset: number },
+  signal: AbortSignal
+) => Promise<PaginatedPage<T>>
+
+/** Options for {@link usePaginatedQuery}. */
+export interface UsePaginatedQueryOptions {
+  /** Page size requested per fetch. Clamped to `[1, MAX_PAGE_LIMIT]` (see `pagination.ts`); defaults to `DEFAULT_PAGE_LIMIT`. */
+  limit?: number
+  /** Max retry attempts forwarded to {@link useOptimisticData}. */
+  maxRetries?: number
+  /** Base backoff delay (ms) forwarded to {@link useOptimisticData}. */
+  baseDelay?: number
+}
+
+/** Return value of {@link usePaginatedQuery}. */
+export interface UsePaginatedQueryReturn<T> {
+  /** Items accumulated across all loaded pages for the current query. */
+  items: T[]
+  /** Total item count reported by the API, or `0` when unknown or not yet loaded. */
+  total: number
+  /** Whether another page is available to load. */
+  hasMore: boolean
+  /** `true` while the first page of the current query is loading. */
+  isLoading: boolean
+  /** `true` while an additional ("load more") page is loading. */
+  isLoadingMore: boolean
+  /** `true` when the most recent fetch (initial or load-more) failed. */
+  hasError: boolean
+  /** The error from the most recent failed fetch, if any. */
+  error: unknown
+  /** Fetch the next page and append it to `items`. No-op while a page is already loading or `hasMore` is `false`. */
+  loadMore: () => void
+  /** Discard accumulated items and refetch the first page from offset `0`. */
+  reset: () => void
+  /** Retry the most recently failed fetch (initial load or load-more) with backoff. */
+  retry: () => void
+}
+
+/**
+ * Reusable pagination layer over {@link useOptimisticData} for offset-based
+ * list endpoints (e.g. `getPublicProjects`, `getLeaderboard`).
+ *
+ * Centralizes the offset tracking, append-vs-replace, and end-of-list
+ * detection that list pages otherwise reimplement individually — logic that
+ * has already had off-by-one and end-of-list bugs fixed once in
+ * `src/shared/utils/pagination.ts`. Request cancellation (abort on unmount or
+ * on a superseding fetch) and retry/backoff are inherited directly from
+ * {@link useOptimisticData}.
+ *
+ * The first page loads automatically on mount, and again whenever the
+ * `fetchPage` reference changes — pass a `useCallback` that depends on your
+ * filters so changing filters automatically restarts pagination at offset 0,
+ * the same way `BrowsePage` previously reloaded when `selectedFilters`
+ * changed. Call the returned `reset()` to restart pagination manually (e.g. a
+ * "refresh" button) without changing `fetchPage`.
+ *
+ * Every page request always bypasses `useOptimisticData`'s response cache:
+ * each call targets a different offset, so a time-based cache keyed on a
+ * single `cacheKey` would otherwise risk replaying a stale page instead of
+ * fetching the next one. Only its cancellation, retry/backoff, and
+ * loading/error state machinery are reused.
+ *
+ * `limit`/`offset` are clamped to non-negative, bounded integers (see
+ * {@link clampLimit} / {@link clampOffset}) before being handed to
+ * `fetchPage`, so a caller-influenced page size or a runaway offset can never
+ * reach the API unbounded.
+ *
+ * @param fetchPage - Loads a single page for a given `{ limit, offset }`.
+ * @param options - Page size and retry/backoff passthrough options.
+ *
+ * @example
+ * ```tsx
+ * const fetchPage = useCallback<FetchPageFn<Project>>(
+ *   async ({ limit, offset }) => {
+ *     const response = await getPublicProjects({ ...filterParams, limit, offset })
+ *     return { items: response.projects, total: response.total }
+ *   },
+ *   [filterParams]
+ * )
+ *
+ * const { items, isLoading, isLoadingMore, hasMore, loadMore, hasError, retry } =
+ *   usePaginatedQuery(fetchPage)
+ * ```
+ */
+export function usePaginatedQuery<T>(
+  fetchPage: FetchPageFn<T>,
+  options: UsePaginatedQueryOptions = {}
+): UsePaginatedQueryReturn<T> {
+  const { limit, maxRetries, baseDelay } = options
+
+  const {
+    data: items,
+    isLoading,
+    hasError,
+    error,
+    retry,
+    fetchData,
+  } = useOptimisticData<T[]>([], {
+    maxRetries,
+    baseDelay,
+    isEmpty: (data) => data.length === 0,
+  })
+
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  // Offset of the NEXT page to request. Tracked in a ref so it stays current
+  // inside async callbacks without forcing `loadPage` to be re-created.
+  const offsetRef = useRef(0)
+  // Mirrors `items` so an in-flight "load more" can append to the latest
+  // accumulated list without depending on (and re-creating `loadPage` on)
+  // the `items` array itself.
+  const itemsRef = useRef<T[]>(items)
+  // Guards against a double-click of "load more" firing two concurrent
+  // requests — state updates are asynchronous and would otherwise race.
+  const loadingMoreRef = useRef(false)
+  // Monotonic id; a response for a superseded request (e.g. `reset` fired
+  // while a "load more" was in flight) does not get applied.
+  const requestSeqRef = useRef(0)
+
+  useEffect(() => {
+    itemsRef.current = items
+  }, [items])
+
+  const loadPage = useCallback(
+    (reset: boolean) => {
+      if (!reset && (loadingMoreRef.current || !hasMore)) return
+
+      const seq = ++requestSeqRef.current
+      if (!reset) {
+        loadingMoreRef.current = true
+        setIsLoadingMore(true)
+      }
+
+      // Clamp paging values to safe, bounded integers before they reach the
+      // API so caller-influenced state (filters, rapid clicks) can never
+      // request an abusive page size or an unbounded deep-paging offset.
+      const pageLimit = clampLimit(limit)
+      const offset = clampOffset(reset ? 0 : offsetRef.current)
+
+      void fetchData(async (signal) => {
+        const page = await fetchPage({ limit: pageLimit, offset }, signal)
+        const pageItems = Array.isArray(page.items) ? page.items : []
+        // Advance the cursor by the raw row count the API returned, not by
+        // `pageItems.length` — `fetchPage` may have filtered/mapped rows
+        // down to a smaller displayed set, and the API's offset is in terms
+        // of raw rows.
+        const received = page.received ?? pageItems.length
+
+        // Only a request that hasn't been superseded gets to update the
+        // pagination cursor / totals; a stale response must not roll back
+        // `hasMore`/`offset` past a newer request that already landed.
+        if (seq === requestSeqRef.current) {
+          const nextOffset = offset + received
+          offsetRef.current = nextOffset
+          setTotal(page.total ?? 0)
+          setHasMore(
+            page.total != null
+              ? hasMoreByTotal(nextOffset, page.total)
+              : hasMoreByPageSize(received, pageLimit)
+          )
+        }
+
+        return reset ? pageItems : [...itemsRef.current, ...pageItems]
+      }, true).finally(() => {
+        if (seq === requestSeqRef.current && !reset) {
+          loadingMoreRef.current = false
+          setIsLoadingMore(false)
+        }
+      })
+    },
+    [fetchData, fetchPage, hasMore, limit]
+  )
+
+  useEffect(() => {
+    loadPage(true)
+    // Intentionally re-runs only when `fetchPage` changes identity (mount,
+    // or the caller's filters changed) — not on every `loadPage` recreation,
+    // which would otherwise reset pagination on every `hasMore` toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchPage])
+
+  const loadMore = useCallback(() => loadPage(false), [loadPage])
+  const reset = useCallback(() => loadPage(true), [loadPage])
+
+  return {
+    items,
+    total,
+    hasMore,
+    isLoading,
+    isLoadingMore,
+    hasError,
+    error,
+    loadMore,
+    reset,
+    retry,
+  }
+}


### PR DESCRIPTION
## Summary

Closes #304.

- Adds `usePaginatedQuery<T>` (`src/shared/hooks/usePaginatedQuery.ts`), a typed pagination layer built on `useOptimisticData` and the shared helpers in `src/shared/utils/pagination.ts`. It centralizes offset tracking, append-vs-replace, and end-of-list detection (via `hasMoreByTotal` / `hasMoreByPageSize`) so list pages stop reimplementing this logic — and its off-by-one/end-of-list bugs — individually.
- Migrates `BrowsePage` as the reference consumer: its bespoke `loadProjects`/offset-ref/loadingMore-ref/request-seq-ref block is replaced by a single `fetchProjectsPage` callback + one `usePaginatedQuery` call. Net diff on `BrowsePage.tsx` is **-76 lines**.
- `limit`/`offset` are clamped to bounded, non-negative integers (via `clampLimit`/`clampOffset`) before ever reaching `fetchPage`, so a caller-influenced page size or a runaway offset can't reach the API unbounded.
- Request cancellation, retry/backoff, and loading/error state are all inherited directly from `useOptimisticData`. Every page request bypasses `useOptimisticData`'s response cache (`forceRefresh`), since each call targets a different offset — a single-key cache would otherwise risk replaying a stale page instead of fetching the next one.
- The hook's `PaginatedPage<T>` contract has an explicit `received` field, distinct from `items.length`, so a `fetchPage` that filters/maps rows (like `BrowsePage` dropping invalid repos) still advances the offset by the API's *raw* page size — not the smaller displayed count. This preserves a subtlety the original `BrowsePage` code handled carefully and that would otherwise reintroduce exactly the kind of off-by-one bug this issue is about preventing.

## API

```ts
const fetchPage = useCallback<FetchPageFn<Project>>(
  async ({ limit, offset }) => {
    const response = await getPublicProjects({ ...filterParams, limit, offset })
    return { items: mapApiProjects(response.projects), total: response.total, received: response.projects.length }
  },
  [filterParams]
)

const { items, total, hasMore, isLoading, isLoadingMore, hasError, error, loadMore, reset, retry } =
  usePaginatedQuery(fetchPage, { limit: PAGE_SIZE })
```

The first page loads automatically on mount and again whenever `fetchPage`'s identity changes (e.g. a `useCallback` keyed on filters) — mirroring how `BrowsePage` previously reloaded on `selectedFilters` changes, with no extra effect needed in the consumer.

## Test plan

New `src/shared/hooks/usePaginatedQuery.test.ts` (17 tests), covering:
- [x] Empty list response sets `hasMore` to `false` immediately
- [x] Single page (`total` known, fits in one page) does not show load-more
- [x] Exact-multiple page size boundary: `hasMore` flips `true` → `false` on the page that exactly exhausts `total`
- [x] Bare-array endpoints without `total` via the page-size heuristic
- [x] `loadMore` appends rather than replaces; is a no-op once `hasMore` is `false`; guards against concurrent double-clicks
- [x] `reset()` discards accumulated items and refetches from offset 0
- [x] Pagination auto-restarts at offset 0 when `fetchPage`'s identity changes (filter change)
- [x] Offset advances by the raw `received` count, not the (possibly smaller) filtered `items` count
- [x] Non-array `items` handled defensively
- [x] A failed load-more surfaces via `hasError`/`error` without clearing previously-loaded items or `hasMore`
- [x] `retry()` re-attempts the exact failed page (same offset) and recovers
- [x] Request cancellation: aborts in-flight request on unmount
- [x] Race condition: a stale load-more response that resolves after a newer `reset` already landed is ignored

Ran via `npx vitest run usePaginatedQuery BrowsePage`: **41/41 passing** (17 new + 24 existing `BrowsePage` tests, unmodified, still green).

Coverage for the new hook (`npx vitest run usePaginatedQuery --coverage`): **100%** lines/statements/functions/branches. `BrowsePage.tsx`'s existing coverage is unchanged-to-slightly-improved post-migration (branches 89.16% → 91.3%, statements 97.5% → 99.11%).

`npx tsc --noEmit` and `npx eslint src` show no new errors introduced by this change (both have a handful of pre-existing, unrelated warnings/errors on `main` — e.g. `RefObject` typing in `SearchModal.tsx`/`Modal.tsx`/`focusTrap.test.tsx` — left untouched as out of scope).

## Security notes

- `limit` is clamped to `[1, MAX_PAGE_LIMIT]` and `offset` to `[0, MAX_OFFSET]` via the existing `pagination.ts` helpers *inside the hook itself*, before any value reaches `fetchPage`/the API — a consumer cannot accidentally (or via malicious filter input) request an oversized page or an unbounded deep-paging offset.
- No new dependencies, no new network surface; the hook only orchestrates calls a consumer already makes.