### PR TITLE
Refactor theming with semantic color tokens and update InvoicesTab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,19 @@ Grainlify implements a premium **Glassmorphism Design** featuring frosted overla
 - **Utility Classes**: Tailwind CSS v4 classes are used for layout and margins. Do not write ad-hoc style utilities or inline CSS rules.
 - **Transitions**: Use smooth transition utility classes (e.g. `transition-all duration-300`) on interactive states like hover, active, or toggle switches.
 
+### Semantic Status Tokens
+
+Status colors are centralized in `src/styles/theme.css` and must be consumed through CSS variables instead of hardcoded hex utilities.
+
+| Token | Meaning | Typical Usage |
+| :---- | :------ | :------------ |
+| `--status-success` | Completed / paid / verified outcomes | Positive badges, success icon accents |
+| `--status-error` | Failures / overdue / blocked outcomes | Error badges, alert icon accents |
+| `--status-warning` | Cautionary but not blocked outcomes | Warning badges, caution callouts |
+| `--status-pending` | Waiting / in-progress outcomes | Pending badges and progress states |
+
+Companion variables (`-foreground`, `-bg`, `-border`) define text, surface, and border values. Apply accessibility fixes by updating these token values once, not by introducing ad-hoc component-level status colors.
+
 ---
 
 ## Routing Setup

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -45,3 +45,58 @@ Test Files  1 passed (1)
 - [x] Search icon is `aria-hidden="true"`
 - [x] Input has an accessible label (`aria-label="Search issues, projects, and contributors"`)
 - [x] RTL test queries the clear button by role + name (`screen.getByRole("button", { name: "Clear search" })`)
+
+---
+
+# refactor(theming): add status-color tokens and adopt in InvoicesTab
+
+## 📌 Description
+
+Adds centralized semantic status color tokens to the global theme and migrates invoice status badges to consume those tokens instead of hardcoded inline hex values.
+
+## 🧩 Requirements and Context
+
+- Added semantic token variables in `src/styles/theme.css`:
+  - `--status-success`
+  - `--status-error`
+  - `--status-warning`
+  - `--status-pending`
+- Added companion token variables for badge rendering (`-foreground`, `-bg`, `-border`) in light and dark themes.
+- Migrated `src/features/settings/components/billing/InvoicesTab.tsx` status mapping to token-based classes.
+- Added TSDoc in `InvoicesTab` status mapper documenting semantic token intent and pending-vs-warning distinction.
+- Expanded `src/features/settings/components/billing/InvoicesTab.test.tsx` to cover:
+  - Correct token class usage for paid/pending/overdue statuses.
+  - WCAG AA contrast validation ($\ge 4.5:1$) for status text/background token pairs in both light and dark themes.
+  - Pending and warning semantic token distinction checks.
+- Documented status token semantics in:
+  - `CONTRIBUTING.md`
+  - `guidelines/Guidelines.md`
+
+## 🔒 Security Notes
+
+- None. Changes are presentation/theming and tests only.
+- No auth flows, network calls, permissions, or data handling logic were modified.
+
+## 🧪 Testing and Coverage
+
+### Targeted suite (changed area)
+```
+npm run test -- src/features/settings/components/billing/InvoicesTab.test.tsx
+
+Test Files  1 passed (1)
+Tests      23 passed (23)
+```
+
+### Full unit suite
+```
+npm run test
+```
+- The full suite currently reports pre-existing unrelated failures in other areas (for example localStorage setup issues in multiple legacy tests and recharts mock export mismatch in dashboard tests).
+- No failures were reported in the updated `InvoicesTab` suite.
+
+## ✅ Acceptance Criteria
+
+- [x] Status CSS variables defined.
+- [x] `InvoicesTab` migrated to status tokens.
+- [x] Contrast verified against WCAG AA in tests.
+- [x] Token semantics documented in contributor/design guidelines.

--- a/guidelines/Guidelines.md
+++ b/guidelines/Guidelines.md
@@ -1,3 +1,11 @@
+## Grainlify Design Token Rules
+
+- Use semantic status tokens from `src/styles/theme.css` for status UI: `--status-success`, `--status-error`, `--status-warning`, `--status-pending`.
+- Keep warning and pending semantically distinct. Warning represents caution; pending represents waiting/in-progress.
+- Do not hardcode inline status hex colors in JSX or Tailwind arbitrary values when a status token exists.
+- For status badges and chips, pair the token companions consistently: `-bg` for container background, `-border` for outline, `-foreground` for text/icon.
+- If contrast or colorblind fixes are needed, update token values in `theme.css` instead of patching individual components.
+
 **Add your own guidelines here**
 <!--
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^26.0.0",
+        "@types/node": "^26.0.1",
         "@types/react": "^19.2.9",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.61.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.61.1",

--- a/src/features/settings/components/billing/InvoicesTab.test.tsx
+++ b/src/features/settings/components/billing/InvoicesTab.test.tsx
@@ -1,23 +1,25 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { InvoicesTab } from './InvoicesTab';
-import { renderWithTheme } from '../../../../test/renderWithTheme';
-import type { Invoice } from '../../types';
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InvoicesTab } from './InvoicesTab'
+import { renderWithTheme } from '../../../../test/renderWithTheme'
+import type { Invoice } from '../../types'
 
 // ── Hoisted mock factories ────────────────────────────────────────────────────
 const { mockDownloadInvoice } = vi.hoisted(() => ({
   mockDownloadInvoice: vi.fn(),
-}));
+}))
 
 vi.mock('../../../../shared/api/client', () => ({
   downloadInvoice: mockDownloadInvoice,
-}));
+}))
 
 vi.mock('../../../../shared/utils/logger', () => ({
   logger: { debug: vi.fn() },
-}));
+}))
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 const INVOICE_PAID: Invoice = {
@@ -29,7 +31,7 @@ const INVOICE_PAID: Invoice = {
   status: 'paid',
   description: 'Monthly subscription',
   billingPeriod: 'Jan 2024',
-};
+}
 
 const INVOICE_PENDING: Invoice = {
   id: 'inv-2',
@@ -40,7 +42,7 @@ const INVOICE_PENDING: Invoice = {
   status: 'pending',
   description: 'Pro plan',
   billingPeriod: 'Feb 2024',
-};
+}
 
 const INVOICE_OVERDUE: Invoice = {
   id: 'inv-3',
@@ -51,192 +53,355 @@ const INVOICE_OVERDUE: Invoice = {
   status: 'overdue',
   description: 'Starter plan',
   billingPeriod: 'Mar 2024',
-};
+}
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
 beforeEach(() => {
+  if (!globalThis.localStorage) {
+    const store = new Map<string, string>()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value)
+        },
+        removeItem: (key: string) => {
+          store.delete(key)
+        },
+        clear: () => {
+          store.clear()
+        },
+        key: (index: number) => Array.from(store.keys())[index] ?? null,
+        get length() {
+          return store.size
+        },
+      },
+      configurable: true,
+      writable: true,
+    })
+  }
+
   // jsdom does not implement these; provide stubs so the component can run.
-  URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
-  URL.revokeObjectURL = vi.fn();
-});
+  URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+  URL.revokeObjectURL = vi.fn()
+})
 
 function setup(invoices: Invoice[] = [INVOICE_PAID]) {
-  return renderWithTheme(<InvoicesTab invoices={invoices} />);
+  return renderWithTheme(<InvoicesTab invoices={invoices} />)
+}
+
+function parseCssBlock(css: string, selector: ':root' | '.dark'): string {
+  const marker = `${selector} {`
+  const startIndex = css.indexOf(marker)
+  if (startIndex === -1) {
+    throw new Error(`Missing CSS block: ${selector}`)
+  }
+
+  let openBraces = 0
+  const contentStart = startIndex + marker.length
+  for (let i = contentStart; i < css.length; i += 1) {
+    if (css[i] === '{') openBraces += 1
+    if (css[i] === '}') {
+      if (openBraces === 0) {
+        return css.slice(contentStart, i)
+      }
+      openBraces -= 1
+    }
+  }
+
+  throw new Error(`Unterminated CSS block: ${selector}`)
+}
+
+function getCssVarValue(block: string, variableName: string): string {
+  const regex = new RegExp(`--${variableName}\\s*:\\s*([^;]+);`)
+  const match = block.match(regex)
+  if (!match) {
+    throw new Error(`Missing CSS variable --${variableName}`)
+  }
+  return match[1].trim()
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = hex.trim()
+  const match = normalized.match(/^#([a-fA-F0-9]{6})$/)
+  if (!match) {
+    throw new Error(`Expected 6-digit hex color, received: ${hex}`)
+  }
+
+  const value = match[1]
+  return {
+    r: Number.parseInt(value.slice(0, 2), 16),
+    g: Number.parseInt(value.slice(2, 4), 16),
+    b: Number.parseInt(value.slice(4, 6), 16),
+  }
+}
+
+function channelToLinearRgb(channel: number): number {
+  const normalized = channel / 255
+  return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex)
+  return (
+    0.2126 * channelToLinearRgb(r) + 0.7152 * channelToLinearRgb(g) + 0.0722 * channelToLinearRgb(b)
+  )
+}
+
+function contrastRatio(hexA: string, hexB: string): number {
+  const lumA = relativeLuminance(hexA)
+  const lumB = relativeLuminance(hexB)
+  const lighter = Math.max(lumA, lumB)
+  const darker = Math.min(lumA, lumB)
+  return (lighter + 0.05) / (darker + 0.05)
 }
 
 // ── Rendering ─────────────────────────────────────────────────────────────────
 describe('InvoicesTab — rendering', () => {
   it('shows the empty state when there are no invoices', () => {
-    setup([]);
-    expect(screen.getByText('No invoices yet')).toBeInTheDocument();
-  });
+    setup([])
+    expect(screen.getByText('No invoices yet')).toBeInTheDocument()
+  })
 
   it('renders a row for each invoice', () => {
-    setup([INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE]);
-    expect(screen.getByText('INV-2024-001')).toBeInTheDocument();
-    expect(screen.getByText('INV-2024-002')).toBeInTheDocument();
-    expect(screen.getByText('INV-2024-003')).toBeInTheDocument();
-  });
+    setup([INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE])
+    expect(screen.getByText('INV-2024-001')).toBeInTheDocument()
+    expect(screen.getByText('INV-2024-002')).toBeInTheDocument()
+    expect(screen.getByText('INV-2024-003')).toBeInTheDocument()
+  })
 
   it('renders all three status variants without error', () => {
-    setup([INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE]);
-    expect(screen.getByText('paid')).toBeInTheDocument();
-    expect(screen.getByText('pending')).toBeInTheDocument();
-    expect(screen.getByText('overdue')).toBeInTheDocument();
-  });
-});
+    setup([INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE])
+    expect(screen.getByText('paid')).toBeInTheDocument()
+    expect(screen.getByText('pending')).toBeInTheDocument()
+    expect(screen.getByText('overdue')).toBeInTheDocument()
+  })
+})
+
+describe('InvoicesTab — status token mapping', () => {
+  it('uses success token classes for paid invoices', () => {
+    setup([INVOICE_PAID])
+    const badge = screen.getByText('paid').parentElement
+    const icon = badge?.querySelector('svg')
+
+    expect(badge).toHaveClass('bg-[var(--status-success-bg)]')
+    expect(badge).toHaveClass('border-[var(--status-success-border)]')
+    expect(screen.getByText('paid')).toHaveClass('text-[var(--status-success-foreground)]')
+    expect(icon).toHaveClass('text-[var(--status-success-foreground)]')
+  })
+
+  it('uses pending token classes for pending invoices', () => {
+    setup([INVOICE_PENDING])
+    const badge = screen.getByText('pending').parentElement
+    const icon = badge?.querySelector('svg')
+
+    expect(badge).toHaveClass('bg-[var(--status-pending-bg)]')
+    expect(badge).toHaveClass('border-[var(--status-pending-border)]')
+    expect(screen.getByText('pending')).toHaveClass('text-[var(--status-pending-foreground)]')
+    expect(icon).toHaveClass('text-[var(--status-pending-foreground)]')
+  })
+
+  it('uses error token classes for overdue invoices', () => {
+    setup([INVOICE_OVERDUE])
+    const badge = screen.getByText('overdue').parentElement
+    const icon = badge?.querySelector('svg')
+
+    expect(badge).toHaveClass('bg-[var(--status-error-bg)]')
+    expect(badge).toHaveClass('border-[var(--status-error-border)]')
+    expect(screen.getByText('overdue')).toHaveClass('text-[var(--status-error-foreground)]')
+    expect(icon).toHaveClass('text-[var(--status-error-foreground)]')
+  })
+})
+
+describe('Status tokens — contrast and semantics', () => {
+  it('meets WCAG AA contrast for status foreground against status background in light and dark themes', () => {
+    const themeCss = readFileSync(join(process.cwd(), 'src/styles/theme.css'), 'utf8')
+    const lightBlock = parseCssBlock(themeCss, ':root')
+    const darkBlock = parseCssBlock(themeCss, '.dark')
+
+    const statusKinds = ['success', 'error', 'warning', 'pending'] as const
+    for (const status of statusKinds) {
+      const lightText = getCssVarValue(lightBlock, `status-${status}-foreground`)
+      const lightBg = getCssVarValue(lightBlock, `status-${status}-bg`)
+      const darkText = getCssVarValue(darkBlock, `status-${status}-foreground`)
+      const darkBg = getCssVarValue(darkBlock, `status-${status}-bg`)
+
+      expect(contrastRatio(lightText, lightBg)).toBeGreaterThanOrEqual(4.5)
+      expect(contrastRatio(darkText, darkBg)).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('keeps pending and warning semantic tokens distinct', () => {
+    const themeCss = readFileSync(join(process.cwd(), 'src/styles/theme.css'), 'utf8')
+    const lightBlock = parseCssBlock(themeCss, ':root')
+
+    expect(getCssVarValue(lightBlock, 'status-pending')).not.toBe(
+      getCssVarValue(lightBlock, 'status-warning')
+    )
+    expect(getCssVarValue(lightBlock, 'status-pending-foreground')).not.toBe(
+      getCssVarValue(lightBlock, 'status-warning-foreground')
+    )
+  })
+})
 
 // ── Download success ──────────────────────────────────────────────────────────
 describe('InvoicesTab — download success', () => {
   it('calls downloadInvoice with the correct invoice id', async () => {
-    mockDownloadInvoice.mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    await waitFor(() => expect(mockDownloadInvoice).toHaveBeenCalledWith('inv-1'));
-  });
+    mockDownloadInvoice.mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }))
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    await waitFor(() => expect(mockDownloadInvoice).toHaveBeenCalledWith('inv-1'))
+  })
 
   it('creates an object URL from the returned blob then revokes it', async () => {
-    const blob = new Blob(['%PDF'], { type: 'application/pdf' });
-    mockDownloadInvoice.mockResolvedValue(blob);
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
+    const blob = new Blob(['%PDF'], { type: 'application/pdf' })
+    mockDownloadInvoice.mockResolvedValue(blob)
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
     await waitFor(() => {
-      expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
-      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
-    });
-  });
+      expect(URL.createObjectURL).toHaveBeenCalledWith(blob)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+    })
+  })
 
   it('downloads without error when invoiceNumber contains only safe characters', async () => {
-    mockDownloadInvoice.mockResolvedValue(new Blob());
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalled());
-  });
+    mockDownloadInvoice.mockResolvedValue(new Blob())
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalled())
+  })
 
   it('clears the row error when a subsequent download succeeds', async () => {
     mockDownloadInvoice
       .mockRejectedValueOnce(new Error('Temporary failure'))
-      .mockResolvedValue(new Blob());
+      .mockResolvedValue(new Blob())
 
-    setup();
-    const btn = screen.getByRole('button', { name: /download invoice/i });
-    await userEvent.click(btn);
-    await screen.findByRole('alert');
+    setup()
+    const btn = screen.getByRole('button', { name: /download invoice/i })
+    await userEvent.click(btn)
+    await screen.findByRole('alert')
 
-    await userEvent.click(btn);
-    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
-  });
-});
+    await userEvent.click(btn)
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+  })
+})
 
 // ── Download error ────────────────────────────────────────────────────────────
 describe('InvoicesTab — download error', () => {
   it('shows the error message in a per-row alert on failure', async () => {
-    mockDownloadInvoice.mockRejectedValue(new Error('Network error'));
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Network error');
-  });
+    mockDownloadInvoice.mockRejectedValue(new Error('Network error'))
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Network error')
+  })
 
   it('shows a fallback message when the thrown value is not an Error instance', async () => {
-    mockDownloadInvoice.mockRejectedValue('unexpected string');
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Download failed. Please try again.');
-  });
+    mockDownloadInvoice.mockRejectedValue('unexpected string')
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Download failed. Please try again.')
+  })
 
   it('isolates the error to the failing row only', async () => {
     mockDownloadInvoice
       .mockRejectedValueOnce(new Error('Row 1 failed'))
-      .mockResolvedValue(new Blob());
+      .mockResolvedValue(new Blob())
 
-    setup([INVOICE_PAID, INVOICE_PENDING]);
-    const [btn1] = screen.getAllByRole('button', { name: /download invoice/i });
-    await userEvent.click(btn1);
-    await screen.findByRole('alert');
+    setup([INVOICE_PAID, INVOICE_PENDING])
+    const [btn1] = screen.getAllByRole('button', { name: /download invoice/i })
+    await userEvent.click(btn1)
+    await screen.findByRole('alert')
 
-    expect(screen.getAllByRole('alert')).toHaveLength(1);
-  });
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+  })
 
   it('does not call createObjectURL or revokeObjectURL on failure', async () => {
-    mockDownloadInvoice.mockRejectedValue(new Error('Server error'));
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    await screen.findByRole('alert');
-    expect(URL.createObjectURL).not.toHaveBeenCalled();
-    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
-  });
-});
+    mockDownloadInvoice.mockRejectedValue(new Error('Server error'))
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    await screen.findByRole('alert')
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+  })
+})
 
 // ── Loading state ─────────────────────────────────────────────────────────────
 describe('InvoicesTab — loading state', () => {
   it('disables the button and updates aria-label while the fetch is in flight', async () => {
-    let resolve!: (b: Blob) => void;
-    mockDownloadInvoice.mockReturnValue(new Promise<Blob>((res) => { resolve = res; }));
+    let resolve!: (b: Blob) => void
+    mockDownloadInvoice.mockReturnValue(
+      new Promise<Blob>((res) => {
+        resolve = res
+      })
+    )
 
-    setup();
-    const btn = screen.getByRole('button', { name: /download invoice/i });
-    await userEvent.click(btn);
+    setup()
+    const btn = screen.getByRole('button', { name: /download invoice/i })
+    await userEvent.click(btn)
 
-    await waitFor(() => expect(btn).toBeDisabled());
-    expect(btn).toHaveAttribute('aria-label', 'Downloading…');
+    await waitFor(() => expect(btn).toBeDisabled())
+    expect(btn).toHaveAttribute('aria-label', 'Downloading…')
 
-    resolve(new Blob());
-    await waitFor(() => expect(btn).not.toBeDisabled());
-    expect(btn).toHaveAttribute('aria-label', 'Download Invoice');
-  });
+    resolve(new Blob())
+    await waitFor(() => expect(btn).not.toBeDisabled())
+    expect(btn).toHaveAttribute('aria-label', 'Download Invoice')
+  })
 
   it('only disables the row being fetched, leaving other rows enabled', async () => {
-    let resolve!: (b: Blob) => void;
-    mockDownloadInvoice.mockReturnValue(new Promise<Blob>((res) => { resolve = res; }));
+    let resolve!: (b: Blob) => void
+    mockDownloadInvoice.mockReturnValue(
+      new Promise<Blob>((res) => {
+        resolve = res
+      })
+    )
 
-    setup([INVOICE_PAID, INVOICE_PENDING]);
-    const [btn1, btn2] = screen.getAllByRole('button', { name: /download invoice/i });
-    await userEvent.click(btn1);
+    setup([INVOICE_PAID, INVOICE_PENDING])
+    const [btn1, btn2] = screen.getAllByRole('button', { name: /download invoice/i })
+    await userEvent.click(btn1)
 
-    await waitFor(() => expect(btn1).toBeDisabled());
-    expect(btn2).not.toBeDisabled();
+    await waitFor(() => expect(btn1).toBeDisabled())
+    expect(btn2).not.toBeDisabled()
 
-    resolve(new Blob());
-    await waitFor(() => expect(btn1).not.toBeDisabled());
-  });
-});
+    resolve(new Blob())
+    await waitFor(() => expect(btn1).not.toBeDisabled())
+  })
+})
 
 // ── Responsive layout ─────────────────────────────────────────────────────────
 describe('InvoicesTab — responsive layout', () => {
   it('wraps the invoice table in an overflow-x-auto scroll container', () => {
-    const { container } = setup();
-    expect(container.querySelector('.overflow-x-auto')).not.toBeNull();
-  });
+    const { container } = setup()
+    expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+  })
 
   it('sets a minimum width on the inner container to prevent column collapse', () => {
-    const { container } = setup();
-    const scrollContainer = container.querySelector('.overflow-x-auto');
-    expect(scrollContainer?.firstElementChild?.className).toMatch(/min-w-/);
-  });
-});
+    const { container } = setup()
+    const scrollContainer = container.querySelector('.overflow-x-auto')
+    expect(scrollContainer?.firstElementChild?.className).toMatch(/min-w-/)
+  })
+})
 
 // ── Dark theme — covers the theme === 'dark' branches in every ternary ────────
 describe('InvoicesTab — dark theme', () => {
   it('renders the invoice table in dark theme without error', () => {
-    renderWithTheme(
-      <InvoicesTab invoices={[INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE]} />,
-      { theme: 'dark' },
-    );
-    expect(screen.getByText('INV-2024-001')).toBeInTheDocument();
-    expect(screen.getByText('paid')).toBeInTheDocument();
-    expect(screen.getByText('pending')).toBeInTheDocument();
-    expect(screen.getByText('overdue')).toBeInTheDocument();
-  });
+    renderWithTheme(<InvoicesTab invoices={[INVOICE_PAID, INVOICE_PENDING, INVOICE_OVERDUE]} />, {
+      theme: 'dark',
+    })
+    expect(screen.getByText('INV-2024-001')).toBeInTheDocument()
+    expect(screen.getByText('paid')).toBeInTheDocument()
+    expect(screen.getByText('pending')).toBeInTheDocument()
+    expect(screen.getByText('overdue')).toBeInTheDocument()
+  })
 
   it('renders the empty state in dark theme without error', () => {
-    renderWithTheme(<InvoicesTab invoices={[]} />, { theme: 'dark' });
-    expect(screen.getByText('No invoices yet')).toBeInTheDocument();
-  });
+    renderWithTheme(<InvoicesTab invoices={[]} />, { theme: 'dark' })
+    expect(screen.getByText('No invoices yet')).toBeInTheDocument()
+  })
 
   it('shows the download error alert in dark theme', async () => {
-    mockDownloadInvoice.mockRejectedValue(new Error('Dark theme network error'));
-    renderWithTheme(<InvoicesTab invoices={[INVOICE_PAID]} />, { theme: 'dark' });
-    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('Dark theme network error');
-  });
-});
+    mockDownloadInvoice.mockRejectedValue(new Error('Dark theme network error'))
+    renderWithTheme(<InvoicesTab invoices={[INVOICE_PAID]} />, { theme: 'dark' })
+    await userEvent.click(screen.getByRole('button', { name: /download invoice/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Dark theme network error')
+  })
+})

--- a/src/features/settings/components/billing/InvoicesTab.tsx
+++ b/src/features/settings/components/billing/InvoicesTab.tsx
@@ -1,33 +1,54 @@
-import { useState } from 'react';
-import { logger } from '../../../../shared/utils/logger';
-import { Download, FileText, CheckCircle2, Clock, AlertCircle, Loader2 } from 'lucide-react';
-import { useTheme } from '../../../../shared/contexts/ThemeContext';
-import { Invoice, InvoiceStatus } from '../../types';
-import { downloadInvoice } from '../../../../shared/api/client';
+import { useState } from 'react'
+import { logger } from '../../../../shared/utils/logger'
+import { Download, FileText, CheckCircle2, Clock, AlertCircle, Loader2 } from 'lucide-react'
+import { useTheme } from '../../../../shared/contexts/ThemeContext'
+import { Invoice, InvoiceStatus } from '../../types'
+import { downloadInvoice } from '../../../../shared/api/client'
 
 interface InvoicesTabProps {
-  invoices: Invoice[];
+  invoices: Invoice[]
 }
 
 function sanitizeFilename(raw: string): string {
-  return raw.replace(/[^a-zA-Z0-9\-_]/g, '-');
+  return raw.replace(/[^a-zA-Z0-9\-_]/g, '-')
 }
 
 export function InvoicesTab({ invoices }: InvoicesTabProps) {
-  const { theme } = useTheme();
-  const [downloadingId, setDownloadingId] = useState<string | null>(null);
-  const [downloadErrors, setDownloadErrors] = useState<Record<string, string>>({});
+  const { theme } = useTheme()
+  const [downloadingId, setDownloadingId] = useState<string | null>(null)
+  const [downloadErrors, setDownloadErrors] = useState<Record<string, string>>({})
 
+  /**
+   * Maps invoice statuses to semantic status tokens.
+   *
+   * Tokens are defined in `src/styles/theme.css` and intentionally keep
+   * `pending` distinct from `warning` for semantic clarity across the app.
+   */
   const getStatusColor = (status: InvoiceStatus) => {
     switch (status) {
       case 'paid':
-        return { bg: 'bg-[#22c55e]/20', text: 'text-[#16a34a]', border: 'border-[#22c55e]/30', icon: CheckCircle2 };
+        return {
+          bg: 'bg-[var(--status-success-bg)]',
+          text: 'text-[var(--status-success-foreground)]',
+          border: 'border-[var(--status-success-border)]',
+          icon: CheckCircle2,
+        }
       case 'pending':
-        return { bg: 'bg-[#eab308]/20', text: 'text-[#ca8a04]', border: 'border-[#eab308]/30', icon: Clock };
+        return {
+          bg: 'bg-[var(--status-pending-bg)]',
+          text: 'text-[var(--status-pending-foreground)]',
+          border: 'border-[var(--status-pending-border)]',
+          icon: Clock,
+        }
       case 'overdue':
-        return { bg: 'bg-[#ef4444]/20', text: 'text-[#dc2626]', border: 'border-[#ef4444]/30', icon: AlertCircle };
+        return {
+          bg: 'bg-[var(--status-error-bg)]',
+          text: 'text-[var(--status-error-foreground)]',
+          border: 'border-[var(--status-error-border)]',
+          icon: AlertCircle,
+        }
     }
-  };
+  }
 
   /**
    * Fetches the PDF for `invoice` from the API and triggers a browser download.
@@ -44,44 +65,50 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
    * @param invoice - The invoice row whose PDF should be downloaded.
    */
   const handleDownloadInvoice = async (invoice: Invoice): Promise<void> => {
-    setDownloadingId(invoice.id);
+    setDownloadingId(invoice.id)
     setDownloadErrors((prev) => {
-      const next = { ...prev };
-      delete next[invoice.id];
-      return next;
-    });
+      const next = { ...prev }
+      delete next[invoice.id]
+      return next
+    })
 
     try {
-      logger.debug('Downloading invoice:', invoice.invoiceNumber);
-      const blob = await downloadInvoice(invoice.id);
-      const objectUrl = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = objectUrl;
-      link.download = `invoice-${sanitizeFilename(invoice.invoiceNumber)}.pdf`;
-      link.click();
-      URL.revokeObjectURL(objectUrl);
+      logger.debug('Downloading invoice:', invoice.invoiceNumber)
+      const blob = await downloadInvoice(invoice.id)
+      const objectUrl = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = objectUrl
+      link.download = `invoice-${sanitizeFilename(invoice.invoiceNumber)}.pdf`
+      link.click()
+      URL.revokeObjectURL(objectUrl)
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Download failed. Please try again.';
-      setDownloadErrors((prev) => ({ ...prev, [invoice.id]: message }));
+      const message = err instanceof Error ? err.message : 'Download failed. Please try again.'
+      setDownloadErrors((prev) => ({ ...prev, [invoice.id]: message }))
     } finally {
-      setDownloadingId(null);
+      setDownloadingId(null)
     }
-  };
+  }
 
   return (
-    <div className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
-      theme === 'dark'
-        ? 'bg-[#2d2820]/[0.4] border-white/10'
-        : 'bg-white/[0.12] border-white/20'
-    }`}>
+    <div
+      className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
+        theme === 'dark' ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.12] border-white/20'
+      }`}
+    >
       {/* Header */}
       <div className="mb-6">
-        <h3 className={`text-[20px] font-bold mb-2 transition-colors ${
-          theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-        }`}>Invoices</h3>
-        <p className={`text-[14px] transition-colors ${
-          theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-        }`}>
+        <h3
+          className={`text-[20px] font-bold mb-2 transition-colors ${
+            theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+          }`}
+        >
+          Invoices
+        </h3>
+        <p
+          className={`text-[14px] transition-colors ${
+            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+          }`}
+        >
           View and download your billing invoices.
         </p>
       </div>
@@ -92,56 +119,73 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
           <div className="overflow-x-auto">
             <div className="min-w-[640px]">
               {/* Table Header */}
-              <div className={`grid grid-cols-[1.2fr_1fr_1fr_1fr_0.8fr_0.6fr] gap-4 px-6 py-3 border-b-2 transition-colors ${
-                theme === 'dark' ? 'border-white/20' : 'border-white/20'
-              }`}>
+              <div
+                className={`grid grid-cols-[1.2fr_1fr_1fr_1fr_0.8fr_0.6fr] gap-4 px-6 py-3 border-b-2 transition-colors ${
+                  theme === 'dark' ? 'border-white/20' : 'border-white/20'
+                }`}
+              >
                 {['Invoice', 'Date', 'Amount', 'Period', 'Status', 'Action'].map((col) => (
-                  <div key={col} className={`text-[12px] font-bold uppercase tracking-wide transition-colors ${
-                    theme === 'dark' ? 'text-[#d4c5b0]' : 'text-[#7a6b5a]'
-                  }`}>{col}</div>
+                  <div
+                    key={col}
+                    className={`text-[12px] font-bold uppercase tracking-wide transition-colors ${
+                      theme === 'dark' ? 'text-[#d4c5b0]' : 'text-[#7a6b5a]'
+                    }`}
+                  >
+                    {col}
+                  </div>
                 ))}
               </div>
 
               {/* Invoice Rows */}
               {invoices.map((invoice) => {
-                const statusConfig = getStatusColor(invoice.status);
-                const StatusIcon = statusConfig.icon;
-                const isDownloading = downloadingId === invoice.id;
-                const rowError = downloadErrors[invoice.id];
+                const statusConfig = getStatusColor(invoice.status)
+                const StatusIcon = statusConfig.icon
+                const isDownloading = downloadingId === invoice.id
+                const rowError = downloadErrors[invoice.id]
 
                 return (
                   <div key={invoice.id} className="mt-3">
-                    <div className={`grid grid-cols-[1.2fr_1fr_1fr_1fr_0.8fr_0.6fr] gap-4 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border transition-all ${
-                      theme === 'dark'
-                        ? 'bg-white/[0.08] border-white/15 hover:bg-white/[0.12] hover:border-[#c9983a]/20'
-                        : 'bg-white/[0.08] border-white/15 hover:bg-white/[0.15] hover:border-[#c9983a]/20'
-                    }`}>
+                    <div
+                      className={`grid grid-cols-[1.2fr_1fr_1fr_1fr_0.8fr_0.6fr] gap-4 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border transition-all ${
+                        theme === 'dark'
+                          ? 'bg-white/[0.08] border-white/15 hover:bg-white/[0.12] hover:border-[#c9983a]/20'
+                          : 'bg-white/[0.08] border-white/15 hover:bg-white/[0.15] hover:border-[#c9983a]/20'
+                      }`}
+                    >
                       {/* Invoice Number & Description */}
                       <div>
                         <div className="flex items-center gap-2 mb-1">
-                          <div className={`w-8 h-8 rounded-[10px] flex items-center justify-center ${
-                            theme === 'dark' ? 'bg-[#c9983a]/20' : 'bg-[#c9983a]/15'
-                          }`}>
+                          <div
+                            className={`w-8 h-8 rounded-[10px] flex items-center justify-center ${
+                              theme === 'dark' ? 'bg-[#c9983a]/20' : 'bg-[#c9983a]/15'
+                            }`}
+                          >
                             <FileText className="w-4 h-4 text-[#c9983a]" />
                           </div>
-                          <h4 className={`text-[14px] font-bold transition-colors ${
-                            theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-                          }`}>
+                          <h4
+                            className={`text-[14px] font-bold transition-colors ${
+                              theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                            }`}
+                          >
                             {invoice.invoiceNumber}
                           </h4>
                         </div>
-                        <p className={`text-[12px] ml-10 transition-colors ${
-                          theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
-                        }`}>
+                        <p
+                          className={`text-[12px] ml-10 transition-colors ${
+                            theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
+                          }`}
+                        >
                           {invoice.description}
                         </p>
                       </div>
 
                       {/* Date */}
                       <div className="flex items-center">
-                        <span className={`text-[13px] transition-colors ${
-                          theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                        }`}>
+                        <span
+                          className={`text-[13px] transition-colors ${
+                            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                          }`}
+                        >
                           {new Date(invoice.date).toLocaleDateString('en-US', {
                             month: 'short',
                             day: 'numeric',
@@ -152,9 +196,11 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
 
                       {/* Amount */}
                       <div className="flex items-center">
-                        <span className={`text-[15px] font-bold transition-colors ${
-                          theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-                        }`}>
+                        <span
+                          className={`text-[15px] font-bold transition-colors ${
+                            theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                          }`}
+                        >
                           {invoice.amount.toLocaleString('en-US', {
                             style: 'currency',
                             currency: invoice.currency,
@@ -164,18 +210,24 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
 
                       {/* Billing Period */}
                       <div className="flex items-center">
-                        <span className={`text-[13px] transition-colors ${
-                          theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                        }`}>
+                        <span
+                          className={`text-[13px] transition-colors ${
+                            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                          }`}
+                        >
                           {invoice.billingPeriod}
                         </span>
                       </div>
 
                       {/* Status */}
                       <div className="flex items-center">
-                        <div className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[8px] border ${statusConfig.bg} ${statusConfig.border}`}>
+                        <div
+                          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[8px] border ${statusConfig.bg} ${statusConfig.border}`}
+                        >
                           <StatusIcon className={`w-3 h-3 ${statusConfig.text}`} />
-                          <span className={`text-[11px] font-semibold capitalize ${statusConfig.text}`}>
+                          <span
+                            className={`text-[11px] font-semibold capitalize ${statusConfig.text}`}
+                          >
                             {invoice.status}
                           </span>
                         </div>
@@ -193,10 +245,11 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
                               : 'hover:bg-white/[0.2] text-[#c9983a]'
                           }`}
                         >
-                          {isDownloading
-                            ? <Loader2 className="w-4 h-4 animate-spin" />
-                            : <Download className="w-4 h-4" />
-                          }
+                          {isDownloading ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : (
+                            <Download className="w-4 h-4" />
+                          )}
                         </button>
                       </div>
                     </div>
@@ -212,32 +265,38 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
                       </p>
                     )}
                   </div>
-                );
+                )
               })}
             </div>
           </div>
         </div>
       ) : (
         <div className="text-center py-12">
-          <div className={`w-16 h-16 rounded-full mx-auto mb-4 flex items-center justify-center ${
-            theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.15]'
-          }`}>
-            <FileText className={`w-8 h-8 ${
-              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-            }`} />
+          <div
+            className={`w-16 h-16 rounded-full mx-auto mb-4 flex items-center justify-center ${
+              theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.15]'
+            }`}
+          >
+            <FileText
+              className={`w-8 h-8 ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}
+            />
           </div>
-          <p className={`text-[14px] mb-2 transition-colors ${
-            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-          }`}>
+          <p
+            className={`text-[14px] mb-2 transition-colors ${
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+            }`}
+          >
             No invoices yet
           </p>
-          <p className={`text-[13px] transition-colors ${
-            theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
-          }`}>
+          <p
+            className={`text-[13px] transition-colors ${
+              theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
+            }`}
+          >
             Your billing invoices will appear here
           </p>
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,12 +2,15 @@
 
 /* Hide scrollbar but keep scroll functionality */
 .scrollbar-hide {
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
+  -ms-overflow-style: none;
+  /* IE and Edge */
+  scrollbar-width: none;
+  /* Firefox */
 }
 
 .scrollbar-hide::-webkit-scrollbar {
-  display: none;  /* Chrome, Safari and Opera */
+  display: none;
+  /* Chrome, Safari and Opera */
 }
 
 /* Custom scrollbar for dropdowns */
@@ -35,6 +38,7 @@
     transform: translateX(100%);
     opacity: 0;
   }
+
   to {
     transform: translateX(0);
     opacity: 1;
@@ -50,6 +54,7 @@
   0% {
     transform: translateX(-100%);
   }
+
   100% {
     transform: translateX(100%);
   }
@@ -61,7 +66,7 @@
 
 :root {
   --font-size: 16px;
-  
+
   /* Glassmorphism Warm Neutral Color Palette - Light Mode */
   --background: #e8dfd0;
   --foreground: #2d2820;
@@ -86,29 +91,50 @@
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --ring: rgba(201, 152, 58, 0.5);
-  
+
+  /* Semantic status tokens (light theme) */
+  --status-success: #22c55e;
+  --status-success-foreground: #166534;
+  --status-success-bg: #dcfce7;
+  --status-success-border: #86efac;
+
+  --status-error: #ef4444;
+  --status-error-foreground: #991b1b;
+  --status-error-bg: #fee2e2;
+  --status-error-border: #fca5a5;
+
+  --status-warning: #eab308;
+  --status-warning-foreground: #854d0e;
+  --status-warning-bg: #fef3c7;
+  --status-warning-border: #fcd34d;
+
+  --status-pending: #ca8a04;
+  --status-pending-foreground: #78350f;
+  --status-pending-bg: #fef9c3;
+  --status-pending-border: #facc15;
+
   /* Gradient colors */
   --gradient-primary: linear-gradient(135deg, #c9983a 0%, #a67c2e 100%);
   --gradient-secondary: linear-gradient(135deg, #d4c4b0 0%, #b8a898 100%);
   --gradient-accent: linear-gradient(135deg, #c9983a 0%, #b8a590 100%);
-  
+
   /* Glassmorphism */
   --glass-bg: rgba(255, 255, 255, 0.35);
   --glass-border: rgba(201, 152, 58, 0.2);
   --glass-blur: 40px;
-  
+
   /* Glow effects */
   --glow-primary: 0 0 20px rgba(201, 152, 58, 0.3);
   --glow-secondary: 0 0 20px rgba(166, 124, 46, 0.3);
   --glow-accent: 0 0 15px rgba(201, 152, 58, 0.2);
-  
+
   /* Chart colors */
   --chart-1: #c9983a;
   --chart-2: #a67c2e;
   --chart-3: #d4c4b0;
   --chart-4: #b8a898;
   --chart-5: #a89780;
-  
+
   --radius: 1rem;
   --sidebar: rgba(255, 255, 255, 0.3);
   --sidebar-foreground: #2d2820;
@@ -142,6 +168,28 @@
   --ring: #a67c2e;
   --font-weight-medium: 500;
   --font-weight-normal: 400;
+
+  /* Semantic status tokens (dark theme) */
+  --status-success: #22c55e;
+  --status-success-foreground: #bbf7d0;
+  --status-success-bg: #14532d;
+  --status-success-border: #16a34a;
+
+  --status-error: #ef4444;
+  --status-error-foreground: #fecaca;
+  --status-error-bg: #7f1d1d;
+  --status-error-border: #dc2626;
+
+  --status-warning: #eab308;
+  --status-warning-foreground: #fde68a;
+  --status-warning-bg: #78350f;
+  --status-warning-border: #ca8a04;
+
+  --status-pending: #ca8a04;
+  --status-pending-foreground: #fef08a;
+  --status-pending-bg: #713f12;
+  --status-pending-border: #a16207;
+
   --chart-1: #c9983a;
   --chart-2: #a67c2e;
   --chart-3: #d4c4b0;
@@ -179,6 +227,22 @@
   --color-input-background: var(--input-background);
   --color-switch-background: var(--switch-background);
   --color-ring: var(--ring);
+  --color-status-success: var(--status-success);
+  --color-status-success-foreground: var(--status-success-foreground);
+  --color-status-success-bg: var(--status-success-bg);
+  --color-status-success-border: var(--status-success-border);
+  --color-status-error: var(--status-error);
+  --color-status-error-foreground: var(--status-error-foreground);
+  --color-status-error-bg: var(--status-error-bg);
+  --color-status-error-border: var(--status-error-border);
+  --color-status-warning: var(--status-warning);
+  --color-status-warning-foreground: var(--status-warning-foreground);
+  --color-status-warning-bg: var(--status-warning-bg);
+  --color-status-warning-border: var(--status-warning-border);
+  --color-status-pending: var(--status-pending);
+  --color-status-pending-foreground: var(--status-pending-foreground);
+  --color-status-pending-bg: var(--status-pending-bg);
+  --color-status-pending-border: var(--status-pending-border);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -224,8 +288,7 @@ body.modal-open aside {
  * ensures the ring only appears for keyboard interaction, not mouse clicks.
  * A lighter gold is used in dark mode for adequate contrast in both themes.
  */
-:where(
-  a[href],
+:where(a[href],
   button,
   input,
   select,
@@ -233,25 +296,21 @@ body.modal-open aside {
   [tabindex],
   [role='option'],
   [role='menuitem'],
-  [role='dialog']
-):focus-visible {
+  [role='dialog']):focus-visible {
   outline: 2px solid #c9983a;
   outline-offset: 2px;
   border-radius: 6px;
 }
 
-.dark
-  :where(
-    a[href],
-    button,
-    input,
-    select,
-    textarea,
-    [tabindex],
-    [role='option'],
-    [role='menuitem'],
-    [role='dialog']
-  ):focus-visible {
+.dark :where(a[href],
+  button,
+  input,
+  select,
+  textarea,
+  [tabindex],
+  [role='option'],
+  [role='menuitem'],
+  [role='dialog']):focus-visible {
   outline-color: #e8c571;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,10 @@
         "isolatedModules": true,
         "noEmit": true,
         "jsx": "react-jsx",
+        "types": [
+            "node",
+            "vitest/globals"
+        ],
         /* Linting */
         "strict": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
## Related Issue
Closes #266 

## Screenshot
<img width="847" height="605" alt="0" src="https://github.com/user-attachments/assets/7b7ef1f2-61bc-4614-980c-380d0cf73acb" />


##Summary

This pull request introduces a centralized system for semantic status color theming across the app. It adds new status color tokens to the global theme, migrates the `InvoicesTab` component to use these tokens instead of hardcoded values, and updates documentation and tests to reflect the new approach. The changes improve maintainability, accessibility, and consistency of status UI elements.

**Theming and Design System Updates**
* Added semantic status color tokens (`--status-success`, `--status-error`, `--status-warning`, `--status-pending`) and their companion variables for foreground, background, and border to `src/styles/theme.css` for both light and dark themes.
* Documented the use and intent of status tokens in `CONTRIBUTING.md` and `guidelines/Guidelines.md`, emphasizing semantic distinctions and accessibility best practices. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R152-R164) [[2]](diffhunk://#diff-cdb6f8fcca82215c3b181ee683380957071de63e47ff410dcda09c11bca576acR1-R8)

**Component Refactor**
* Refactored `src/features/settings/components/billing/InvoicesTab.tsx` to consume the new status tokens for invoice status badges, replacing all inline hex color values. Added TSDoc to clarify token mapping and semantic intent.
* Updated `InvoicesTab` test suite to verify correct token usage and ensure WCAG AA contrast compliance for status badges in both light and dark themes.

**Other Changes**
* Minor update to `@types/node` dev dependency version in `package.json`.

These changes are theming, documentation, and test-only—no business logic, data handling, or security-related code was affected.