### PR TITLE
Add a centralized 401 redirect-to-signin handler instead of only clearing the token in apiRequest

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -27,6 +27,20 @@ export const removeAuthToken = (): void => {
   }
 }
 
+/**
+ * Emits a `patchwork-auth-401` CustomEvent so that the app layer (e.g.
+ * AuthContext) can redirect the user to sign-in while preserving the current
+ * location as `returnTo`. Kept separate from `removeAuthToken` so that
+ * `client.ts` remains free of any router imports.
+ *
+ * @internal Only called by `apiRequest` and `downloadInvoice` on HTTP 401.
+ */
+export const emit401Event = (): void => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('patchwork-auth-401'))
+  }
+}
+
 // API request helper
 /**
  * Options for API requests extending standard RequestInit
@@ -99,8 +113,9 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
   // Handle errors
   if (!response.ok) {
     if (response.status === 401) {
-      // Token expired or invalid - clear it
+      // Token expired or invalid - clear it and signal the app layer to redirect.
       removeAuthToken()
+      emit401Event()
       throw new Error('Authentication failed. Please sign in again.')
     }
 
@@ -1239,6 +1254,7 @@ export async function downloadInvoice(invoiceId: string): Promise<Blob> {
   if (!response.ok) {
     if (response.status === 401) {
       removeAuthToken()
+      emit401Event()
       throw new Error('Authentication failed. Please sign in again.')
     }
     throw new Error(`Failed to download invoice (${response.status}).`)

--- a/src/shared/contexts/AuthContext.test.tsx
+++ b/src/shared/contexts/AuthContext.test.tsx
@@ -317,3 +317,145 @@ describe('AuthProvider + useAuth', () => {
     );
   });
 });
+
+describe('AuthProvider - 401 redirect handler', () => {
+  let originalHref: string;
+  let hrefSetter: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.useFakeTimers();
+
+    // Capture window.location.href assignments without actually navigating.
+    originalHref = window.location.href;
+    hrefSetter = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: {
+        ...window.location,
+        pathname: '/dashboard',
+        search: '',
+        href: originalHref,
+      },
+    });
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => originalHref,
+    });
+
+    mockGetAuthToken.mockImplementation(() => localStorage.getItem('patchwork_jwt'));
+    mockRemoveAuthToken.mockImplementation(() => {
+      localStorage.removeItem('patchwork_jwt');
+      window.dispatchEvent(
+        new CustomEvent('patchwork-auth-token', { detail: { token: null } }),
+      );
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('redirects to /signin with returnTo when patchwork-auth-401 fires on a protected route', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+    });
+
+    expect(hrefSetter).toHaveBeenCalledWith(
+      expect.stringContaining('/signin?returnTo='),
+    );
+    // The returnTo value must encode the protected pathname.
+    const calledHref: string = hrefSetter.mock.calls[0][0];
+    expect(decodeURIComponent(calledHref)).toContain('/dashboard');
+  });
+
+  it('does not redirect when 401 fires while on a public route', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...window.location, pathname: '/signin', search: '' },
+    });
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => originalHref,
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+    });
+
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when 401 fires on root public route (/)', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...window.location, pathname: '/', search: '' },
+    });
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => originalHref,
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+    });
+
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect on concurrent 401 events (loop prevention)', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+    });
+
+    // Only the first 401 should trigger a redirect.
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes query string in returnTo', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...window.location, pathname: '/projects', search: '?tab=open' },
+    });
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => originalHref,
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('patchwork-auth-401'));
+    });
+
+    const calledHref: string = hrefSetter.mock.calls[0][0];
+    const decoded = decodeURIComponent(calledHref);
+    expect(decoded).toContain('/projects');
+    expect(decoded).toContain('?tab=open');
+  });
+});

--- a/src/shared/contexts/AuthContext.tsx
+++ b/src/shared/contexts/AuthContext.tsx
@@ -1,6 +1,13 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react';
 import { getCurrentUser, getAuthToken, setAuthToken, removeAuthToken } from '../api/client';
 import { logger } from '../utils/logger';
+
+/**
+ * Public routes that should never trigger a redirect-to-signin on 401.
+ * Matches exact pathnames to prevent false positives (e.g. `/signup-confirm`
+ * should not be listed here even though it starts with `/signup`).
+ */
+const PUBLIC_ROUTES = new Set(['/', '/signin', '/signup', '/auth/callback']);
 
 export type UserRole = 'contributor' | 'maintainer' | 'admin' | null;
 
@@ -35,6 +42,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [userId, setUserId] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  /**
+   * Guards against concurrent 401 events triggering multiple simultaneous
+   * navigations. The ref is reset after the redirect completes.
+   */
+  const isRedirectingRef = useRef(false);
 
   const checkAuth = async () => {
     const token = getAuthToken();
@@ -107,6 +119,57 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       window.removeEventListener('patchwork-auth-token', onTokenEvent);
       window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  /**
+   * Centralized 401 redirect handler.
+   *
+   * Listens for the `patchwork-auth-401` CustomEvent emitted by `client.ts`
+   * whenever an API response returns HTTP 401. On receipt it:
+   *   1. Skips redirect when the user is already on a public route.
+   *   2. Prevents redirect loops by tracking in-flight redirects via a ref.
+   *   3. Navigates to `/signin?returnTo=<current-relative-path>`, where
+   *      `returnTo` is validated to be a same-origin relative path so that
+   *      open-redirect attacks are not possible.
+   *
+   * The handler is deliberately kept separate from the token-event listener so
+   * that the redirect is only triggered by genuine 401 API responses, not by
+   * programmatic token removal (e.g. logout).
+   */
+  useEffect(() => {
+    const on401 = () => {
+      const pathname = window.location.pathname;
+
+      // Do not redirect from public routes.
+      if (PUBLIC_ROUTES.has(pathname)) {
+        logger.debug('AuthContext - 401 on public route, skipping redirect:', pathname);
+        return;
+      }
+
+      // Prevent redirect loops when multiple concurrent 401s fire.
+      if (isRedirectingRef.current) {
+        logger.debug('AuthContext - 401 redirect already in progress, skipping duplicate');
+        return;
+      }
+
+      isRedirectingRef.current = true;
+      logger.info('AuthContext - 401 detected on protected route, redirecting to signin', { pathname });
+
+      // Build a safe same-origin returnTo value (pathname + search only).
+      const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.href = `/signin?returnTo=${returnTo}`;
+
+      // Reset guard after a short delay so a hard navigation on the same page
+      // does not permanently block future redirects (SSR / test environments).
+      setTimeout(() => {
+        isRedirectingRef.current = false;
+      }, 5000);
+    };
+
+    window.addEventListener('patchwork-auth-401', on401);
+    return () => {
+      window.removeEventListener('patchwork-auth-401', on401);
     };
   }, []);
 


### PR DESCRIPTION
Fixes #277

## Summary
- Emit a dedicated `patchwork-auth-401` CustomEvent from `client.ts` on HTTP 401 so the transport layer stays free of router imports
- Add a centralized 401 listener in `AuthContext` that redirects to `/signin?returnTo=<path>` using a safe same-origin relative path
- Skip redirect when the user is already on a public route (`/`, `/signin`, `/signup`, `/auth/callback`)
- Use a ref-based guard to prevent redirect loops from concurrent 401 responses

## Changes
- `src/shared/api/client.ts`: Add `emit401Event()` helper and call it in both `apiRequest` and `downloadInvoice` after clearing the token on 401
- `src/shared/contexts/AuthContext.tsx`: Add `PUBLIC_ROUTES` set, `isRedirectingRef` loop guard, and `patchwork-auth-401` event listener with redirect logic
- `src/shared/contexts/AuthContext.test.tsx`: Add test suite covering redirect on protected route, no-redirect on public routes (`/`, `/signin`), concurrent 401 loop prevention, and `returnTo` query-string preservation