### PR TITLE
Add an aria label to the dashboard layout

### DIFF
--- a/src/features/dashboard/DashboardLayout.test.tsx
+++ b/src/features/dashboard/DashboardLayout.test.tsx
@@ -84,3 +84,33 @@ describe('DashboardLayout i18n nav labels', () => {
     expect(screen.getByText('Data')).toBeInTheDocument()
   })
 })
+
+describe('DashboardLayout sidebar toggle accessibility', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.clearAllMocks()
+    window.innerWidth = 1024
+  })
+
+  it('labels the expanded sidebar toggle with its collapse action and expanded state', () => {
+    renderLayout()
+
+    const toggle = screen.getByRole('button', { name: 'Collapse sidebar' })
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAttribute('title', 'Collapse sidebar')
+    expect(toggle).toHaveClass('focus-visible:ring-2')
+    expect(toggle).toHaveClass('focus-visible:ring-[#c9983a]')
+  })
+
+  it('updates the sidebar toggle label, title, and expanded state after collapsing', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+
+    const toggle = screen.getByRole('button', { name: 'Expand sidebar' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('title', 'Expand sidebar')
+  })
+})

--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -168,6 +168,12 @@ export function DashboardLayout() {
   const darkTheme = theme === "dark";
   const isSmallDevice = deviceWidth && deviceWidth < 1024;
   const showMobileNav = mobileMenuOpen && isSmallDevice;
+  /**
+   * Accessible action text for the icon-only sidebar toggle.
+   * The label describes the action that will happen on activation, while
+   * aria-expanded below exposes the sidebar's current expanded state.
+   */
+  const sidebarToggleLabel = isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (
     <div
@@ -201,8 +207,12 @@ export function DashboardLayout() {
       >
         {/* Toggle Arrow Button */}
         <button
+          type="button"
           onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-          className={`absolute z-[100] backdrop-blur-[90px] rounded-full border-[0.5px] w-6 h-6 shadow-md hover:shadow-lg transition-all flex items-center justify-center ${
+          aria-label={sidebarToggleLabel}
+          aria-expanded={!isSidebarCollapsed}
+          title={sidebarToggleLabel}
+          className={`absolute z-[100] backdrop-blur-[90px] rounded-full border-[0.5px] w-6 h-6 shadow-md hover:shadow-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${
             isSidebarCollapsed ? "-right-3 top-[60px]" : "-right-3 top-[60px]"
           } ${
             darkTheme


### PR DESCRIPTION
Motivation
The sidebar collapse/expand control was icon-only with only a title, so screen readers could not announce its purpose or state.
This control is a primary layout action and must communicate both its action and current state to assistive technologies.
The change aims to improve keyboard focus visibility and keep the existing mouse tooltip behavior.
Description
Add a computed sidebarToggleLabel and a short TSDoc explaining the accessible action text in src/features/dashboard/DashboardLayout.tsx.
Add type="button", aria-label={sidebarToggleLabel}, aria-expanded={!isSidebarCollapsed}, and title={sidebarToggleLabel} to the sidebar toggle button.
Add visible keyboard focus styling via focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 on the toggle.
Add unit tests in src/features/dashboard/DashboardLayout.test.tsx that assert the toggle's aria-expanded, aria-label/title values and that the label updates after clicking (both expanded and collapsed states).
Testing
Ran the focused test file with npm run test -- src/features/dashboard/DashboardLayout.test.tsx and it passed (4 tests).
Ran npx eslint src/features/dashboard/DashboardLayout.tsx src/features/dashboard/DashboardLayout.test.tsx which passed, with pre-existing warnings in DashboardLayout.tsx (unused _pendingAdminTarget and an explicit any).
Running the entire test suite with npm run test produced unrelated existing failures (mock/export issues for recharts LabelList, missing I18nProvider in mocks, useAuth used outside a provider, and jsdom navigation limitations).
Running npm run typecheck revealed unrelated pre-existing RefObject<HTMLDivElement | null> nullability errors in other components and tests and did not fail due to the accessibility changes introduced here.
Closes https://github.com/Grainlify/Grainlify-Frontend/issues/246