### PR TITLE
fix(a11y): enlarge landing Navbar mobile toggle to 44px touch target

### DIFF
--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -144,11 +144,17 @@ export function Navbar() {
           </div>
 
           {/* Mobile Menu Button */}
+          {/*
+           * Mobile menu toggle — minimum 44×44 px touch target per WCAG 2.5.8.
+           * `min-h-[44px] min-w-[44px]` guarantees the hit area even when the
+           * icon is smaller; `flex items-center justify-center` keeps it centred.
+           */}
           <button
-            className="md:hidden p-2"
+            className="md:hidden min-h-[44px] min-w-[44px] p-2.5 flex items-center justify-center rounded-[10px] transition-colors hover:bg-white/[0.1]"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={mobileMenuOpen}
+            aria-controls="mobile-menu"
           >
             {mobileMenuOpen ? (
               <X className="w-6 h-6" />
@@ -160,7 +166,7 @@ export function Navbar() {
 
         {/* Mobile Menu */}
         {mobileMenuOpen && (
-          <div className="md:hidden mt-4 pb-4 space-y-4">
+          <div id="mobile-menu" className="md:hidden mt-4 pb-4 space-y-4">
             <a
               href="#features"
               className={`block transition-colors font-medium ${


### PR DESCRIPTION
Fixes #255

## What was done
- Replaced `p-2` (≈32px hit area) with `min-h-[44px] min-w-[44px] p-2.5 flex items-center justify-center` on the mobile menu `<button>` in `src/features/landing/components/Navbar.tsx`.
- The button now guarantees a 44×44 px touch target as required by WCAG 2.5.8 and Apple/Google HIG.
- Added `aria-controls="mobile-menu"` to the toggle button and `id="mobile-menu"` to the collapsible panel for proper ARIA wiring (`aria-label` and `aria-expanded` were already present).
- Added `rounded-[10px]` and `hover:bg-white/[0.1]` for a subtle visual hover state matching the design language.
- Added inline comment explaining the 44px requirement.
- No layout shift in the navbar — icon remains centred.