### PR TITLE
test(blog): cover slug edge cases

### DIFF
--- a/src/features/blog/utils/slug.test.ts
+++ b/src/features/blog/utils/slug.test.ts
@@ -1,32 +1,65 @@
-import { describe, it, expect } from "vitest";
-import { sanitizeSlug } from "./slug";
+import { describe, expect, it } from 'vitest'
 
-describe("sanitizeSlug", () => {
-  it("accepts and lowercases a well-formed slug", () => {
-    expect(sanitizeSlug("Cross-Chain-Collaboration")).toBe(
-      "cross-chain-collaboration",
-    );
-    expect(sanitizeSlug("  future-of-dev  ")).toBe("future-of-dev");
-    expect(sanitizeSlug("post123")).toBe("post123");
-  });
+import { allBlogPosts } from '../data/blogPosts'
+import { sanitizeSlug } from './slug'
 
-  it("returns null for empty or missing input", () => {
-    expect(sanitizeSlug(undefined)).toBeNull();
-    expect(sanitizeSlug("")).toBeNull();
-    expect(sanitizeSlug("   ")).toBeNull();
-  });
+const URL_PATH_SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function expectSafeResult(input: string | undefined, expected: string | null) {
+  const result = sanitizeSlug(input)
+
+  expect(result).toBe(expected)
+  expect(sanitizeSlug(input)).toBe(result)
+
+  if (result !== null) {
+    expect(result).toMatch(URL_PATH_SEGMENT_PATTERN)
+    expect(encodeURIComponent(result)).toBe(result)
+    expect(result).not.toContain('../')
+  }
+}
+
+describe('sanitizeSlug', () => {
+  it.each([
+    ['Cross-Chain-Collaboration', 'cross-chain-collaboration'],
+    ['  future-of-dev  ', 'future-of-dev'],
+    ['post123', 'post123'],
+  ])('normalizes the safe slug %j', (input, expected) => {
+    expectSafeResult(input, expected)
+  })
 
   it.each([
-    "../etc/passwd",
-    "a/b",
-    "<script>",
-    "has space",
-    "-leading",
-    "trailing-",
-    "double--hyphen",
-    "under_score",
-    "emoji-🚀",
-  ])("rejects the unsafe slug %j", (input) => {
-    expect(sanitizeSlug(input)).toBeNull();
-  });
-});
+    ['accented Latin characters', 'café-consensus'],
+    ['non-Latin characters', '跨链-collaboration'],
+    ['emoji', 'web3-🚀'],
+    ['slashes', 'a/b'],
+    ['markup', '<script>'],
+    ['single spaces', 'has space'],
+    ['consecutive spaces', 'cross  chain'],
+    ['tabs', 'cross\tchain'],
+    ['leading hyphens', '-leading'],
+    ['trailing hyphens', 'trailing-'],
+    ['consecutive hyphens', 'cross--chain'],
+    ['underscores', 'under_score'],
+    ['leading punctuation', '.future-of-web3'],
+    ['trailing punctuation', 'future-of-web3!'],
+    ['punctuation only', '...!!!'],
+    ['Unicode punctuation only', '———'],
+  ])('rejects title-like input containing $0', (_caseName, input) => {
+    expectSafeResult(input, null)
+  })
+
+  it.each([undefined, '', '   '])('returns null for empty input %j', (input) => {
+    expectSafeResult(input, null)
+  })
+
+  it.each(['../etc/passwd', 'safe/../admin', '..%2Fetc%2Fpasswd', '%2e%2e%2fsecret'])(
+    'rejects the path-traversal input %j',
+    (input) => {
+      expectSafeResult(input, null)
+    }
+  )
+
+  it.each(allBlogPosts)('accepts the checked-in slug for "$title"', (post) => {
+    expectSafeResult(post.slug, post.slug)
+  })
+})


### PR DESCRIPTION
## Summary
- expand slug validation coverage for Unicode, punctuation, whitespace, hyphen, and traversal edge cases
- assert URL-path safety and deterministic output
- validate every checked-in blog slug

## Verification
- `TZ=UTC corepack pnpm@10 test`
- `corepack pnpm@10 typecheck`
- `corepack pnpm@10 lint`
- `corepack pnpm@10 build`

Closes #459