### PR TITLE
test(maintainers): cover add repository schema validation

### DIFF
--- a/src/features/maintainers/components/AddRepositoryModal.test.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.test.tsx
@@ -66,6 +66,27 @@ describe('AddRepositoryModal', () => {
     expect(mockCreateProject).not.toHaveBeenCalled()
   })
 
+  it('surfaces the schema error for a non-GitHub repository URL', async () => {
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(
+      screen.getByPlaceholderText(/owner\/repo/i),
+      'https://gitlab.com/owner/repository'
+    )
+
+    expect(
+      await screen.findByText(
+        'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add repository/i })).toBeDisabled()
+    expect(mockCreateProject).not.toHaveBeenCalled()
+  })
+
   it('calls createProject on valid submit', async () => {
     mockCreateProject.mockResolvedValue({ id: '1' })
     const user = userEvent.setup()

--- a/src/features/maintainers/components/addRepositorySchema.test.ts
+++ b/src/features/maintainers/components/addRepositorySchema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { addRepositorySchema } from './addRepositorySchema'
+
+const formatMessage = 'Repository name must be in format: owner/repo'
+const invalidRepositoryMessage =
+  'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.'
+
+const validForm = (githubFullName: string) => ({
+  githubFullName,
+  ecosystemName: 'Ethereum',
+  language: '',
+  tags: '',
+  category: '',
+})
+
+describe('addRepositorySchema', () => {
+  it.each([
+    ['owner/repository', 'owner/repository'],
+    ['grainlify/frontend_ui.v2', 'grainlify/frontend_ui.v2'],
+    ['https://github.com/owner/repository', 'owner/repository'],
+  ])('accepts %s and normalizes it to %s', (input, expected) => {
+    const result = addRepositorySchema.safeParse(validForm(input))
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.githubFullName).toBe(expected)
+    }
+  })
+
+  it.each([
+    ['', 'Repository name is required'],
+    ['/repository', formatMessage],
+    ['owner/', formatMessage],
+    ['owner/repository/', formatMessage],
+    ['https://github.com/owner/repository/', formatMessage],
+    ['https://gitlab.com/owner/repository', invalidRepositoryMessage],
+    [' owner/repository', invalidRepositoryMessage],
+    ['owner/repository ', invalidRepositoryMessage],
+  ])('rejects %j with the expected message', (input, expectedMessage) => {
+    const result = addRepositorySchema.safeParse(validForm(input))
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(expectedMessage)
+    }
+  })
+
+  it('rejects repository names longer than 140 characters after URL normalization', () => {
+    const result = addRepositorySchema.safeParse(validForm(`owner/${'r'.repeat(135)}`))
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Repository name must be 140 characters or less')
+    }
+  })
+})

--- a/src/features/maintainers/components/addRepositorySchema.ts
+++ b/src/features/maintainers/components/addRepositorySchema.ts
@@ -1,5 +1,37 @@
 import { z } from 'zod'
 
+const REPOSITORY_FORMAT_MESSAGE = 'Repository name must be in format: owner/repo'
+const INVALID_REPOSITORY_MESSAGE =
+  'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.'
+
+/**
+ * Converts a strict GitHub repository URL to the owner/repo form expected by the API.
+ * Values that are not canonical HTTPS GitHub URLs are left unchanged for validation.
+ */
+function normalizeGitHubRepositoryName(value: string): string {
+  if (!/^https:\/\//i.test(value)) return value
+
+  try {
+    const url = new URL(value)
+    const path = url.pathname.slice(1)
+    const parts = path.split('/')
+    const isCanonicalGitHubUrl =
+      url.protocol === 'https:' &&
+      url.hostname === 'github.com' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.port === '' &&
+      url.search === '' &&
+      url.hash === '' &&
+      parts.length === 2 &&
+      parts.every(Boolean)
+
+    return isCanonicalGitHubUrl ? path : value
+  } catch {
+    return value
+  }
+}
+
 /**
  * TSDoc for Add Repository Schema Module
  *
@@ -9,30 +41,36 @@ import { z } from 'zod'
 export const addRepositorySchema = z.object({
   githubFullName: z
     .string()
-    .trim()
-    .min(1, { message: 'Repository name is required' })
-    .max(140, { message: 'Repository name must be 140 characters or less' })
-    .refine((val) => val.includes('/'), {
-      message: 'Repository name must be in format: owner/repo',
-    })
-    .refine((val) => !val.startsWith('/') && !val.endsWith('/'), {
-      message: 'Repository name must be in format: owner/repo',
-    })
-    .refine(
-      (val) => {
-        const parts = val.split('/')
-        if (parts.length !== 2) return false
-        const [owner, repo] = parts
-        // GitHub owner/organization rules (alphanumeric or hyphens, max 39 characters, no leading/trailing/consecutive hyphens)
-        const ownerRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/
-        // GitHub repository rules (alphanumeric, hyphens, underscores, dots, max 100 characters)
-        const repoRegex = /^[a-zA-Z0-9._-]{1,100}$/
-        return ownerRegex.test(owner) && repoRegex.test(repo)
-      },
-      {
-        message:
-          'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.',
+    .superRefine((value, context) => {
+      if (value !== value.trim()) {
+        context.addIssue({ code: 'custom', message: INVALID_REPOSITORY_MESSAGE })
       }
+    })
+    .transform(normalizeGitHubRepositoryName)
+    .pipe(
+      z
+        .string()
+        .min(1, { message: 'Repository name is required' })
+        .max(140, { message: 'Repository name must be 140 characters or less' })
+        .refine((val) => val.includes('/'), {
+          message: REPOSITORY_FORMAT_MESSAGE,
+        })
+        .refine((val) => !val.startsWith('/') && !val.endsWith('/'), {
+          message: REPOSITORY_FORMAT_MESSAGE,
+        })
+        .refine(
+          (val) => {
+            const parts = val.split('/')
+            if (parts.length !== 2) return false
+            const [owner, repo] = parts
+            // GitHub owner/organization rules (alphanumeric or hyphens, max 39 characters, no leading/trailing/consecutive hyphens)
+            const ownerRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/
+            // GitHub repository rules (alphanumeric, hyphens, underscores, dots, max 100 characters)
+            const repoRegex = /^[a-zA-Z0-9._-]{1,100}$/
+            return ownerRegex.test(owner) && repoRegex.test(repo)
+          },
+          { message: INVALID_REPOSITORY_MESSAGE }
+        )
     ),
   ecosystemName: z.string().trim().min(1, { message: 'Ecosystem is required' }),
   language: z.string().optional().or(z.literal('')),


### PR DESCRIPTION
## Summary

- add table-driven coverage for valid repository slugs, canonical GitHub URLs, malformed inputs, and exact validation messages
- normalize canonical `https://github.com/owner/repo` inputs to the existing `owner/repo` API contract
- verify `AddRepositoryModal` surfaces the schema error for a non-GitHub URL

## Tests

- `20` focused tests pass
- schema coverage: `100%` statements, branches, functions, and lines
- full UTC suite: `1,011` passed, `4` skipped
- touched-file ESLint and TypeScript checks pass
- production build passes

## Baseline note

The repository-wide `pnpm run typecheck` remains blocked by existing unrelated errors in leaderboard props, pull-request state, shared UI components, and older tests. No typecheck error references the three files changed here.

Closes #472