### PR TITLE
feat(forms): bound tag input length with accessible counter in NewPro…

### DIFF
--- a/src/features/maintainers/components/NewProjectSetupModal.test.tsx
+++ b/src/features/maintainers/components/NewProjectSetupModal.test.tsx
@@ -505,4 +505,86 @@ describe('NewProjectSetupModal', () => {
       expect(payload.description).not.toBe('Tampered draft for A');
     });
   });
+
+  describe('tags length bound', () => {
+    it('bounds the tags input and renders an accessible live counter', async () => {
+      renderWithTheme(
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject({ tags: [] })}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(getTags()).toHaveValue(''));
+      const input = getTags();
+      expect(input).toHaveAttribute('maxlength', '120');
+
+      const counter = screen.getByText('0/120');
+      expect(counter).toHaveAttribute('aria-live', 'polite');
+      expect(input.getAttribute('aria-describedby')).toContain(counter.id);
+    });
+
+    it('updates the counter as the user types', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject({ tags: [] })}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(getTags()).toHaveValue(''));
+      await user.type(getTags(), 'DeFi');
+      expect(screen.getByText('4/120')).toBeInTheDocument();
+    });
+
+    it('surfaces a per-tag error, marks the field invalid, and blocks submit for an over-long tag', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject({ tags: [] })}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(getTags()).toHaveValue(''));
+      const input = getTags();
+      await user.type(input, 'a'.repeat(31));
+
+      const error = await screen.findByText(/Each tag must be 30 characters or fewer/i);
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(input.getAttribute('aria-describedby')).toContain(error.id);
+
+      const submit = screen.getByRole('button', { name: /save & continue/i });
+      expect(submit).toBeDisabled();
+      await user.click(submit);
+      expect(updateProjectMetadata).not.toHaveBeenCalled();
+    });
+
+    it('accepts multiple tags within the per-tag bound', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject({ tags: [] })}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(getTags()).toHaveValue(''));
+      const input = getTags();
+      await user.type(input, 'Payments, DeFi, Tooling');
+
+      expect(screen.queryByText(/Each tag must be/i)).not.toBeInTheDocument();
+      expect(input).not.toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByRole('button', { name: /save & continue/i })).toBeEnabled();
+    });
+  });
 });

--- a/src/features/maintainers/components/NewProjectSetupModal.tsx
+++ b/src/features/maintainers/components/NewProjectSetupModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Loader2, AlertCircle, CheckCircle2, ChevronDown } from 'lucide-react';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
@@ -8,6 +8,11 @@ import {
   type PendingSetupProject,
 } from '../../../shared/api/client';
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
+
+/** Maximum length of any single comma-separated tag. */
+const MAX_TAG_LENGTH = 30;
+/** Maximum length of the entire tags field (all tags plus separators). */
+const MAX_TAGS_LENGTH = 120;
 
 interface NewProjectSetupModalProps {
   isOpen: boolean;
@@ -41,6 +46,11 @@ export function NewProjectSetupModal({
   const [success, setSuccess] = useState(false);
   const [ecosystemDropdownOpen, setEcosystemDropdownOpen] = useState(false);
   const ecosystemDropdownRef = useRef<HTMLDivElement>(null);
+
+  const tagsFieldId = useId();
+  const tagsCounterId = `${tagsFieldId}-counter`;
+  const tagsHintId = `${tagsFieldId}-hint`;
+  const tagsErrorId = `${tagsFieldId}-error`;
 
   /**
    * Tracks the live `isOpen` value for async callbacks. A submission started
@@ -141,6 +151,11 @@ export function NewProjectSetupModal({
       return;
     }
 
+    if (tags.split(',').some((tag) => tag.trim().length > MAX_TAG_LENGTH)) {
+      setError(`Each tag must be ${MAX_TAG_LENGTH} characters or fewer`);
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -192,6 +207,15 @@ export function NewProjectSetupModal({
   };
 
   if (!isOpen || !project) return null;
+
+  // Any individual (trimmed, non-empty) tag that exceeds the per-tag bound.
+  const overLongTags = tags
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > MAX_TAG_LENGTH);
+  const tagsTooLong = overLongTags.length > 0;
+  const tagsAtLimit = tags.length >= MAX_TAGS_LENGTH;
+  const tagsDescribedBy = `${tagsHintId} ${tagsCounterId}${tagsTooLong ? ` ${tagsErrorId}` : ''}`;
 
   const modalContent = (
     <div className="fixed inset-0 z-[10000] flex items-center justify-center p-4">
@@ -403,19 +427,46 @@ export function NewProjectSetupModal({
               onChange={(e) => setTags(e.target.value)}
               placeholder="e.g., Payments, DeFi, Tooling"
               disabled={isSubmitting}
+              maxLength={MAX_TAGS_LENGTH}
+              aria-describedby={tagsDescribedBy}
+              aria-invalid={tagsTooLong || undefined}
               className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all ${
                 darkTheme
                   ? 'bg-white/10 border-white/20 text-[#e8dfd0] placeholder:text-[#b8a898] focus:border-[#c9983a] focus:bg-white/15'
                   : 'bg-white/40 border-white/50 text-[#2d2820] placeholder:text-[#7a6b5a] focus:border-[#c9983a] focus:bg-white/60'
-              } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
+              } ${tagsTooLong ? '!border-red-500/60' : ''} ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
             />
-            <p
-              className={`mt-1.5 text-[12px] transition-colors ${
-                darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-              }`}
-            >
-              Separate multiple tags with commas
-            </p>
+            <div className="mt-1.5 flex items-start justify-between gap-3">
+              <p
+                id={tagsHintId}
+                className={`text-[12px] transition-colors ${
+                  darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                }`}
+              >
+                Separate multiple tags with commas
+              </p>
+              <span
+                id={tagsCounterId}
+                aria-live="polite"
+                className={`text-[12px] flex-shrink-0 transition-colors ${
+                  tagsAtLimit
+                    ? darkTheme ? 'text-[#e8c571]' : 'text-[#c9983a]'
+                    : darkTheme ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                }`}
+              >
+                {tags.length}/{MAX_TAGS_LENGTH}
+              </span>
+            </div>
+            {tagsTooLong && (
+              <p
+                id={tagsErrorId}
+                className={`mt-1 text-[12px] transition-colors ${
+                  darkTheme ? 'text-red-400' : 'text-red-600'
+                }`}
+              >
+                Each tag must be {MAX_TAG_LENGTH} characters or fewer.
+              </p>
+            )}
           </div>
 
           {/* Category */}
@@ -444,12 +495,12 @@ export function NewProjectSetupModal({
           <div className="flex items-center gap-3 pt-2">
             <button
               type="submit"
-              disabled={isSubmitting || success}
+              disabled={isSubmitting || success || tagsTooLong}
               className={`flex-1 px-5 py-3 rounded-[12px] border-2 font-semibold text-[14px] transition-all ${
                 darkTheme
                   ? 'bg-gradient-to-br from-[#c9983a]/40 to-[#d4af37]/30 border-[#c9983a]/70 text-[#fef5e7] hover:from-[#c9983a]/50 hover:to-[#d4af37]/40 shadow-[0_4px_16px_rgba(201,152,58,0.4)]'
                   : 'bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/25 border-[#c9983a]/50 text-[#2d2820] hover:from-[#c9983a]/40 hover:to-[#d4af37]/35 shadow-[0_4px_16px_rgba(201,152,58,0.25)]'
-              } ${isSubmitting || success ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+              } ${isSubmitting || success || tagsTooLong ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
               {isSubmitting ? (
                 <span className="flex items-center justify-center gap-2">

--- a/src/shared/components/ui/Modal.test.tsx
+++ b/src/shared/components/ui/Modal.test.tsx
@@ -252,6 +252,50 @@ describe('Modal building blocks', () => {
     expect(onChange).toHaveBeenCalled();
   });
 
+  it('ModalInput forwards maxLength and renders a live counter linked to the field', () => {
+    renderWithTheme(
+      <ModalInput label="Tagline" value="hello" onChange={() => {}} maxLength={20} />,
+    );
+    const input = screen.getByDisplayValue('hello');
+    expect(input).toHaveAttribute('maxlength', '20');
+
+    const counter = screen.getByText('5/20');
+    expect(counter).toHaveAttribute('aria-live', 'polite');
+    // The field points at the counter so screen readers announce the remaining room.
+    expect(input.getAttribute('aria-describedby')).toContain(counter.id);
+  });
+
+  it('ModalInput renders no counter when maxLength is unset', () => {
+    renderWithTheme(<ModalInput label="Name" value="abc" onChange={() => {}} />);
+    expect(screen.queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('abc')).not.toHaveAttribute('maxlength');
+  });
+
+  it('ModalInput caps typed input at maxLength and updates the counter', async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [value, setValue] = useState('');
+      return <ModalInput label="Code" value={value} onChange={setValue} maxLength={3} placeholder="code" />;
+    }
+    renderWithTheme(<Harness />);
+    const input = screen.getByPlaceholderText('code');
+
+    await user.type(input, 'abcdef');
+    // Native maxLength stops input at the bound, including the at-limit counter.
+    expect(input).toHaveValue('abc');
+    expect(screen.getByText('3/3')).toBeInTheDocument();
+  });
+
+  it('ModalInput forwards maxLength to the textarea variant', () => {
+    renderWithTheme(
+      <ModalInput label="Bio" value="hi" onChange={() => {}} rows={3} maxLength={140} />,
+    );
+    const textarea = screen.getByDisplayValue('hi');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveAttribute('maxlength', '140');
+    expect(screen.getByText('2/140')).toBeInTheDocument();
+  });
+
   it('ModalSelect renders a labelled trigger with the selected value', () => {
     renderWithTheme(
       <ModalSelect

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -210,6 +210,14 @@ interface ModalInputProps {
   rows?: number;
   className?: string;
   error?: string | null;
+  /**
+   * Optional maximum character length. When set, it is forwarded to the
+   * underlying `input`/`textarea` (so the browser caps typing and paste) and a
+   * live character counter (`current/max`) is rendered beneath the field. The
+   * counter is announced to assistive tech via `aria-live="polite"` and linked
+   * to the field with `aria-describedby`.
+   */
+  maxLength?: number;
 }
 
 export function ModalInput({
@@ -222,11 +230,21 @@ export function ModalInput({
   required = false,
   rows,
   className = '',
-  error
+  error,
+  maxLength
 }: ModalInputProps) {
   const { theme } = useTheme();
 
   const isError = !!error;
+  const fieldId = useId();
+  const counterId = `${fieldId}-counter`;
+  const errorId = `${fieldId}-error`;
+  const showCounter = typeof maxLength === 'number';
+  const atLimit = showCounter && value.length >= maxLength;
+  const describedBy =
+    [isError ? errorId : null, showCounter ? counterId : null]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   const inputClasses = `w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none transition-all text-[14px] ${isError
     ? theme === 'dark'
@@ -253,6 +271,9 @@ export function ModalInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onBlur}
+          maxLength={maxLength}
+          aria-describedby={describedBy}
+          aria-invalid={isError || undefined}
           className={`${inputClasses} resize-none`}
           placeholder={placeholder}
         />
@@ -263,14 +284,29 @@ export function ModalInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onBlur}
+          maxLength={maxLength}
+          aria-describedby={describedBy}
+          aria-invalid={isError || undefined}
           className={inputClasses}
           placeholder={placeholder}
         />
       )}
       {isError && (
-        <p className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
+        <p id={errorId} className={`text-[12px] mt-1.5 transition-colors ${theme === 'dark' ? 'text-red-400' : 'text-red-600'
           }`}>
           {error}
+        </p>
+      )}
+      {showCounter && (
+        <p
+          id={counterId}
+          aria-live="polite"
+          className={`text-[12px] mt-1.5 text-right transition-colors ${atLimit
+            ? theme === 'dark' ? 'text-[#e8c571]' : 'text-[#c9983a]'
+            : theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+            }`}
+        >
+          {value.length}/{maxLength}
         </p>
       )}
     </div>


### PR DESCRIPTION
Closes #235 
ModalInput had no way to cap input length, and the tags field in NewProjectSetupModal accepted arbitrarily long text with no feedback. This adds both.

ModalInput now takes an optional maxLength. When it's set it's forwarded to the input/textarea so the browser caps typing and paste, and a live current/max counter shows under the field, announced with aria-live=polite and tied to the field with aria-describedby. Nothing changes when the prop is left off, so the existing usages aren't affected.

The tags field in NewProjectSetupModal is bounded too: total length capped at 120, a per-tag cap of 30 with an inline message and aria-invalid when a tag runs over, and submit is disabled while it's invalid. The counter sits next to the existing "separate with commas" hint.

One scope note: the issue mentions a ModalInput textarea, but the tags input here is actually a plain input rather than a ModalInput, so I bounded it directly and added the reusable maxLength to ModalInput for the first requirement.

Tests: 4 new cases for ModalInput and 4 for the tags field, added to the existing Modal.test.tsx and NewProjectSetupModal.test.tsx. All 45 in those two files pass.

I kept the diff surgical and matched each file's existing style instead of reformatting, since both files predate the no-semi prettier config and aren't prettier-clean on main already. The wider test run has a few unrelated failures on main right now (route splitting, a recharts chart, a couple of context tests).