### PR TITLE
Handle 429 rate-limit responses with Retry-After awareness in apiRequest

### DIFF
--- a/src/shared/api/client.test.ts
+++ b/src/shared/api/client.test.ts
@@ -14,6 +14,9 @@ import {
   getAuthToken,
   setAuthToken,
   removeAuthToken,
+  RateLimitError,
+  parseRetryAfter,
+  DEFAULT_RETRY_AFTER_SECONDS,
 } from './client';
 import { API_BASE_URL } from '../config/api';
 
@@ -336,6 +339,107 @@ describe('apiRequest - Core Request Helper', () => {
       });
 
       await expect(apiRequest('/test')).rejects.toThrow('Bad request error');
+    });
+
+    it('should throw RateLimitError for 429 with numeric Retry-After header', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (name: string) => (name === 'Retry-After' ? '30' : null) },
+        json: async () => ({ message: 'Too Many Requests' }),
+      });
+
+      const error = await apiRequest('/test').catch(e => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retryAfterSeconds).toBe(30);
+      expect(error.message).toContain('30');
+    });
+
+    it('should throw RateLimitError for 429 with HTTP-date Retry-After header', async () => {
+      const futureDate = new Date(Date.now() + 45_000).toUTCString();
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (name: string) => (name === 'Retry-After' ? futureDate : null) },
+        json: async () => ({}),
+      });
+
+      const error = await apiRequest('/test').catch(e => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      // Allow ±2s rounding tolerance
+      expect((error as RateLimitError).retryAfterSeconds).toBeGreaterThanOrEqual(43);
+      expect((error as RateLimitError).retryAfterSeconds).toBeLessThanOrEqual(47);
+    });
+
+    it('should throw RateLimitError with default delay when Retry-After header is absent', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: () => null },
+        json: async () => ({}),
+      });
+
+      const error = await apiRequest('/test').catch(e => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retryAfterSeconds).toBe(DEFAULT_RETRY_AFTER_SECONDS);
+    });
+
+    it('RateLimitError should have name "RateLimitError"', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: () => null },
+        json: async () => ({}),
+      });
+
+      const error = await apiRequest('/test').catch(e => e);
+      expect(error.name).toBe('RateLimitError');
+    });
+  });
+
+  describe('parseRetryAfter', () => {
+    it('should return default delay for null header', () => {
+      expect(parseRetryAfter(null)).toBe(DEFAULT_RETRY_AFTER_SECONDS);
+    });
+
+    it('should return default delay for empty string header', () => {
+      expect(parseRetryAfter('')).toBe(DEFAULT_RETRY_AFTER_SECONDS);
+    });
+
+    it('should parse a valid numeric delay-seconds header', () => {
+      expect(parseRetryAfter('30')).toBe(30);
+    });
+
+    it('should parse zero as a valid delay', () => {
+      expect(parseRetryAfter('0')).toBe(0);
+    });
+
+    it('should floor fractional numeric values', () => {
+      expect(parseRetryAfter('30.9')).toBe(30);
+    });
+
+    it('should return default delay for negative numeric value', () => {
+      expect(parseRetryAfter('-10')).toBe(DEFAULT_RETRY_AFTER_SECONDS);
+    });
+
+    it('should return default delay for non-finite numeric value (Infinity)', () => {
+      expect(parseRetryAfter('Infinity')).toBe(DEFAULT_RETRY_AFTER_SECONDS);
+    });
+
+    it('should parse a future HTTP-date header and return positive seconds', () => {
+      const futureDate = new Date(Date.now() + 60_000).toUTCString();
+      const result = parseRetryAfter(futureDate);
+      expect(result).toBeGreaterThanOrEqual(58);
+      expect(result).toBeLessThanOrEqual(62);
+    });
+
+    it('should return 0 for a past HTTP-date header', () => {
+      const pastDate = new Date(Date.now() - 60_000).toUTCString();
+      expect(parseRetryAfter(pastDate)).toBe(0);
+    });
+
+    it('should return default delay for an unparseable string', () => {
+      expect(parseRetryAfter('invalid-value')).toBe(DEFAULT_RETRY_AFTER_SECONDS);
     });
   });
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -38,12 +38,90 @@ export interface ApiRequestOptions extends RequestInit {
 }
 
 /**
+ * Default retry delay in seconds when the `Retry-After` header is absent on a
+ * 429 response. Chosen to be safe for public polling endpoints.
+ */
+export const DEFAULT_RETRY_AFTER_SECONDS = 60
+
+/**
+ * Parses the `Retry-After` response header into a number of seconds.
+ *
+ * Supports both formats defined by RFC 9110:
+ * - **Delay-seconds** – a non-negative integer, e.g. `"30"`
+ * - **HTTP-date** – an absolute date/time, e.g. `"Wed, 21 Oct 2025 07:28:00 GMT"`
+ *
+ * The returned value is clamped to a finite non-negative number so that
+ * attacker-controlled header values cannot pass an unexpected delay to
+ * `setTimeout` or similar callers.
+ *
+ * @param headerValue - Raw value of the `Retry-After` header, or `null` if absent.
+ * @returns Retry delay in seconds; falls back to {@link DEFAULT_RETRY_AFTER_SECONDS} when
+ *   the header is absent, unparseable, negative, or non-finite.
+ */
+export function parseRetryAfter(headerValue: string | null): number {
+  if (headerValue === null || headerValue.trim() === '') {
+    return DEFAULT_RETRY_AFTER_SECONDS
+  }
+
+  const trimmed = headerValue.trim()
+
+  // Try numeric (delay-seconds) format first
+  const numeric = Number(trimmed)
+  if (!isNaN(numeric) && isFinite(numeric) && numeric >= 0) {
+    return Math.floor(numeric)
+  }
+
+  // Try HTTP-date format
+  const parsed = Date.parse(trimmed)
+  if (!isNaN(parsed)) {
+    const delaySecs = Math.floor((parsed - Date.now()) / 1000)
+    return delaySecs > 0 ? delaySecs : 0
+  }
+
+  return DEFAULT_RETRY_AFTER_SECONDS
+}
+
+/**
+ * Error thrown when the API responds with HTTP 429 Too Many Requests.
+ *
+ * Callers can inspect `retryAfterSeconds` to implement back-off logic without
+ * hammering the API further.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await getLeaderboard();
+ * } catch (err) {
+ *   if (err instanceof RateLimitError) {
+ *     console.warn(`Rate limited. Retry after ${err.retryAfterSeconds}s`);
+ *   }
+ * }
+ * ```
+ */
+export class RateLimitError extends Error {
+  /** Number of seconds the caller should wait before retrying. */
+  readonly retryAfterSeconds: number
+
+  constructor(retryAfterSeconds: number) {
+    super(
+      `Rate limit exceeded. Please retry after ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`
+    )
+    this.name = 'RateLimitError'
+    this.retryAfterSeconds = retryAfterSeconds
+  }
+}
+
+/**
  * Core API request helper that handles authentication, headers, and error handling
  * @template T - The expected response type
  * @param {string} endpoint - API endpoint path (will be prefixed with API_BASE_URL)
  * @param {ApiRequestOptions} options - Request options including auth requirements
  * @returns {Promise<T>} Parsed JSON response
- * @throws {Error} On network failures, authentication errors, or non-2xx responses
+ * @throws {RateLimitError} When the server responds with 429 Too Many Requests.
+ *   The error exposes `retryAfterSeconds` parsed from the `Retry-After` header
+ *   (numeric or HTTP-date), falling back to {@link DEFAULT_RETRY_AFTER_SECONDS}.
+ *   `apiRequest` does **not** auto-retry; callers are responsible for back-off.
+ * @throws {Error} On network failures, authentication errors, or other non-2xx responses
  * @internal This function is exported for testing purposes
  */
 export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions = {}): Promise<T> {
@@ -115,6 +193,11 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
       throw new Error(
         `Permission denied: ${errorMsg}. You may need admin privileges to perform this action.`
       )
+    }
+
+    if (response.status === 429) {
+      const retryAfterSeconds = parseRetryAfter(response.headers.get('Retry-After'))
+      throw new RateLimitError(retryAfterSeconds)
     }
 
     // Try to parse error response


### PR DESCRIPTION
Fixes #275

## Summary
Basic implementation of: Handle 429 rate-limit responses with Retry-After awareness in apiRequest

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.