### PR TITLE
feat(ux): add processing/loading state to BillingProfileCard (#273)

### DIFF
--- a/src/features/settings/components/billing/BillingProfileCard.test.tsx
+++ b/src/features/settings/components/billing/BillingProfileCard.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithTheme } from '../../../../test/renderWithTheme'
+import { BillingProfileCard } from './BillingProfileCard'
+import type { BillingProfile } from '../../types'
+
+const baseProfile: BillingProfile = {
+  id: 1,
+  name: 'Acme Inc',
+  type: 'organization',
+  status: 'verified',
+}
+
+describe('BillingProfileCard', () => {
+  it('renders the profile and triggers onClick when not processing', () => {
+    const onClick = vi.fn()
+    const { container } = renderWithTheme(
+      <BillingProfileCard profile={baseProfile} onClick={onClick} />
+    )
+
+    expect(screen.getByText('Acme Inc')).toBeInTheDocument()
+    expect(screen.getByText('Company')).toBeInTheDocument() // organization -> Company
+    expect(screen.getByText('Verified')).toBeInTheDocument()
+
+    const card = container.querySelector('[aria-busy]') as HTMLElement
+    expect(card).toHaveAttribute('aria-busy', 'false')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    fireEvent.click(card)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a spinner, marks aria-busy and prevents duplicate activation while processing', () => {
+    const onClick = vi.fn()
+    const { container } = renderWithTheme(
+      <BillingProfileCard profile={baseProfile} onClick={onClick} isProcessing />
+    )
+
+    const card = container.querySelector('[aria-busy]') as HTMLElement
+    expect(card).toHaveAttribute('aria-busy', 'true')
+
+    const spinner = screen.getByRole('status', { name: 'Processing' })
+    expect(spinner).toBeInTheDocument()
+
+    // Clicking while processing must not re-trigger the action.
+    fireEvent.click(card)
+    fireEvent.click(card)
+    expect(onClick).not.toHaveBeenCalled()
+
+    // The colorblind-safe status badge stays intact.
+    expect(screen.getByText('Verified')).toBeInTheDocument()
+  })
+
+  it('restores the interactive state when processing completes', () => {
+    const onClick = vi.fn()
+    const { container, rerender } = renderWithTheme(
+      <BillingProfileCard profile={baseProfile} onClick={onClick} isProcessing />
+    )
+    expect(screen.getByRole('status')).toBeInTheDocument()
+
+    rerender(<BillingProfileCard profile={baseProfile} onClick={onClick} />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    const card = container.querySelector('[aria-busy]') as HTMLElement
+    expect(card).toHaveAttribute('aria-busy', 'false')
+
+    fireEvent.click(card)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the missing-verification status badge', () => {
+    renderWithTheme(
+      <BillingProfileCard
+        profile={{ ...baseProfile, status: 'missing-verification' }}
+        onClick={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Missing Verification')).toBeInTheDocument()
+  })
+
+  it('renders the limit-reached status badge', () => {
+    renderWithTheme(
+      <BillingProfileCard profile={{ ...baseProfile, status: 'limit-reached' }} onClick={vi.fn()} />
+    )
+    expect(screen.getByText('Individual Limit Reached')).toBeInTheDocument()
+  })
+
+  it('formats non-organization type labels', () => {
+    renderWithTheme(
+      <BillingProfileCard profile={{ ...baseProfile, type: 'self-employed' }} onClick={vi.fn()} />
+    )
+    expect(screen.getByText('self employed')).toBeInTheDocument()
+  })
+
+  it('supports the dark theme without losing the status badge', () => {
+    renderWithTheme(<BillingProfileCard profile={baseProfile} onClick={vi.fn()} />, {
+      theme: 'dark',
+    })
+    expect(screen.getByText('Verified')).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/billing/BillingProfileCard.tsx
+++ b/src/features/settings/components/billing/BillingProfileCard.tsx
@@ -1,68 +1,113 @@
-import { Circle, AlertCircle, CircleX } from 'lucide-react';
-import { BillingProfile } from '../../types';
-import { useTheme } from '../../../../shared/contexts/ThemeContext';
+import { Circle, AlertCircle, CircleX, Loader2 } from 'lucide-react'
+import { BillingProfile } from '../../types'
+import { useTheme } from '../../../../shared/contexts/ThemeContext'
 
 interface BillingProfileCardProps {
-  profile: BillingProfile;
-  onClick: () => void;
+  profile: BillingProfile
+  onClick: () => void
+  /**
+   * When `true`, the card shows a spinner, is marked `aria-busy`, and ignores
+   * clicks so an in-flight action cannot be triggered twice.
+   * @defaultValue false
+   */
+  isProcessing?: boolean
 }
 
-export function BillingProfileCard({ profile, onClick }: BillingProfileCardProps) {
-  const { theme } = useTheme();
+export function BillingProfileCard({
+  profile,
+  onClick,
+  isProcessing = false,
+}: BillingProfileCardProps) {
+  const { theme } = useTheme()
+
+  // Ignore activation while an action is in flight to avoid duplicate triggers.
+  const handleClick = () => {
+    if (isProcessing) return
+    onClick()
+  }
 
   const getStatusBadge = () => {
     switch (profile.status) {
       case 'verified':
         return (
-          <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
-            theme === 'dark'
-              ? 'bg-gradient-to-br from-[#10b981]/20 to-[#059669]/15 border-[#10b981]/40'
-              : 'bg-gradient-to-br from-[#10b981]/15 to-[#059669]/10 border-[#10b981]/35'
-          }`}>
-            <Circle className={`w-4 h-4 ${theme === 'dark' ? 'text-[#10b981] fill-[#10b981]' : 'text-[#059669] fill-[#059669]'}`} />
-            <span className={`text-[13px] font-medium transition-colors ${
-              theme === 'dark' ? 'text-[#10b981]' : 'text-[#059669]'
-            }`}>Verified</span>
+          <div
+            className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+              theme === 'dark'
+                ? 'bg-gradient-to-br from-[#10b981]/20 to-[#059669]/15 border-[#10b981]/40'
+                : 'bg-gradient-to-br from-[#10b981]/15 to-[#059669]/10 border-[#10b981]/35'
+            }`}
+          >
+            <Circle
+              className={`w-4 h-4 ${theme === 'dark' ? 'text-[#10b981] fill-[#10b981]' : 'text-[#059669] fill-[#059669]'}`}
+            />
+            <span
+              className={`text-[13px] font-medium transition-colors ${
+                theme === 'dark' ? 'text-[#10b981]' : 'text-[#059669]'
+              }`}
+            >
+              Verified
+            </span>
           </div>
-        );
+        )
       case 'missing-verification':
         return (
-          <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
-            theme === 'dark'
-              ? 'bg-gradient-to-br from-[#f59e0b]/20 to-[#d97706]/15 border-[#f59e0b]/40'
-              : 'bg-gradient-to-br from-[#f59e0b]/15 to-[#d97706]/10 border-[#f59e0b]/35'
-          }`}>
-            <AlertCircle className={`w-4 h-4 ${theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'}`} />
-            <span className={`text-[13px] font-medium transition-colors ${
-              theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'
-            }`}>Missing Verification</span>
+          <div
+            className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+              theme === 'dark'
+                ? 'bg-gradient-to-br from-[#f59e0b]/20 to-[#d97706]/15 border-[#f59e0b]/40'
+                : 'bg-gradient-to-br from-[#f59e0b]/15 to-[#d97706]/10 border-[#f59e0b]/35'
+            }`}
+          >
+            <AlertCircle
+              className={`w-4 h-4 ${theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'}`}
+            />
+            <span
+              className={`text-[13px] font-medium transition-colors ${
+                theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'
+              }`}
+            >
+              Missing Verification
+            </span>
           </div>
-        );
+        )
       case 'limit-reached':
         return (
-          <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
-            theme === 'dark'
-              ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/40'
-              : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/35'
-          }`}>
-            <CircleX className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`} />
-            <span className={`text-[13px] font-medium transition-colors ${
-              theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
-            }`}>Individual Limit Reached</span>
+          <div
+            className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+              theme === 'dark'
+                ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/40'
+                : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/35'
+            }`}
+          >
+            <CircleX
+              className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`}
+            />
+            <span
+              className={`text-[13px] font-medium transition-colors ${
+                theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
+              }`}
+            >
+              Individual Limit Reached
+            </span>
           </div>
-        );
+        )
     }
-  };
+  }
 
   const getTypeLabel = () => {
-    if (profile.type === 'organization') return 'Company';
-    return profile.type.replace('-', ' ');
-  };
+    if (profile.type === 'organization') return 'Company'
+    return profile.type.replace('-', ' ')
+  }
 
   return (
     <div
-      onClick={onClick}
-      className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 hover:border-[#c9983a]/30 transition-all cursor-pointer group ${
+      onClick={handleClick}
+      aria-busy={isProcessing}
+      className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-all group ${
+        isProcessing
+          ? 'opacity-60 cursor-default pointer-events-none'
+          : 'cursor-pointer hover:border-[#c9983a]/30'
+      } ${
         theme === 'dark'
           ? 'bg-[#2d2820]/[0.4] border-white/10 hover:bg-[#2d2820]/[0.5]'
           : 'bg-white/[0.12] border-white/20 hover:bg-white/[0.16]'
@@ -70,17 +115,30 @@ export function BillingProfileCard({ profile, onClick }: BillingProfileCardProps
     >
       <div className="flex items-start justify-between mb-4">
         <div className="flex-1">
-          <h3 className={`text-[20px] font-bold mb-1 group-hover:text-[#c9983a] transition-colors ${
-            theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-          }`}>
+          <h3
+            className={`text-[20px] font-bold mb-1 group-hover:text-[#c9983a] transition-colors ${
+              theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+            }`}
+          >
             {profile.name}
           </h3>
-          <p className={`text-[14px] capitalize transition-colors ${
-            theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
-          }`}>{getTypeLabel()}</p>
+          <p
+            className={`text-[14px] capitalize transition-colors ${
+              theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
+            }`}
+          >
+            {getTypeLabel()}
+          </p>
         </div>
+        {isProcessing && (
+          <Loader2
+            role="status"
+            aria-label="Processing"
+            className="w-5 h-5 animate-spin text-[#c9983a] flex-shrink-0"
+          />
+        )}
       </div>
       {getStatusBadge()}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
Closes #273

## What
`BillingProfileCard` (`src/features/settings/components/billing/BillingProfileCard.tsx`) invoked its click handler with no in-card feedback, so while an action was processing the card looked idle and could be clicked repeatedly.

## Changes
- New optional prop **`isProcessing?: boolean`** (default `false`, documented with TSDoc).
- While processing the card:
  - shows a `Loader2` spinner (`role="status"`, `aria-label="Processing"`), matching the existing spinner pattern in `ApplicationCard.tsx`;
  - is marked **`aria-busy`**;
  - is visually disabled (`opacity-60`, `pointer-events-none`, `cursor-default`) with hover affordances removed;
  - **guards its click handler** so the action cannot be triggered twice.
- Normal interactive state is restored when `isProcessing` returns to `false`.
- The colorblind-safe status badges are unchanged.

`BillingTab` is untouched — the prop is optional and backward compatible.

## Tests
New `BillingProfileCard.test.tsx`: normal click works; processing shows the spinner + `aria-busy` and blocks duplicate activation; state restores after processing; plus status-badge, type-label and dark-theme coverage.

## Verification
- `npm run typecheck` — passes.
- `BillingProfileCard.test.tsx` — 7/7 pass. Coverage of the file: 100% lines / 100% statements / 100% functions.
- Genuineness: reverting the component change makes the new tests fail.

## Security
None.