### PR TITLE
Report ErrorBoundary crashes through the logger error sink instead of swallowing them

### DIFF
--- a/src/shared/components/ErrorBoundary.test.tsx
+++ b/src/shared/components/ErrorBoundary.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+import * as loggerModule from '../utils/logger';
+
+// Suppress React's own console.error output for expected throws during tests
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A component that unconditionally throws on render. */
+function ThrowingChild({ message = 'test render error' }: { message?: string }) {
+  throw new Error(message);
+}
+
+/** A component that renders normally. */
+function SafeChild() {
+  return <p>Safe content</p>;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <SafeChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Safe content')).toBeInTheDocument();
+  });
+
+  it('renders the fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('calls logger.error with message and componentStack when a child throws', () => {
+    const loggerErrorSpy = vi.spyOn(loggerModule.logger, 'error');
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild message="boom" />
+      </ErrorBoundary>
+    );
+
+    expect(loggerErrorSpy).toHaveBeenCalledOnce();
+    expect(loggerErrorSpy).toHaveBeenCalledWith('ErrorBoundary caught', {
+      message: 'boom',
+      componentStack: expect.any(String),
+    });
+  });
+
+  it('does not log the full error object to prevent PII leakage', () => {
+    const loggerErrorSpy = vi.spyOn(loggerModule.logger, 'error');
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild message="sensitive detail" />
+      </ErrorBoundary>
+    );
+
+    const [, payload] = loggerErrorSpy.mock.calls[0];
+    // Only message and componentStack should be present — no full Error instance
+    expect(payload).not.toHaveProperty('stack');
+    expect(payload).toHaveProperty('message');
+    expect(payload).toHaveProperty('componentStack');
+  });
+
+  it('shows a Reload Page button in the fallback UI', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('button', { name: 'Reload Page' })).toBeInTheDocument();
+  });
+
+  it('shows a Go to Home button in the fallback UI', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('button', { name: 'Go to Home' })).toBeInTheDocument();
+  });
+
+  it('clicking Reload Page triggers window.location.reload', () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Page' }));
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
-import { Component, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 import { useTheme } from '../contexts/ThemeContext';
+import { logger } from '../utils/logger';
 
 interface Props {
   children: ReactNode;
@@ -20,9 +21,22 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: any) {
-    // eslint-disable-next-line no-console
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  /**
+   * Lifecycle method called after a descendant throws during rendering.
+   *
+   * @remarks
+   * Only the error message and component stack are forwarded to the logger so
+   * that no full Error object, serialised props, or other PII reaches the
+   * error sink.
+   *
+   * @param error - The thrown error value.
+   * @param errorInfo - React-supplied metadata containing the component stack.
+   */
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    logger.error('ErrorBoundary caught', {
+      message: error.message,
+      componentStack: errorInfo.componentStack,
+    });
   }
 
   handleReset = () => {


### PR DESCRIPTION
Fixes #280

## Summary
Basic implementation of: Report ErrorBoundary crashes through the logger error sink instead of swallowing them

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.