### PR TITLE
Add unit tests for src/shared/utils/validation.ts edge cases 

### DIFF
--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -1,184 +1,125 @@
-import { describe, it, expect } from 'vitest'
-import { validateRepoName, validateUrl, validateEmail, validateRequired } from './validation'
+import { describe, expect, it } from 'vitest'
+import {
+  isValidRouteParam,
+  validateEmail,
+  validateRepoName,
+  validateRequired,
+  validateUrl,
+} from './validation'
+
+const repoNameRequiredMessage = 'Repository name is required'
+const repoNameFormatMessage = 'Repository name must be in format: owner/repo'
+const repoNameInvalidCharactersMessage =
+  'Repository name contains invalid characters. Use owner/repo format with letters, numbers, hyphens, underscores, and dots.'
+const invalidUrlMessage = 'Please enter a valid URL starting with http:// or https://'
+const invalidUrlProtocolMessage = 'URL must start with http:// or https://'
+const invalidEmailMessage = 'Please enter a valid email address'
 
 describe('validateRepoName', () => {
-  it('accepts valid owner/repo format', () => {
-    expect(validateRepoName('facebook/react')).toBe(true)
-  })
-
-  it('accepts names with hyphens', () => {
-    expect(validateRepoName('my-org/my-repo')).toBe(true)
-  })
-
-  it('accepts names with dots', () => {
-    expect(validateRepoName('org/repo.name')).toBe(true)
-  })
-
-  it('accepts names with underscores', () => {
-    expect(validateRepoName('my_org/my_repo')).toBe(true)
-  })
-
-  it('rejects empty string', () => {
-    expect(validateRepoName('')).toBe('Repository name is required')
-  })
-
-  it('rejects whitespace-only string', () => {
-    expect(validateRepoName('   ')).toBe('Repository name is required')
-  })
-
-  it('rejects missing slash', () => {
-    const result = validateRepoName('just-a-name')
-    expect(result).toBe('Repository name must be in format: owner/repo')
-  })
-
-  it('rejects trailing slash', () => {
-    const result = validateRepoName('owner/')
-    expect(result).toBe('Repository name must be in format: owner/repo')
-  })
-
-  it('rejects leading slash', () => {
-    const result = validateRepoName('/repo')
-    expect(result).toBe('Repository name must be in format: owner/repo')
-  })
-
-  it('rejects special characters', () => {
-    const result = validateRepoName('own er/repo')
-    expect(result).toContain('invalid characters')
-  })
-
-  it('rejects uppercase characters', () => {
-    // lowercase & alphanumeric are fine; test special chars
-    expect(validateRepoName('owner/repo!')).toContain('invalid characters')
+  it.each([
+    ['valid owner/repo format', 'facebook/react', true],
+    ['hyphens', 'my-org/my-repo', true],
+    ['dots', 'org/repo.name', true],
+    ['underscores', 'my_org/my_repo', true],
+    ['leading and trailing whitespace around a valid repo', '  facebook/react  ', true],
+    ['empty string', '', repoNameRequiredMessage],
+    ['whitespace-only string', '   ', repoNameRequiredMessage],
+    ['missing slash', 'just-a-name', repoNameFormatMessage],
+    ['trailing slash', 'owner/', repoNameFormatMessage],
+    ['leading slash', '/repo', repoNameFormatMessage],
+    ['space in owner', 'own er/repo', repoNameInvalidCharactersMessage],
+    ['punctuation in repo', 'owner/repo!', repoNameInvalidCharactersMessage],
+    ['unicode owner', 'mañana/repo', repoNameInvalidCharactersMessage],
+    ['emoji repo', 'owner/repo🚀', repoNameInvalidCharactersMessage],
+  ])('returns a stable result for %s', (_caseName, value, expected) => {
+    expect(validateRepoName(value)).toBe(expected)
   })
 })
 
 describe('validateUrl', () => {
-  it('accepts empty string (optional field)', () => {
-    expect(validateUrl('')).toBe(true)
-  })
+  const exactlyAtLimitHost = `${'a'.repeat(63)}.com`
 
-  it('accepts whitespace-only as empty', () => {
-    expect(validateUrl('   ')).toBe(true)
-  })
-
-  it('accepts valid https URL', () => {
-    expect(validateUrl('https://example.com')).toBe(true)
-  })
-
-  it('accepts valid http URL', () => {
-    expect(validateUrl('http://example.com')).toBe(true)
-  })
-
-  it('accepts URL with path', () => {
-    expect(validateUrl('https://example.com/path/to/page')).toBe(true)
-  })
-
-  it('rejects plain text', () => {
-    const result = validateUrl('not-a-url')
-    expect(result).toContain('valid URL')
-  })
-
-  it('rejects ftp protocol', () => {
-    const result = validateUrl('ftp://example.com')
-    expect(result).toContain('http')
-  })
-
-  it('rejects missing hostname', () => {
-    const result = validateUrl('https://')
-    expect(result).toContain('valid URL')
-  })
-
-  it('accepts localhost (no dot required)', () => {
-    expect(validateUrl('https://localhost')).toBe(true)
-  })
-
-  it('accepts localhost with port', () => {
-    expect(validateUrl('http://localhost:3000')).toBe(true)
-  })
-
-  it('accepts IP address', () => {
-    expect(validateUrl('http://192.168.1.1')).toBe(true)
-  })
-
-  it('rejects javascript: scheme', () => {
-    const result = validateUrl('javascript:alert(1)')
-    expect(result).toContain('http')
-  })
-
-  it('rejects data: scheme', () => {
-    const result = validateUrl('data:text/html,<h1>hi</h1>')
-    expect(result).toContain('http')
+  it.each([
+    ['empty string optional value', '', true],
+    ['whitespace-only optional value', '   ', true],
+    ['https URL', 'https://example.com', true],
+    ['http URL', 'http://example.com', true],
+    ['URL with path', 'https://example.com/path/to/page', true],
+    ['trimmed URL', '  https://example.com  ', true],
+    ['localhost', 'https://localhost', true],
+    ['localhost with port', 'http://localhost:3000', true],
+    ['IP address', 'http://192.168.1.1', true],
+    ['unicode hostname', 'https://例え.テスト', true],
+    ['emoji path', 'https://example.com/🚀', true],
+    ['63-character DNS label', `https://${exactlyAtLimitHost}`, true],
+    ['plain text', 'not-a-url', invalidUrlMessage],
+    ['missing hostname', 'https://', invalidUrlMessage],
+    ['ftp protocol', 'ftp://example.com', invalidUrlProtocolMessage],
+    ['javascript scheme', 'javascript:alert(1)', invalidUrlProtocolMessage],
+    ['data scheme', 'data:text/html,<h1>hi</h1>', invalidUrlProtocolMessage],
+  ])('returns a stable result for %s', (_caseName, value, expected) => {
+    expect(validateUrl(value)).toBe(expected)
   })
 })
 
 describe('validateEmail', () => {
-  it('accepts empty string (optional field)', () => {
-    expect(validateEmail('')).toBe(true)
-  })
+  const exactlyAtLimitLocalPart = 'a'.repeat(64)
 
-  it('accepts whitespace-only as empty', () => {
-    expect(validateEmail('   ')).toBe(true)
+  it.each([
+    ['empty string optional value', '', true],
+    ['whitespace-only optional value', '   ', true],
+    ['valid email', 'user@example.com', true],
+    ['trimmed valid email', '  user@example.com  ', true],
+    ['dots and plus in local part', 'user.name+tag@example.co.uk', true],
+    ['subdomain email', 'user@mail.example.co.uk', true],
+    ['64-character local part', `${exactlyAtLimitLocalPart}@example.com`, true],
+    ['unicode local part', 'mañana@example.com', true],
+    ['unicode domain', 'user@例え.テスト', true],
+    ['emoji local part', '🚀@example.com', true],
+    ['missing TLD', 'user@example', invalidEmailMessage],
+    ['missing local part', '@example.com', invalidEmailMessage],
+    ['double @', 'user@@example.com', invalidEmailMessage],
+    ['spaces in email', 'user @example.com', invalidEmailMessage],
+    ['missing domain name', 'user@.com', invalidEmailMessage],
+    ['trailing dot after TLD', 'user@example.', invalidEmailMessage],
+    ['double dot in domain', 'user@example..com', invalidEmailMessage],
+  ])('returns a stable result for %s', (_caseName, value, expected) => {
+    expect(validateEmail(value)).toBe(expected)
   })
+})
 
-  it('accepts valid email', () => {
-    expect(validateEmail('user@example.com')).toBe(true)
-  })
+describe('isValidRouteParam', () => {
+  const exactlyAtLimit = 'a'.repeat(100)
+  const overLimit = 'a'.repeat(101)
 
-  it('accepts email with dots and plus in local part', () => {
-    expect(validateEmail('user.name+tag@example.co.uk')).toBe(true)
-  })
-
-  it('rejects missing TLD', () => {
-    expect(validateEmail('user@example')).toContain('valid email')
-  })
-
-  it('rejects missing local part', () => {
-    expect(validateEmail('@example.com')).toContain('valid email')
-  })
-
-  it('rejects double @', () => {
-    expect(validateEmail('user@@example.com')).toContain('valid email')
-  })
-
-  it('rejects spaces in email', () => {
-    expect(validateEmail('user @example.com')).toContain('valid email')
-  })
-
-  it('rejects missing domain name', () => {
-    expect(validateEmail('user@.com')).toContain('valid email')
-  })
-
-  it('rejects trailing dot after TLD', () => {
-    expect(validateEmail('user@example.')).toContain('valid email')
-  })
-
-  it('rejects double dot in domain', () => {
-    expect(validateEmail('user@example..com')).toContain('valid email')
-  })
-
-  it('accepts subdomain email', () => {
-    expect(validateEmail('user@mail.example.co.uk')).toBe(true)
-  })
-
-  it('rejects missing domain before dot', () => {
-    expect(validateEmail('user@.com')).toContain('valid email')
+  it.each([
+    ['undefined', undefined, false],
+    ['empty string', '', false],
+    ['whitespace-only string', '   ', false],
+    ['single character lower boundary', 'a', true],
+    ['hyphenated alphanumeric slug', 'project-123', true],
+    ['exactly 100 characters', exactlyAtLimit, true],
+    ['over 100 characters', overLimit, false],
+    ['unicode text', 'mañana', false],
+    ['emoji input', 'project🚀', false],
+    ['slash path segment', 'owner/repo', false],
+    ['dot path segment', 'project.name', false],
+  ])('returns a stable result for %s', (_caseName, value, expected) => {
+    expect(isValidRouteParam(value)).toBe(expected)
   })
 })
 
 describe('validateRequired', () => {
-  it('accepts non-empty value', () => {
-    expect(validateRequired('hello', 'Field')).toBe(true)
-  })
-
-  it('rejects empty string', () => {
-    expect(validateRequired('', 'Field')).toBe('Field is required')
-  })
-
-  it('rejects whitespace-only', () => {
-    expect(validateRequired('   ', 'Field')).toBe('Field is required')
-  })
-
-  it('uses custom field name in message', () => {
-    expect(validateRequired('', 'Ecosystem')).toBe('Ecosystem is required')
+  it.each([
+    ['non-empty value', 'hello', 'Field', true],
+    ['trimmed non-empty value', '  hello  ', 'Field', true],
+    ['unicode value', 'mañana', 'Field', true],
+    ['emoji value', '🚀', 'Field', true],
+    ['exactly one character', 'a', 'Field', true],
+    ['empty string', '', 'Field', 'Field is required'],
+    ['whitespace-only', '   ', 'Field', 'Field is required'],
+    ['custom field name', '', 'Ecosystem', 'Ecosystem is required'],
+  ])('returns a stable result for %s', (_caseName, value, fieldName, expected) => {
+    expect(validateRequired(value, fieldName)).toBe(expected)
   })
 })


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for `src/shared/utils/validation.ts` by exercising boundary cases used throughout forms and settings. 
- Ensure UI-facing error message strings are stable and can be asserted directly in downstream components.

### Description
- Updated `src/shared/utils/validation.test.ts` to add table-driven tests that cover every exported validator including `isValidRouteParam` and edge cases for empty, whitespace-only, exact-limit, over-limit, unicode, and emoji inputs. 
- Converted many single-case tests to `it.each` table-driven cases for compact, repeatable assertions. 
- Asserted exact error message strings for repository name, URL, email, and required-field validators instead of partial/match checks. 
- Added tests for hostname/label length and route parameter length boundaries where applicable.

### Testing
- Ran `pnpm exec vitest run src/shared/utils/validation.test.ts src/features/settings/components/profile/ProfileTab.test.tsx` and all tests passed. 
- Ran `pnpm exec tsc --noEmit`, which failed due to unrelated pre-existing TypeScript errors in other parts of the codebase and not caused by the test additions. 
- All automated validator tests introduced in this change succeeded under `vitest`.

------

Closes #440