### PR TITLE
fix(a11y): make ContributorsTable rows keyboard-activatable with butt…

### DIFF
--- a/src/features/leaderboard/components/ContributorsTable.test.tsx
+++ b/src/features/leaderboard/components/ContributorsTable.test.tsx
@@ -65,3 +65,43 @@ describe('ContributorsTable states', () => {
     expect(screen.queryByText('octocat')).not.toBeInTheDocument()
   })
 })
+
+describe('ContributorsTable row accessibility', () => {
+  it('exposes each clickable row as a focusable button with an accessible name', () => {
+    renderTable()
+    const row = screen.getByRole('button', { name: 'View contributor octocat' })
+    expect(row).toHaveAttribute('tabindex', '0')
+  })
+
+  it('activates a row with the Enter key', async () => {
+    const user = userEvent.setup()
+    const onUserClick = vi.fn()
+    renderTable({ onUserClick })
+
+    const row = screen.getByRole('button', { name: 'View contributor octocat' })
+    row.focus()
+    expect(row).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(onUserClick).toHaveBeenCalledWith('octocat', 'uid-1')
+  })
+
+  it('activates a row with the Space key', async () => {
+    const user = userEvent.setup()
+    const onUserClick = vi.fn()
+    renderTable({ onUserClick })
+
+    const row = screen.getByRole('button', { name: 'View contributor octocat' })
+    row.focus()
+    await user.keyboard(' ')
+    expect(onUserClick).toHaveBeenCalledWith('octocat', 'uid-1')
+  })
+
+  it('still activates a row on pointer click', async () => {
+    const user = userEvent.setup()
+    const onUserClick = vi.fn()
+    renderTable({ onUserClick })
+
+    await user.click(screen.getByRole('button', { name: 'View contributor octocat' }))
+    expect(onUserClick).toHaveBeenCalledWith('octocat', 'uid-1')
+  })
+})

--- a/src/features/leaderboard/components/ContributorsTable.tsx
+++ b/src/features/leaderboard/components/ContributorsTable.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react'
 import { TrendingUp, TrendingDown, Minus, Award } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { LeaderData, FilterType } from '../types'
@@ -37,6 +38,15 @@ export function ContributorsTable({
   const handleRowClick = (leader: LeaderData) => {
     if (onUserClick) {
       onUserClick(leader.username, leader.user_id)
+    }
+  }
+
+  // Activate a focused row with Enter or Space, mirroring native button
+  // behaviour. preventDefault on Space stops the page from scrolling.
+  const handleRowKeyDown = (e: KeyboardEvent<HTMLDivElement>, leader: LeaderData) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleRowClick(leader)
     }
   }
 
@@ -93,8 +103,12 @@ export function ContributorsTable({
           {data.map((leader, index) => (
             <div
               key={leader.rank}
+              role="button"
+              tabIndex={0}
+              aria-label={`View contributor ${leader.username}`}
               onClick={() => handleRowClick(leader)}
-              className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
+              onKeyDown={(e) => handleRowKeyDown(e, leader)}
+              className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#c9983a]"
               style={{
                 animation: isLoaded
                   ? `slideInLeft 0.5s ease-out ${1.1 + index * 0.1}s both`


### PR DESCRIPTION
…on semantics

The clickable rows in ContributorsTable were divs with onClick and no keyboard or screen-reader support, so the leaderboard's main navigation was unreachable without a mouse.

Each row now carries role=button, tabIndex 0, an accessible name (View contributor {username}), and Enter/Space activation, plus a visible focus-visible ring. The ring is inset so the card's overflow-hidden doesn't clip it. Visual layout is unchanged.

Added tests for the button role and accessible name, Enter and Space activation, and that pointer click still works.

Closes #241