### PR TITLE
Add unit tests for src/shared/hooks/use debounced value.ts 

### DIFF
--- a/src/shared/hooks/useDebouncedValue.test.ts
+++ b/src/shared/hooks/useDebouncedValue.test.ts
@@ -1,46 +1,104 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useDebouncedValue } from './useDebouncedValue';
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useDebouncedValue } from './useDebouncedValue'
 
-describe('useDebouncedValue Hook', () => {
+describe('useDebouncedValue', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-  });
+    vi.useFakeTimers()
+  })
 
-  it('should return initial value immediately', () => {
-    const { result } = renderHook(() => useDebouncedValue('initial', 300));
-    expect(result.current).toBe('initial');
-  });
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
 
-  it('should debounce value updates based on specified delay', () => {
-    const { result, rerender } = renderHook(
-      ({ value }) => useDebouncedValue(value, 300),
-      { initialProps: { value: 'first' } }
-    );
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('initial'))
 
-    rerender({ value: 'second' });
-    expect(result.current).toBe('first');
+    expect(result.current).toBe('initial')
+  })
+
+  it('uses the default 300ms delay before updating the debounced value', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'first' },
+    })
+
+    rerender({ value: 'second' })
 
     act(() => {
-      vi.advanceTimersByTime(300);
-    });
-    expect(result.current).toBe('second');
-  });
+      vi.advanceTimersByTime(299)
+    })
+    expect(result.current).toBe('first')
 
-  it('should cancel previous timers and only resolve the latest value', () => {
-    const { result, rerender } = renderHook(
-      ({ value }) => useDebouncedValue(value, 300),
-      { initialProps: { value: 'a' } }
-    );
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('second')
+  })
 
-    rerender({ value: 'ab' });
-    act(() => { vi.advanceTimersByTime(150); });
-    
-    rerender({ value: 'abc' });
-    act(() => { vi.advanceTimersByTime(150); }); 
-    expect(result.current).toBe('a'); // 'ab' was cancelled/skipped
+  it('respects a custom delay before updating the debounced value', () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebouncedValue(value, delay), {
+      initialProps: { value: 'first', delay: 500 },
+    })
 
-    act(() => { vi.advanceTimersByTime(150); }); 
-    expect(result.current).toBe('abc'); // The latest one wins
-  });
-});
+    rerender({ value: 'second', delay: 500 })
+
+    act(() => {
+      vi.advanceTimersByTime(499)
+    })
+    expect(result.current).toBe('first')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('second')
+  })
+
+  it('coalesces rapid successive updates into the final pending value', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'ab' })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    rerender({ value: 'abc' })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    rerender({ value: 'abcd' })
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('abcd')
+  })
+
+  it('cleans up a pending debounce on unmount without React warnings', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { result, rerender, unmount } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'mounted' },
+    })
+
+    rerender({ value: 'pending' })
+    expect(result.current).toBe('mounted')
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    expect(consoleWarn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Motivation
- Add dedicated unit tests for the `useDebouncedValue` hook to validate debounce delay, rapid-update coalescing, and cleanup-on-unmount behavior so debounced UI inputs are reliable and regression-safe.

### Description
- Add `src/shared/hooks/useDebouncedValue.test.ts` implementing tests that use `renderHook` and fake timers (`vi.useFakeTimers()`) to control debounce timing.
- Add assertions for immediate initial value, default `300ms` delay behavior, and a custom delay (`500ms`) case using `vi.advanceTimersByTime()`.
- Add a coalescing test that ensures rapid successive updates collapse to the final value after the last debounce interval.
- Add an unmount cleanup test that advances timers after `unmount()` and asserts no `console.error` or `console.warn` calls occur; test setup/teardown clears timers and restores real timers.

### Testing
- Ran `pnpm test src/shared/hooks/useDebouncedValue.test.ts` and all tests in that file passed (`5` tests passed). 
- Ran `pnpm exec eslint src/shared/hooks/useDebouncedValue.test.ts` and `prettier --check` for the test file which succeeded. 
- Running `pnpm exec tsc --noEmit` failed due to unrelated TypeScript errors elsewhere in the repository and is not caused by these test additions.

------

Closes #443