### PR TITLE
feat(i18n): add locale-aware useIntlFormatters hook and adopt in InvoicesTab

### DIFF
--- a/src/features/settings/components/billing/InvoicesTab.tsx
+++ b/src/features/settings/components/billing/InvoicesTab.tsx
@@ -4,6 +4,7 @@ import { Download, FileText, CheckCircle2, Clock, AlertCircle, Loader2 } from 'l
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { Invoice, InvoiceStatus } from '../../types'
 import { downloadInvoice } from '../../../../shared/api/client'
+import { useIntlFormatters } from '../../../../shared/i18n'
 
 interface InvoicesTabProps {
   invoices: Invoice[]
@@ -15,6 +16,7 @@ function sanitizeFilename(raw: string): string {
 
 export function InvoicesTab({ invoices }: InvoicesTabProps) {
   const { theme } = useTheme()
+  const { formatDate, formatCurrency } = useIntlFormatters()
   const [downloadingId, setDownloadingId] = useState<string | null>(null)
   const [downloadErrors, setDownloadErrors] = useState<Record<string, string>>({})
 
@@ -186,7 +188,7 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
                             theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
                           }`}
                         >
-                          {new Date(invoice.date).toLocaleDateString('en-US', {
+                          {formatDate(invoice.date, {
                             month: 'short',
                             day: 'numeric',
                             year: 'numeric',
@@ -201,8 +203,7 @@ export function InvoicesTab({ invoices }: InvoicesTabProps) {
                             theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
                           }`}
                         >
-                          {invoice.amount.toLocaleString('en-US', {
-                            style: 'currency',
+                          {formatCurrency(invoice.amount, {
                             currency: invoice.currency,
                           })}
                         </span>

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -11,6 +11,7 @@
 export { I18nProvider, type I18nProviderProps } from './I18nProvider'
 export { handleIntlError } from './errors'
 export { useTranslation, type TranslationValues, type UseTranslation } from './useTranslation'
+export { useIntlFormatters, type UseIntlFormatters, type FormatDateOptions, type FormatNumberOptions, type FormatCurrencyOptions } from './useIntlFormatters'
 export {
   en,
   catalogs,

--- a/src/shared/i18n/useIntlFormatters.ts
+++ b/src/shared/i18n/useIntlFormatters.ts
@@ -1,0 +1,101 @@
+import { useTranslation } from './useTranslation'
+
+/**
+ * Options accepted by {@link UseIntlFormatters.formatDate}.
+ * A subset of `Intl.DateTimeFormatOptions` for the most common use cases.
+ */
+export type FormatDateOptions = Intl.DateTimeFormatOptions
+
+/**
+ * Options accepted by {@link UseIntlFormatters.formatNumber}.
+ * A subset of `Intl.NumberFormatOptions`.
+ */
+export type FormatNumberOptions = Intl.NumberFormatOptions
+
+/**
+ * Options accepted by {@link UseIntlFormatters.formatCurrency}.
+ * The `currency` field is required; other options are optional.
+ */
+export interface FormatCurrencyOptions extends Omit<Intl.NumberFormatOptions, 'style' | 'currency'> {
+  /** ISO 4217 currency code, e.g. `"USD"`. */
+  currency: string
+}
+
+/**
+ * Return value of {@link useIntlFormatters}.
+ */
+export interface UseIntlFormatters {
+  /**
+   * Formats a date/time value using the active locale.
+   *
+   * @param value - Date instance, timestamp (ms), or ISO-8601 string.
+   * @param options - `Intl.DateTimeFormatOptions` (e.g. `{ month: 'short', day: 'numeric', year: 'numeric' }`).
+   * @returns Locale-aware date string.
+   *
+   * @example
+   * formatDate(new Date('2024-01-15'), { month: 'short', day: 'numeric', year: 'numeric' })
+   * // → "Jan 15, 2024" for en
+   */
+  formatDate: (value: Date | number | string, options?: FormatDateOptions) => string
+
+  /**
+   * Formats a plain number using the active locale.
+   *
+   * @param value - Numeric value to format.
+   * @param options - `Intl.NumberFormatOptions`.
+   * @returns Locale-aware number string.
+   *
+   * @example
+   * formatNumber(1234567.89)
+   * // → "1,234,567.89" for en
+   */
+  formatNumber: (value: number, options?: FormatNumberOptions) => string
+
+  /**
+   * Formats a monetary amount using the active locale and a required currency code.
+   *
+   * @param value - Amount to format.
+   * @param options - Must include `currency` (ISO 4217); other `Intl.NumberFormatOptions` are optional.
+   * @returns Locale-aware currency string.
+   *
+   * @example
+   * formatCurrency(49.99, { currency: 'USD' })
+   * // → "$49.99" for en
+   */
+  formatCurrency: (value: number, options: FormatCurrencyOptions) => string
+}
+
+/**
+ * Returns locale-aware date, number, and currency formatters bound to the
+ * active i18n locale exposed by {@link useTranslation}.
+ *
+ * Replaces ad-hoc `toLocaleDateString('en-US', …)` and
+ * `Intl.NumberFormat('en-US', …)` calls scattered across the app, ensuring
+ * that formatting automatically follows the active locale when additional
+ * locales are introduced.
+ *
+ * Must be called inside an {@link import('./I18nProvider').I18nProvider}.
+ *
+ * @example
+ * const { formatDate, formatCurrency } = useIntlFormatters();
+ * formatDate(invoice.date, { month: 'short', day: 'numeric', year: 'numeric' });
+ * formatCurrency(invoice.amount, { currency: invoice.currency });
+ */
+export function useIntlFormatters(): UseIntlFormatters {
+  const { locale } = useTranslation()
+
+  const formatDate = (value: Date | number | string, options?: FormatDateOptions): string => {
+    const date = value instanceof Date ? value : new Date(value)
+    return new Intl.DateTimeFormat(locale, options).format(date)
+  }
+
+  const formatNumber = (value: number, options?: FormatNumberOptions): string => {
+    return new Intl.NumberFormat(locale, options).format(value)
+  }
+
+  const formatCurrency = (value: number, { currency, ...rest }: FormatCurrencyOptions): string => {
+    return new Intl.NumberFormat(locale, { style: 'currency', currency, ...rest }).format(value)
+  }
+
+  return { formatDate, formatNumber, formatCurrency }
+}


### PR DESCRIPTION
Fixes #258

## What was done
- Created `src/shared/i18n/useIntlFormatters.ts` with a `useIntlFormatters()` hook exposing three locale-bound formatters:
  - `formatDate(value, options?)` — wraps `Intl.DateTimeFormat` using the active locale.
  - `formatNumber(value, options?)` — wraps `Intl.NumberFormat` using the active locale.
  - `formatCurrency(value, { currency, ...options })` — wraps `Intl.NumberFormat` with `style: 'currency'` using the active locale.
- The hook reads `locale` from `useTranslation()`, so it always reflects the active i18n locale and updates automatically when the locale changes.
- Exported the hook and its types from `src/shared/i18n/index.ts`.
- Migrated `src/features/settings/components/billing/InvoicesTab.tsx`:
  - Replaced `new Date(invoice.date).toLocaleDateString('en-US', …)` with `formatDate(invoice.date, …)`.
  - Replaced `invoice.amount.toLocaleString('en-US', { style: 'currency', … })` with `formatCurrency(invoice.amount, …)`.
- Output for the `'en'` locale is identical to the previous hardcoded `'en-US'` output, preserving current behaviour.
- Full TSDoc on the hook, types, and each formatter method.