### PR TITLE
i18n: extract SettingsPage tab labels into message catalog

### DIFF
--- a/src/features/settings/pages/SettingsPage.tsx
+++ b/src/features/settings/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { BillingTab } from '../components/billing/BillingTab';
 import { TermsTab } from '../components/terms/TermsTab';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { BillingProfilesProvider } from '../contexts/BillingProfilesContext';
+import { useTranslation } from '../../../shared/i18n';
 
 interface SettingsPageProps {
   initialTab?: SettingsTabType;
@@ -28,13 +29,14 @@ interface SettingsPageProps {
 export function SettingsPage({ initialTab = 'profile' }: SettingsPageProps) {
   const [activeTab, setActiveTab] = useState<SettingsTabType>(initialTab);
   const { theme } = useTheme();
+  const { t } = useTranslation();
 
   const tabs: { id: SettingsTabType; label: string }[] = [
-    { id: 'profile', label: 'Profile' },
-    { id: 'notifications', label: 'Notifications' },
-    { id: 'payout', label: 'Payout Preferences' },
-    { id: 'billing', label: 'Billing Profiles' },
-    { id: 'terms', label: 'Terms and Conditions' },
+    { id: 'profile', label: t('settings.tabs.profile') },
+    { id: 'notifications', label: t('settings.tabs.notifications') },
+    { id: 'payout', label: t('settings.tabs.payout') },
+    { id: 'billing', label: t('settings.tabs.billing') },
+    { id: 'terms', label: t('settings.tabs.terms') },
   ];
 
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -47,6 +47,13 @@ export const en = {
   'landingNav.signOut': 'Sign Out',
   'landingNav.getStarted': 'Get Started',
 
+  // ── Settings tabs — src/features/settings/pages/SettingsPage.tsx ──
+  'settings.tabs.profile': 'Profile',
+  'settings.tabs.notifications': 'Notifications',
+  'settings.tabs.payout': 'Payout Preferences',
+  'settings.tabs.billing': 'Billing Profiles',
+  'settings.tabs.terms': 'Terms and Conditions',
+
   // ── Dashboard sidebar — src/features/dashboard/DashboardLayout.tsx ──
   'dashboardNav.discover': 'Discover',
   'dashboardNav.browse': 'Browse',


### PR DESCRIPTION
Fixes #259

- Adds `settings.tabs.*` keys to `src/shared/i18n/messages.ts`
- Replaces hardcoded English strings in `SettingsPage.tsx` with `t()` calls via `useTranslation`
- Maintains existing tab order and ARIA behavior