### PR TITLE
Extract hardcoded strings in src/features/settings/components/terms/terms tab.tsx to the i18n catalog 

### DIFF
--- a/src/features/settings/components/terms/TermsTab.test.tsx
+++ b/src/features/settings/components/terms/TermsTab.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { TermsTab, CURRENT_TERMS_VERSION, SKELETON_DELAY_MS } from './TermsTab'
 import { getTermsStatus, acceptTerms } from '../../../../shared/api/client'
 import { ThemeProvider } from '../../../../shared/contexts/ThemeContext'
+import { I18nProvider, en } from '../../../../shared/i18n'
 
 // Mock the API client
 vi.mock('../../../../shared/api/client', () => ({
@@ -10,13 +11,59 @@ vi.mock('../../../../shared/api/client', () => ({
   acceptTerms: vi.fn(),
 }))
 
-const renderWithTheme = (ui: React.ReactElement) => {
-  return render(<ThemeProvider>{ui}</ThemeProvider>)
+const renderWithTheme = (ui: React.ReactElement, messages: Record<string, string> = en) => {
+  return render(
+    <I18nProvider messages={messages}>
+      <ThemeProvider>{ui}</ThemeProvider>
+    </I18nProvider>
+  )
 }
 
 describe('TermsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('renders copy from the i18n catalog', async () => {
+    vi.mocked(getTermsStatus).mockResolvedValue({
+      accepted: false,
+      version: null,
+      accepted_at: null,
+    })
+
+    renderWithTheme(<TermsTab />, {
+      ...en,
+      'terms.title': 'Catalog Terms Title',
+      'terms.description': 'Catalog terms description.',
+      'terms.service.title': 'Catalog Service Heading',
+      'terms.service.bodyPrefix': 'Catalog service prefix',
+      'terms.service.bodySuffix': ' catalog service suffix.',
+      'terms.privacy.title': 'Catalog Privacy Heading',
+      'terms.privacy.bodyPrefix': 'Catalog privacy prefix',
+      'terms.privacy.bodySuffix': 'catalog privacy suffix.',
+      'terms.dataCollection.title': 'Catalog Data Heading',
+      'terms.dataCollection.body': 'Catalog data body.',
+      'terms.userResponsibilities.title': 'Catalog Responsibilities Heading',
+      'terms.userResponsibilities.body': 'Catalog responsibilities body.',
+      'terms.acceptance.title': 'Catalog Accept Heading',
+      'terms.actions.accept': 'Catalog Accept CTA',
+    })
+
+    expect(await screen.findByRole('heading', { name: 'Catalog Terms Title' })).toBeInTheDocument()
+    expect(screen.getByText('Catalog terms description.')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Catalog Service Heading' })).toBeInTheDocument()
+    expect(screen.getByText(/Catalog service prefix/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Catalog Privacy Heading' })).toBeInTheDocument()
+    expect(screen.getByText(/Catalog privacy prefix/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Catalog Data Heading' })).toBeInTheDocument()
+    expect(screen.getByText('Catalog data body.')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Catalog Responsibilities Heading' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Catalog responsibilities body.')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Catalog Accept Heading' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Catalog Accept CTA' })).toBeInTheDocument()
+    expect(screen.queryByText('Terms and Conditions')).not.toBeInTheDocument()
   })
 
   it('renders loading state initially', () => {

--- a/src/features/settings/components/terms/TermsTab.tsx
+++ b/src/features/settings/components/terms/TermsTab.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { getTermsStatus, acceptTerms } from '../../../../shared/api/client'
 import { Skeleton } from '../../../../shared/components/ui/skeleton'
 import { logger } from '../../../../shared/utils/logger'
+import { useTranslation } from '../../../../shared/i18n'
 
 /**
  * Current version of the terms and conditions.
@@ -22,6 +23,8 @@ export const SKELETON_DELAY_MS = 300
  */
 export function TermsTab() {
   const { theme } = useTheme()
+  const { t } = useTranslation()
+  const loadStatusFailedMessage = t('terms.errors.loadStatusFailed')
   const [isLoading, setIsLoading] = useState(true)
   const [isAccepting, setIsAccepting] = useState(false)
   const [isAccepted, setIsAccepted] = useState(false)
@@ -49,7 +52,7 @@ export function TermsTab() {
       } catch (err) {
         logger.error('Failed to fetch terms status:', err)
         if (mounted) {
-          setFetchError(err instanceof Error ? err.message : 'Failed to load terms status.')
+          setFetchError(err instanceof Error ? err.message : loadStatusFailedMessage)
         }
       } finally {
         if (mounted) {
@@ -61,7 +64,7 @@ export function TermsTab() {
     return () => {
       mounted = false
     }
-  }, [])
+  }, [loadStatusFailedMessage])
 
   // Delay the skeleton so quick fetches don't cause a flash of loading UI.
   useEffect(() => {
@@ -82,7 +85,7 @@ export function TermsTab() {
       setAcceptedVersion(res.version)
       setAcceptedDate(res.accepted_at)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to accept terms. Please try again.')
+      setError(err instanceof Error ? err.message : t('terms.errors.acceptFailed'))
     } finally {
       setIsAccepting(false)
     }
@@ -103,14 +106,14 @@ export function TermsTab() {
             theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
           }`}
         >
-          Terms and Conditions
+          {t('terms.title')}
         </h2>
         <p
           className={`text-[14px] transition-colors ${
             theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
           }`}
         >
-          Review our terms of service and privacy policy.
+          {t('terms.description')}
         </p>
       </div>
 
@@ -128,19 +131,18 @@ export function TermsTab() {
               theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
             }`}
           >
-            Terms of Service
+            {t('terms.service.title')}
           </h3>
           <p
             className={`text-[14px] leading-relaxed mb-6 transition-colors ${
               theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
             }`}
           >
-            By using Grainlify, you agree to abide by our{' '}
+            {t('terms.service.bodyPrefix')}{' '}
             <a href="/terms" className="underline hover:opacity-80">
-              terms of service
+              {t('terms.links.termsOfService')}
             </a>
-            . These terms govern your use of the platform and outline your rights and
-            responsibilities as a user.
+            {t('terms.service.bodySuffix')}
           </p>
 
           <h3
@@ -148,18 +150,18 @@ export function TermsTab() {
               theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
             }`}
           >
-            Privacy Policy
+            {t('terms.privacy.title')}
           </h3>
           <p
             className={`text-[14px] leading-relaxed mb-6 transition-colors ${
               theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
             }`}
           >
-            We take your privacy seriously. Our{' '}
+            {t('terms.privacy.bodyPrefix')}{' '}
             <a href="/privacy" className="underline hover:opacity-80">
-              privacy policy
+              {t('terms.links.privacyPolicy')}
             </a>{' '}
-            explains how we collect, use, and protect your personal information.
+            {t('terms.privacy.bodySuffix')}
           </p>
 
           <h3
@@ -167,15 +169,14 @@ export function TermsTab() {
               theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
             }`}
           >
-            Data Collection
+            {t('terms.dataCollection.title')}
           </h3>
           <p
             className={`text-[14px] leading-relaxed mb-6 transition-colors ${
               theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
             }`}
           >
-            We collect information necessary to provide our services, including your GitHub profile
-            data, contribution history, and reward preferences.
+            {t('terms.dataCollection.body')}
           </p>
 
           <h3
@@ -183,15 +184,14 @@ export function TermsTab() {
               theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
             }`}
           >
-            User Responsibilities
+            {t('terms.userResponsibilities.title')}
           </h3>
           <p
             className={`text-[14px] leading-relaxed mb-6 transition-colors ${
               theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
             }`}
           >
-            Users are responsible for maintaining the security of their accounts, providing accurate
-            information, and complying with all applicable laws and regulations.
+            {t('terms.userResponsibilities.body')}
           </p>
         </div>
       </div>
@@ -210,22 +210,22 @@ export function TermsTab() {
               theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
             }`}
           >
-            Accept Terms
+            {t('terms.acceptance.title')}
           </h3>
           <p
             className={`text-[13px] transition-colors ${
               theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
             }`}
           >
-            By clicking accept, you agree to our{' '}
+            {t('terms.acceptance.bodyPrefix')}{' '}
             <a href="/terms" className="underline hover:opacity-80">
-              terms of service
+              {t('terms.links.termsOfService')}
             </a>{' '}
-            and{' '}
+            {t('terms.acceptance.bodyConnector')}{' '}
             <a href="/privacy" className="underline hover:opacity-80">
-              privacy policy
+              {t('terms.links.privacyPolicy')}
             </a>
-            .
+            {t('terms.acceptance.bodySuffix')}
           </p>
 
           {/* Acceptance status region: announced and gated behind a delay so
@@ -234,7 +234,7 @@ export function TermsTab() {
             {isLoading ? (
               showSkeleton ? (
                 <div data-testid="terms-status-skeleton">
-                  <span className="sr-only">Loading terms status…</span>
+                  <span className="sr-only">{t('terms.status.loading')}</span>
                   <Skeleton className="h-4 w-64" />
                 </div>
               ) : null
@@ -242,8 +242,10 @@ export function TermsTab() {
               <p className="text-[12px] text-red-500 font-medium">{fetchError}</p>
             ) : isAccepted && acceptedVersion && acceptedDate ? (
               <p className="text-[12px] text-green-500 font-medium">
-                ✓ Accepted version {acceptedVersion} on{' '}
-                {new Date(acceptedDate).toLocaleDateString()}
+                {t('terms.status.acceptedVersion', {
+                  version: acceptedVersion,
+                  date: new Date(acceptedDate).toLocaleDateString(),
+                })}
               </p>
             ) : null}
           </div>
@@ -262,12 +264,12 @@ export function TermsTab() {
           }`}
         >
           {isLoading
-            ? 'Loading...'
+            ? t('terms.actions.loading')
             : isAccepting
-              ? 'Accepting...'
+              ? t('terms.actions.accepting')
               : isAccepted
-                ? 'Accepted'
-                : 'Accept'}
+                ? t('terms.actions.accepted')
+                : t('terms.actions.accept')}
         </button>
       </div>
     </div>

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -58,6 +58,8 @@ export function isLocale(value: unknown): value is Locale {
  *   extracted from `src/features/dashboard/DashboardLayout.tsx`.
  * - `settings.tabs.*` — SettingsPage tab labels,
  *   extracted from `src/features/settings/pages/SettingsPage.tsx`.
+ * - `terms.*` — Settings terms tab copy and consent states,
+ *   extracted from `src/features/settings/components/terms/TermsTab.tsx`.
  *
  * `as const` keeps every value a string literal so {@link MessageId} can be
  * derived from the keys with full type-safety.
@@ -81,6 +83,38 @@ export const en = {
   'settings.tabs.payout': 'Payout Preferences',
   'settings.tabs.billing': 'Billing Profiles',
   'settings.tabs.terms': 'Terms and Conditions',
+
+  // ── Terms settings tab — src/features/settings/components/terms/TermsTab.tsx ──
+  'terms.title': 'Terms and Conditions',
+  'terms.description': 'Review our terms of service and privacy policy.',
+  'terms.service.title': 'Terms of Service',
+  'terms.service.bodyPrefix': 'By using Grainlify, you agree to abide by our',
+  'terms.service.bodySuffix':
+    '. These terms govern your use of the platform and outline your rights and responsibilities as a user.',
+  'terms.privacy.title': 'Privacy Policy',
+  'terms.privacy.bodyPrefix': 'We take your privacy seriously. Our',
+  'terms.privacy.bodySuffix':
+    'explains how we collect, use, and protect your personal information.',
+  'terms.dataCollection.title': 'Data Collection',
+  'terms.dataCollection.body':
+    'We collect information necessary to provide our services, including your GitHub profile data, contribution history, and reward preferences.',
+  'terms.userResponsibilities.title': 'User Responsibilities',
+  'terms.userResponsibilities.body':
+    'Users are responsible for maintaining the security of their accounts, providing accurate information, and complying with all applicable laws and regulations.',
+  'terms.acceptance.title': 'Accept Terms',
+  'terms.acceptance.bodyPrefix': 'By clicking accept, you agree to our',
+  'terms.acceptance.bodyConnector': 'and',
+  'terms.acceptance.bodySuffix': '.',
+  'terms.links.termsOfService': 'terms of service',
+  'terms.links.privacyPolicy': 'privacy policy',
+  'terms.status.loading': 'Loading terms status…',
+  'terms.status.acceptedVersion': '✓ Accepted version {version} on {date}',
+  'terms.actions.loading': 'Loading...',
+  'terms.actions.accepting': 'Accepting...',
+  'terms.actions.accepted': 'Accepted',
+  'terms.actions.accept': 'Accept',
+  'terms.errors.loadStatusFailed': 'Failed to load terms status.',
+  'terms.errors.acceptFailed': 'Failed to accept terms. Please try again.',
 
   // ── Dashboard sidebar — src/features/dashboard/DashboardLayout.tsx ──
   'dashboardNav.discover': 'Discover',


### PR DESCRIPTION
### Motivation

- TermsTab contained hardcoded user-facing copy which prevented translations from applying and diverged from the existing i18n pattern used elsewhere. 
- The change centralizes terms copy into the message catalog so non-English locales can render the same content via the app's translation infrastructure.

### Description

- Added a `terms.*` namespace with English source strings for headings, body copy, link labels, button states, status text, and error fallbacks in `src/shared/i18n/messages.ts`.
- Replaced inline strings in `src/features/settings/components/terms/TermsTab.tsx` with `useTranslation().t(...)` lookups and wired fallback error messages to the catalog.
- Updated status/accepted text and action labels to use message ids (including interpolation for accepted version/date).
- Wrapped the existing test harness with `I18nProvider` and added a test in `src/features/settings/components/terms/TermsTab.test.tsx` that asserts copy is rendered from the provided catalog overrides.

### Testing

- Ran `npm test -- --run src/features/settings/components/terms/TermsTab.test.tsx`, which completed successfully with all tests passing (11 tests passed). 
- Ran `npx eslint` against the modified files which completed but reported a pre-existing warning in the skeleton effect (no new lint errors introduced). 
- Ran `npm run typecheck` which fails on unrelated, pre-existing TypeScript issues elsewhere in the repo; there are no type errors for the touched `TermsTab` / `messages.ts` changes when scoped.

------

Closes #442