### PR TITLE
feat(i18n): sync document lang attribute with active locale

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import type { ReactElement } from 'react'
+import { useEffect, type ReactElement } from 'react'
 import { AuthProvider } from '../shared/contexts/AuthContext'
 import { ThemeProvider } from '../shared/contexts/ThemeContext'
 import { LandingPage } from '../features/landing'
@@ -30,7 +30,30 @@ import { RoleGuard } from '../shared/components/RoleGuard'
 import { AuthGuard } from '../shared/components/AuthGuard'
 import Toast from '../shared/components/Toast'
 import { I18nProvider } from '../shared/i18n'
+import { useTranslation } from '../shared/i18n/useTranslation'
 import { ScrollToTop } from '../shared/components/ScrollToTop'
+
+/**
+ * Synchronises `document.documentElement.lang` with the active i18n locale.
+ *
+ * Must be rendered inside {@link I18nProvider} (which supplies the `IntlProvider`
+ * context that `useTranslation` reads). Renders nothing itself; exists purely
+ * for its side-effect. Defaults to `"en"` on mount and updates whenever the
+ * locale changes.
+ *
+ * Keeping this as a separate component rather than an inline `useEffect` in
+ * `App` means it can be unit-tested in isolation and can be relocated under a
+ * future `LocaleProvider` without touching the route tree.
+ */
+function HtmlLangSync() {
+  const { locale } = useTranslation()
+
+  useEffect(() => {
+    document.documentElement.lang = locale
+  }, [locale])
+
+  return null
+}
 
 /**
  * Applies the three-state authentication boundary to protected routes.
@@ -100,6 +123,8 @@ export function AppRoutes() {
 export default function App() {
   return (
     <I18nProvider>
+      {/* Syncs <html lang="…"> with the active locale — must be inside I18nProvider */}
+      <HtmlLangSync />
       <BrowserRouter>
         <ThemeProvider>
           <AuthProvider>


### PR DESCRIPTION
Fixes #257

## What was done
- Added a `HtmlLangSync` component to `src/app/App.tsx` that reads `locale` from `useTranslation()` and writes it to `document.documentElement.lang` via `useEffect`.
- The component renders `null` (no DOM output) and runs only for its side-effect.
- It is placed as the first child of `<I18nProvider>`, which means it is guaranteed to be inside the react-intl context and updates synchronously on every locale change.
- `index.html` retains `lang="en"` as the static initial value (pre-hydration); the effect updates it immediately on mount and on any subsequent locale change.
- The locale value is constrained to the `Locale` union type (`'en'` today; future codes added to the catalog), so no arbitrary string can be written to the attribute.
- Added TSDoc comment documenting the component's purpose and placement requirement.
- Added `useTranslation` import; changed `ReactElement` import to include `useEffect`.