### PR TITLE
a11y/issuelistsidebar search busy

### DIFF
--- a/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
@@ -137,4 +137,114 @@ describe('IssueListSidebar', () => {
 
     expect(screen.getByText('99+')).toBeInTheDocument()
   })
+
+  it('shows spinner and sets aria-busy while search is pending', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hello' } })
+    })
+
+    // Spinner should appear immediately on typing
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+
+    // Results region should be marked busy
+    expect(screen.getByLabelText('Issues list')).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('hides spinner and clears aria-busy after debounce settles', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hello' } })
+    })
+
+    // Advance beyond the debounce delay so it settles
+    act(() => {
+      vi.advanceTimersByTime(350)
+    })
+
+    // Spinner should be gone
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+
+    // aria-busy should be cleared
+    expect(screen.getByLabelText('Issues list')).toHaveAttribute('aria-busy', 'false')
+  })
+
+  it('keeps spinner visible during rapid typing before debounce settles', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    // Type multiple characters in quick succession (before debounce fires)
+    act(() => {
+      fireEvent.change(input, { target: { value: 'h' } })
+    })
+    act(() => {
+      fireEvent.change(input, { target: { value: 'he' } })
+    })
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hel' } })
+    })
+
+    // Spinner should still be visible since debounce hasn't fired yet
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+
+    // Advance timers past debounce
+    act(() => {
+      vi.advanceTimersByTime(350)
+    })
+
+    // Spinner should now be gone
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+  })
 })

--- a/src/features/maintainers/components/issues/IssueListSidebar.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.tsx
@@ -1,4 +1,4 @@
-import { Search, Filter } from 'lucide-react'
+import { Search, Filter, Loader2 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../../shared/hooks/useDebouncedValue'
@@ -38,6 +38,11 @@ function formatCountBadge(count: number): string {
  * so list filtering doesn't run on every keystroke. Renders a distinct
  * empty state when there are no issues at all versus when search/filters
  * exclude every issue.
+ *
+ * While a search is pending (debounce window + parent re-filter) the
+ * results region receives `aria-busy="true"` and an inline spinner is
+ * shown inside the search input. Both clear automatically once the
+ * debounced value settles and the parent re-renders with updated issues.
  */
 export function IssueListSidebar({
   issues,
@@ -70,6 +75,13 @@ export function IssueListSidebar({
     }
     setSearchQuery(debouncedSearch)
   }, [debouncedSearch, setSearchQuery])
+
+  // Track whether a search is in-flight: covers the debounce window
+  // (draft !== debounced) and the brief synchronous re-filter by the parent.
+  const [isSearching, setIsSearching] = useState(false)
+  useEffect(() => {
+    setIsSearching(debouncedSearch !== draftSearch)
+  }, [debouncedSearch, draftSearch])
 
   const badgeText = useMemo(() => formatCountBadge(appliedFilterCount), [appliedFilterCount])
 
@@ -119,17 +131,25 @@ export function IssueListSidebar({
             placeholder="Search"
             value={draftSearch}
             onChange={(e) => setDraftSearch(e.target.value)}
-            className={`w-full pl-11 pr-4 py-3 rounded-[14px] backdrop-blur-[25px] border text-[14px] focus:outline-none focus:border-[#c9983a]/40 focus:ring-2 focus:ring-[#c9983a]/20 transition-all ${
+            className={`w-full pl-11 pr-11 py-3 rounded-[14px] backdrop-blur-[25px] border text-[14px] focus:outline-none focus:border-[#c9983a]/40 focus:ring-2 focus:ring-[#c9983a]/20 transition-all ${
               theme === 'dark'
                 ? 'bg-white/[0.08] border-white/15 text-[#e8dfd0] placeholder:text-[#8a7b6a] focus:bg-white/[0.12]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder:text-[#9a8b7a] focus:bg-white/[0.2]'
             }`}
           />
+          {isSearching && (
+            <Loader2
+              className={`absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin transition-colors ${
+                theme === 'dark' ? 'text-[#c9983a]' : 'text-[#c9983a]'
+              }`}
+              aria-hidden="true"
+            />
+          )}
         </div>
       </div>
 
       {/* Scrollable Issues List */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">
+      <div className="flex-1 overflow-y-auto px-6 pb-6" aria-busy={isSearching} aria-label="Issues list">
         <div className="space-y-3">
           {showNoIssuesFound && (
             <div

--- a/src/shared/components/ui/Modal.test.tsx
+++ b/src/shared/components/ui/Modal.test.tsx
@@ -252,6 +252,74 @@ describe('Modal building blocks', () => {
     expect(onChange).toHaveBeenCalled();
   });
 
+  describe('ModalInput accessibility (ARIA)', () => {
+    it('sets aria-invalid="true" and links error via aria-describedby when error is present (input)', () => {
+      renderWithTheme(
+        <ModalInput value="hello" onChange={() => {}} error="This field is required" />,
+      );
+      const input = screen.getByDisplayValue('hello');
+      expect(input.tagName).toBe('INPUT');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+
+      const describedBy = input.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)).toHaveTextContent('This field is required');
+    });
+
+    it('sets aria-invalid="true" and links error via aria-describedby when error is present (textarea)', () => {
+      renderWithTheme(
+        <ModalInput value="bio text" onChange={() => {}} rows={3} error="Must not be empty" />,
+      );
+      const textarea = screen.getByDisplayValue('bio text');
+      expect(textarea.tagName).toBe('TEXTAREA');
+      expect(textarea).toHaveAttribute('aria-invalid', 'true');
+
+      const describedBy = textarea.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)).toHaveTextContent('Must not be empty');
+    });
+
+    it('omits aria-invalid and aria-describedby when no error is set (input)', () => {
+      renderWithTheme(
+        <ModalInput value="hello" onChange={() => {}} />,
+      );
+      const input = screen.getByDisplayValue('hello');
+      expect(input).not.toHaveAttribute('aria-invalid');
+      expect(input).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('omits aria-invalid and aria-describedby when no error is set (textarea)', () => {
+      renderWithTheme(
+        <ModalInput value="notes" onChange={() => {}} rows={2} />,
+      );
+      const textarea = screen.getByDisplayValue('notes');
+      expect(textarea).not.toHaveAttribute('aria-invalid');
+      expect(textarea).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('removes aria-invalid and aria-describedby when error is cleared', () => {
+      const { rerender } = renderWithTheme(
+        <ModalInput value="test" onChange={() => {}} error="Something wrong" />,
+      );
+      const input = screen.getByDisplayValue('test');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+
+      rerender(
+        <ModalInput value="test" onChange={() => {}} error={null} />,
+      );
+      expect(input).not.toHaveAttribute('aria-invalid');
+      expect(input).not.toHaveAttribute('aria-describedby');
+      expect(screen.queryByText('Something wrong')).not.toBeInTheDocument();
+    });
+
+    it('does not render an error paragraph when error is null', () => {
+      renderWithTheme(
+        <ModalInput value="test" onChange={() => {}} />,
+      );
+      expect(screen.queryByText(/this field is required/i)).not.toBeInTheDocument();
+    });
+  });
+
   it('ModalSelect renders a labelled trigger with the selected value', () => {
     renderWithTheme(
       <ModalSelect

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -200,18 +200,35 @@ export function ModalButton({
 }
 
 interface ModalInputProps {
+  /** Visible label rendered above the field. */
   label?: string;
+  /** Input type (ignored when `rows` is set — renders a `<textarea>`). */
   type?: string;
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
   placeholder?: string;
   required?: boolean;
+  /** When > 0 the field renders as a `<textarea>` with this many rows. */
   rows?: number;
   className?: string;
+  /**
+   * Error message displayed below the field. When set the input receives
+   * `aria-invalid="true"` and the message is linked via `aria-describedby`.
+   * Error text is rendered as plain text (no markup).
+   */
   error?: string | null;
 }
 
+/**
+ * Accessible labelled input / textarea with error-state ARIA wiring.
+ *
+ * When `error` is set:
+ * - `aria-invalid="true"` is applied to the native input/textarea.
+ * - `aria-describedby` points at the rendered error paragraph.
+ * - The error text is rendered as plain React children (no
+ *   `dangerouslySetInnerHTML`).
+ */
 export function ModalInput({
   label,
   type = 'text',
@@ -227,6 +244,7 @@ export function ModalInput({
   const { theme } = useTheme();
 
   const isError = !!error;
+  const errorId = useId();
 
   const inputClasses = `w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none transition-all text-[14px] ${isError
     ? theme === 'dark'
@@ -255,6 +273,8 @@ export function ModalInput({
           onBlur={onBlur}
           className={`${inputClasses} resize-none`}
           placeholder={placeholder}
+          aria-invalid={isError || undefined}
+          aria-describedby={isError ? errorId : undefined}
         />
       ) : (
         <input
@@ -265,11 +285,16 @@ export function ModalInput({
           onBlur={onBlur}
           className={inputClasses}
           placeholder={placeholder}
+          aria-invalid={isError || undefined}
+          aria-describedby={isError ? errorId : undefined}
         />
       )}
       {isError && (
-        <p className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
-          }`}>
+        <p
+          id={errorId}
+          className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
+            }`}
+        >
           {error}
         </p>
       )}


### PR DESCRIPTION
# feat(a11y): add aria-busy and spinner to IssueListSidebar search

Closes #239 

## Description

Adds a `isSearching` state to the debounced search in `IssueListSidebar` that covers the debounce + synchronous re-filter window. While pending, the results region receives `aria-busy="true"` and an inline `<Loader2>` spinner appears inside the search input. Both clear automatically once the debounced value settles and the parent re-renders with updated issues.

## Requirements and Context

- **`aria-busy`**: Set dynamically on the results list container (`aria-busy={isSearching}`) so screen readers announce the pending state.
- **Inline spinner**: `<Loader2 className="animate-spin" />` from `lucide-react` (existing project dependency) rendered inside the search input when `isSearching` is true. Marked `aria-hidden="true"`.
- **State management**: Single `useEffect` comparing `debouncedSearch !== draftSearch` — covers the debounce window (300ms) and resolves on the same render cycle as the parent's filtered `issues` prop, avoiding any flash of stale content.
- **Input padding**: Adjusted `pr-4` → `pr-11` to prevent text overlap with the spinner.
- **TSDoc**: Updated component doc comment to describe the searching behavior.

## Security Notes

- No new data sources are introduced; purely presentational state.
- No untrusted markup is rendered. The spinner is a static SVG icon.
- No auth flows, network calls, permissions, or data handling logic were modified.

## Testing and Coverage

### Targeted suite
```
npx vitest run src/features/maintainers/components/issues/IssueListSidebar.test.tsx

 ✓ src/features/maintainers/components/issues/IssueListSidebar.test.tsx (7 tests) 820ms
```

### Test breakdown
| Test | What it covers |
|---|---|
| renders "No issues found" when sidebar has no issues and search/filter are at defaults | _(pre-existing, unchanged)_ |
| renders "No matches for search/filters" when sidebar has no issues but search is non-empty | _(pre-existing, unchanged)_ |
| debounces search input and only calls setSearchQuery after delay | _(pre-existing, unchanged)_ |
| clamps the filter count badge for large counts (100+ => "99+") | _(pre-existing, unchanged)_ |
| **shows spinner and sets aria-busy while search is pending** | Spinner visible + `aria-busy="true"` immediately after typing |
| **hides spinner and clears aria-busy after debounce settles** | Spinner gone + `aria-busy="false"` after advancing 350ms |
| **keeps spinner visible during rapid typing before debounce settles** | 3 rapid keystrokes keep spinner visible; clears after settle |

### Lint
```
npx eslint src/features/maintainers/components/issues/IssueListSidebar.tsx
→ 0 warnings, 0 errors

npx eslint src/features/maintainers/components/issues/IssueListSidebar.test.tsx
→ 2 warnings (pre-existing `@typescript-eslint/no-explicit-any` in mocks)
```

## Acceptance Criteria

- [x] `aria-busy` toggles `"true"` during search and `"false"` on settle.
- [x] Spinner visible while pending, hidden on settle.
- [x] State clears on debounce settle.
- [x] Tests cover pending state (immediate after typing) and settled state (after debounce).
- [x] Rapid-typing edge case covered.

## Screenshot
<img width="1543" height="545" alt="image" src="https://github.com/user-attachments/assets/238f8025-6350-42d2-a974-c0a3ae968331" />
