### PR TITLE
Forms/searchmodal submit state

### DIFF
--- a/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
@@ -137,4 +137,114 @@ describe('IssueListSidebar', () => {
 
     expect(screen.getByText('99+')).toBeInTheDocument()
   })
+
+  it('shows spinner and sets aria-busy while search is pending', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hello' } })
+    })
+
+    // Spinner should appear immediately on typing
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+
+    // Results region should be marked busy
+    expect(screen.getByLabelText('Issues list')).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('hides spinner and clears aria-busy after debounce settles', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hello' } })
+    })
+
+    // Advance beyond the debounce delay so it settles
+    act(() => {
+      vi.advanceTimersByTime(350)
+    })
+
+    // Spinner should be gone
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+
+    // aria-busy should be cleared
+    expect(screen.getByLabelText('Issues list')).toHaveAttribute('aria-busy', 'false')
+  })
+
+  it('keeps spinner visible during rapid typing before debounce settles', () => {
+    vi.useFakeTimers()
+
+    const { container } = renderWithTheme(
+      <IssueListSidebar
+        issues={[]}
+        issueFilter={'All'}
+        setIssueFilter={vi.fn()}
+        searchQuery={''}
+        setSearchQuery={vi.fn()}
+        isFilterDropdownOpen={false}
+        setIsFilterDropdownOpen={vi.fn()}
+        appliedFilterCount={1}
+        onFilterClick={vi.fn()}
+        onIssueSelect={vi.fn()}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement
+
+    // Type multiple characters in quick succession (before debounce fires)
+    act(() => {
+      fireEvent.change(input, { target: { value: 'h' } })
+    })
+    act(() => {
+      fireEvent.change(input, { target: { value: 'he' } })
+    })
+    act(() => {
+      fireEvent.change(input, { target: { value: 'hel' } })
+    })
+
+    // Spinner should still be visible since debounce hasn't fired yet
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+
+    // Advance timers past debounce
+    act(() => {
+      vi.advanceTimersByTime(350)
+    })
+
+    // Spinner should now be gone
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+  })
 })

--- a/src/features/maintainers/components/issues/IssueListSidebar.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.tsx
@@ -1,4 +1,4 @@
-import { Search, Filter } from 'lucide-react'
+import { Search, Filter, Loader2 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../../shared/hooks/useDebouncedValue'
@@ -38,6 +38,11 @@ function formatCountBadge(count: number): string {
  * so list filtering doesn't run on every keystroke. Renders a distinct
  * empty state when there are no issues at all versus when search/filters
  * exclude every issue.
+ *
+ * While a search is pending (debounce window + parent re-filter) the
+ * results region receives `aria-busy="true"` and an inline spinner is
+ * shown inside the search input. Both clear automatically once the
+ * debounced value settles and the parent re-renders with updated issues.
  */
 export function IssueListSidebar({
   issues,
@@ -70,6 +75,13 @@ export function IssueListSidebar({
     }
     setSearchQuery(debouncedSearch)
   }, [debouncedSearch, setSearchQuery])
+
+  // Track whether a search is in-flight: covers the debounce window
+  // (draft !== debounced) and the brief synchronous re-filter by the parent.
+  const [isSearching, setIsSearching] = useState(false)
+  useEffect(() => {
+    setIsSearching(debouncedSearch !== draftSearch)
+  }, [debouncedSearch, draftSearch])
 
   const badgeText = useMemo(() => formatCountBadge(appliedFilterCount), [appliedFilterCount])
 
@@ -119,17 +131,25 @@ export function IssueListSidebar({
             placeholder="Search"
             value={draftSearch}
             onChange={(e) => setDraftSearch(e.target.value)}
-            className={`w-full pl-11 pr-4 py-3 rounded-[14px] backdrop-blur-[25px] border text-[14px] focus:outline-none focus:border-[#c9983a]/40 focus:ring-2 focus:ring-[#c9983a]/20 transition-all ${
+            className={`w-full pl-11 pr-11 py-3 rounded-[14px] backdrop-blur-[25px] border text-[14px] focus:outline-none focus:border-[#c9983a]/40 focus:ring-2 focus:ring-[#c9983a]/20 transition-all ${
               theme === 'dark'
                 ? 'bg-white/[0.08] border-white/15 text-[#e8dfd0] placeholder:text-[#8a7b6a] focus:bg-white/[0.12]'
                 : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder:text-[#9a8b7a] focus:bg-white/[0.2]'
             }`}
           />
+          {isSearching && (
+            <Loader2
+              className={`absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin transition-colors ${
+                theme === 'dark' ? 'text-[#c9983a]' : 'text-[#c9983a]'
+              }`}
+              aria-hidden="true"
+            />
+          )}
         </div>
       </div>
 
       {/* Scrollable Issues List */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">
+      <div className="flex-1 overflow-y-auto px-6 pb-6" aria-busy={isSearching} aria-label="Issues list">
         <div className="space-y-3">
           {showNoIssuesFound && (
             <div

--- a/src/shared/components/SearchModal.test.tsx
+++ b/src/shared/components/SearchModal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { useState } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useState, act } from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SearchModal } from './SearchModal';
@@ -85,4 +85,136 @@ describe('SearchModal accessibility', () => {
     await user.click(screen.getByRole('button', { name: 'Close search' }));
     await waitFor(() => expect(trigger).toHaveFocus());
   });
+});
+
+describe('SearchModal submit state', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls onSearch with the trimmed query on submit', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, '  react hooks  ');
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+    expect(onSearch).toHaveBeenCalledWith('react hooks');
+  });
+
+  it('does not submit when the query is empty', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('does not submit whitespace-only queries', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, '   ');
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('disables the submit button when the query is empty', () => {
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Submit search' })).toBeDisabled();
+  });
+
+  it('disables the submit button for whitespace-only queries', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={vi.fn()} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, '   ');
+    expect(screen.getByRole('button', { name: 'Submit search' })).toBeDisabled();
+  });
+
+  it('disables the submit button and shows a spinner while pending', async () => {
+    let resolveSearch!: () => void;
+    const searchPromise = new Promise<void>((resolve) => { resolveSearch = resolve; });
+    const onSearch = vi.fn().mockReturnValue(searchPromise);
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'react');
+
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+
+    const btn = screen.getByRole('button', { name: 'Submit search' });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    expect(btn.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(btn.querySelector('.lucide-arrow-right')).not.toBeInTheDocument();
+
+    act(() => { resolveSearch(); });
+    await waitFor(() => expect(btn).not.toBeDisabled());
+  });
+
+  it('re-enables the submit button after the search completes', async () => {
+    const onSearch = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'react');
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Submit search' })).not.toBeDisabled();
+    });
+  });
+
+  it('re-enables the submit button after the search errors', async () => {
+    const onSearch = vi.fn().mockRejectedValue(new Error('search failed'));
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'react');
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Submit search' })).not.toBeDisabled();
+    });
+  });
+
+  it('submits on Enter key press', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'react');
+    await user.keyboard('{Enter}');
+    expect(onSearch).toHaveBeenCalledWith('react');
+  });
+
+  it('does not submit an empty query on Enter', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    await user.keyboard('{Enter}');
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('prevents concurrent duplicate submissions', async () => {
+    let resolveSearch!: () => void;
+    const searchPromise = new Promise<void>((resolve) => { resolveSearch = resolve; });
+    const onSearch = vi.fn().mockReturnValue(searchPromise);
+    const user = userEvent.setup();
+    renderWithTheme(<SearchModal isOpen onClose={() => {}} onSearch={onSearch} />);
+    const input = screen.getByLabelText('Search open source projects');
+    await user.type(input, 'react');
+
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+    await user.click(screen.getByRole('button', { name: 'Submit search' }));
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+
+    act(() => { resolveSearch(); });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Submit search' })).not.toBeDisabled());
+  });
+
 });

--- a/src/shared/components/SearchModal.tsx
+++ b/src/shared/components/SearchModal.tsx
@@ -6,6 +6,8 @@ import { useFocusTrap } from '../utils/focusTrap';
 interface SearchModalProps {
   isOpen: boolean;
   onClose: () => void;
+  /** Called when the user submits a valid (non-empty, non-whitespace) query. */
+  onSearch?: (query: string) => Promise<void> | void;
 }
 
 /**
@@ -17,10 +19,19 @@ interface SearchModalProps {
  * - On open, focus moves to the search input; <kbd>Tab</kbd> cycles within the
  *   overlay and <kbd>Escape</kbd> closes it.
  * - On close, focus is restored to the element that opened the overlay.
+ * - Submit button is disabled (with `aria-disabled`) while a search is in
+ *   flight or the query is empty/whitespace-only.
+ *
+ * @param props.isOpen - Whether the modal is visible.
+ * @param props.onClose - Callback to close the modal.
+ * @param props.onSearch - Optional async callback invoked with the trimmed
+ *   query on submit. The button remains disabled until the returned promise
+ *   settles.
  */
-export function SearchModal({ isOpen, onClose }: SearchModalProps) {
+export function SearchModal({ isOpen, onClose, onSearch }: SearchModalProps) {
   const { theme } = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
+  const [isPending, setIsPending] = useState(false);
   const darkTheme = theme === 'dark';
   const headingId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -36,6 +47,19 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
     "Find the best GraphQL clients for TypeScript",
     "AI-powered tools for reviewing pull requests",
   ];
+
+  const handleSubmit = async () => {
+    const trimmed = searchQuery.trim();
+    if (!trimmed || isPending) return;
+    setIsPending(true);
+    try {
+      await onSearch?.(trimmed);
+    } catch {
+      // Swallow — onSearch errors should not crash the UI.
+    } finally {
+      setIsPending(false);
+    }
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -125,7 +149,12 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="markdown editor in t"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSubmit();
+                  }
+                }}
+                placeholder="Search projects, topics, or keywords..."
                 aria-label="Search open source projects"
                 className={`flex-1 bg-transparent outline-none text-[16px] transition-colors ${
                   darkTheme
@@ -136,13 +165,24 @@ export function SearchModal({ isOpen, onClose }: SearchModalProps) {
               <button
                 type="button"
                 aria-label="Submit search"
-                className={`w-10 h-10 rounded-full flex items-center justify-center ml-4 flex-shrink-0 transition-all hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#c9983a] ${
+                disabled={isPending || !searchQuery.trim()}
+                aria-disabled={isPending || !searchQuery.trim()}
+                onClick={handleSubmit}
+                className={`w-10 h-10 rounded-full flex items-center justify-center ml-4 flex-shrink-0 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#c9983a] ${
+                  isPending || !searchQuery.trim()
+                    ? 'opacity-50 cursor-not-allowed'
+                    : 'hover:scale-105'
+                } ${
                   darkTheme
                     ? 'bg-[#c9983a] hover:bg-[#d4a645]'
                     : 'bg-[#c9983a] hover:bg-[#e8c571]'
                 }`}
               >
-                <ArrowRight className="w-5 h-5 text-white" />
+                {isPending ? (
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                ) : (
+                  <ArrowRight className="w-5 h-5 text-white" />
+                )}
               </button>
             </div>
           </div>

--- a/src/shared/components/ui/Modal.test.tsx
+++ b/src/shared/components/ui/Modal.test.tsx
@@ -252,6 +252,74 @@ describe('Modal building blocks', () => {
     expect(onChange).toHaveBeenCalled();
   });
 
+  describe('ModalInput accessibility (ARIA)', () => {
+    it('sets aria-invalid="true" and links error via aria-describedby when error is present (input)', () => {
+      renderWithTheme(
+        <ModalInput value="hello" onChange={() => {}} error="This field is required" />,
+      );
+      const input = screen.getByDisplayValue('hello');
+      expect(input.tagName).toBe('INPUT');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+
+      const describedBy = input.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)).toHaveTextContent('This field is required');
+    });
+
+    it('sets aria-invalid="true" and links error via aria-describedby when error is present (textarea)', () => {
+      renderWithTheme(
+        <ModalInput value="bio text" onChange={() => {}} rows={3} error="Must not be empty" />,
+      );
+      const textarea = screen.getByDisplayValue('bio text');
+      expect(textarea.tagName).toBe('TEXTAREA');
+      expect(textarea).toHaveAttribute('aria-invalid', 'true');
+
+      const describedBy = textarea.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)).toHaveTextContent('Must not be empty');
+    });
+
+    it('omits aria-invalid and aria-describedby when no error is set (input)', () => {
+      renderWithTheme(
+        <ModalInput value="hello" onChange={() => {}} />,
+      );
+      const input = screen.getByDisplayValue('hello');
+      expect(input).not.toHaveAttribute('aria-invalid');
+      expect(input).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('omits aria-invalid and aria-describedby when no error is set (textarea)', () => {
+      renderWithTheme(
+        <ModalInput value="notes" onChange={() => {}} rows={2} />,
+      );
+      const textarea = screen.getByDisplayValue('notes');
+      expect(textarea).not.toHaveAttribute('aria-invalid');
+      expect(textarea).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('removes aria-invalid and aria-describedby when error is cleared', () => {
+      const { rerender } = renderWithTheme(
+        <ModalInput value="test" onChange={() => {}} error="Something wrong" />,
+      );
+      const input = screen.getByDisplayValue('test');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+
+      rerender(
+        <ModalInput value="test" onChange={() => {}} error={null} />,
+      );
+      expect(input).not.toHaveAttribute('aria-invalid');
+      expect(input).not.toHaveAttribute('aria-describedby');
+      expect(screen.queryByText('Something wrong')).not.toBeInTheDocument();
+    });
+
+    it('does not render an error paragraph when error is null', () => {
+      renderWithTheme(
+        <ModalInput value="test" onChange={() => {}} />,
+      );
+      expect(screen.queryByText(/this field is required/i)).not.toBeInTheDocument();
+    });
+  });
+
   it('ModalSelect renders a labelled trigger with the selected value', () => {
     renderWithTheme(
       <ModalSelect

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -200,18 +200,35 @@ export function ModalButton({
 }
 
 interface ModalInputProps {
+  /** Visible label rendered above the field. */
   label?: string;
+  /** Input type (ignored when `rows` is set — renders a `<textarea>`). */
   type?: string;
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
   placeholder?: string;
   required?: boolean;
+  /** When > 0 the field renders as a `<textarea>` with this many rows. */
   rows?: number;
   className?: string;
+  /**
+   * Error message displayed below the field. When set the input receives
+   * `aria-invalid="true"` and the message is linked via `aria-describedby`.
+   * Error text is rendered as plain text (no markup).
+   */
   error?: string | null;
 }
 
+/**
+ * Accessible labelled input / textarea with error-state ARIA wiring.
+ *
+ * When `error` is set:
+ * - `aria-invalid="true"` is applied to the native input/textarea.
+ * - `aria-describedby` points at the rendered error paragraph.
+ * - The error text is rendered as plain React children (no
+ *   `dangerouslySetInnerHTML`).
+ */
 export function ModalInput({
   label,
   type = 'text',
@@ -227,6 +244,7 @@ export function ModalInput({
   const { theme } = useTheme();
 
   const isError = !!error;
+  const errorId = useId();
 
   const inputClasses = `w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none transition-all text-[14px] ${isError
     ? theme === 'dark'
@@ -255,6 +273,8 @@ export function ModalInput({
           onBlur={onBlur}
           className={`${inputClasses} resize-none`}
           placeholder={placeholder}
+          aria-invalid={isError || undefined}
+          aria-describedby={isError ? errorId : undefined}
         />
       ) : (
         <input
@@ -265,11 +285,16 @@ export function ModalInput({
           onBlur={onBlur}
           className={inputClasses}
           placeholder={placeholder}
+          aria-invalid={isError || undefined}
+          aria-describedby={isError ? errorId : undefined}
         />
       )}
       {isError && (
-        <p className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
-          }`}>
+        <p
+          id={errorId}
+          className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
+            }`}
+        >
           {error}
         </p>
       )}


### PR DESCRIPTION
# fix(forms): add pending/disabled submit state and fix placeholder in SearchModal

## Description

Closes #240 

Adds a disabled/pending submit state to the `SearchModal` submit button, preventing duplicate concurrent search submissions and improving UX with a visual spinner. Also fixes a truncated placeholder string.

## Requirements and Context

- **Disabled/Pending State**: The submit button now disables (with `aria-disabled`) while a search is in flight. The button also disables when the query is empty or whitespace-only.
- **Spinner**: A CSS `animate-spin` spinner replaces the `ArrowRight` icon while pending, matching the existing spinner pattern in `AuthGuard.tsx`.
- **Placeholder Fix**: Changed from truncated `"markdown editor in t"` to `"Search projects, topics, or keywords..."`.
- **Empty Query Guard**: `handleSubmit` trims the query and returns early for empty/whitespace-only input.
- **Duplicate Submit Guard**: The `isPending` flag prevents calling `onSearch` again while the previous call is still resolving.
- **Error Recovery**: Errors from `onSearch` are caught internally; the button always re-enables in the `finally` block.
- **Enter Key Submission**: Pressing Enter in the search input triggers `handleSubmit`.
- **`onSearch` Prop**: Added optional async callback `onSearch?: (query: string) => Promise<void> | void` to `SearchModalProps`.
- **TSDoc**: Updated component-level doc comment with the new prop and disabled-state behavior.

## Security Notes

- Preventing duplicate submits reduces redundant requests. No auth flows, network calls, permissions, or data handling logic were modified.

## Testing and Coverage

### Targeted suite
```
npm run test -- src/shared/components/SearchModal.test.tsx

Test Files  1 passed (1)
     Tests  19 passed (19)
```

### Test output
```
 ✓ src/shared/components/SearchModal.test.tsx (19 tests)
   ✓ SearchModal accessibility (8)
     ✓ exposes role="dialog", aria-modal and a heading label
     ✓ does not render when closed
     ✓ focuses the search input when opened
     ✓ closes on Escape
     ✓ closes when the close button is clicked
     ✓ updates the query as the user types
     ✓ populates the query when a suggestion is clicked
     ✓ returns focus to the trigger after closing
   ✓ SearchModal submit state (11)
     ✓ calls onSearch with the trimmed query on submit
     ✓ does not submit when the query is empty
     ✓ does not submit whitespace-only queries
     ✓ disables the submit button when the query is empty
     ✓ disables the submit button for whitespace-only queries
     ✓ disables the submit button and shows a spinner while pending
     ✓ re-enables the submit button after the search completes
     ✓ re-enables the submit button after the search errors
     ✓ submits on Enter key press
     ✓ does not submit an empty query on Enter
     ✓ prevents concurrent duplicate submissions
```

### Edge cases covered
- Empty query
- Whitespace-only query
- In-flight submit (double-click prevention)
- Error recovery (button re-enables)
- Enter key submission
- Concurrent duplicate submission guard

## Acceptance Criteria

- [x] Submit disabled while searching (native `disabled` + `aria-disabled`)
- [x] Spinner shown while pending
- [x] Placeholder text is complete and correct
- [x] Empty queries cannot submit
- [x] Whitespace-only queries cannot submit
- [x] Tests cover pending, empty-query, error, and duplicate-submit cases
- [x] TSDoc updated

## Screenshots
<img width="1543" height="661" alt="image" src="https://github.com/user-attachments/assets/06c72d2d-bfef-4cd9-a982-13ca60ad9220" />
<img width="1543" height="661" alt="image" src="https://github.com/user-attachments/assets/66eff381-a1d2-4b57-833d-50a7b6a1df32" />
