### PR TITLE
feat(maintainers): add loading skeleton to ApplicationsChart (#453)

### DIFF
--- a/src/features/maintainers/components/dashboard/ApplicationsChart.test.tsx
+++ b/src/features/maintainers/components/dashboard/ApplicationsChart.test.tsx
@@ -93,7 +93,7 @@ describe('ApplicationsChart Component', () => {
     render(<ApplicationsChart data={mockData} />)
     const table = screen.getByTestId('accessible-applications-table')
     expect(table).toBeInTheDocument()
-    expect(table).toHaveClass('visually-hidden')
+    expect(table).toHaveClass('sr-only')
     expect(table.textContent).toContain('Jan')
     expect(table.textContent).toContain('120')
     expect(table.textContent).toContain('80')
@@ -226,5 +226,63 @@ describe('ApplicationsChart Component', () => {
     expect(screen.getAllByText('Merged').length).toBeGreaterThanOrEqual(3)
     expect(screen.getAllByText('120').length).toBeGreaterThan(0)
     expect(screen.getAllByText('80').length).toBeGreaterThan(0)
+  })
+})
+
+describe('ApplicationsChart loading state', () => {
+  it('renders skeleton, real title, disabled toggle and busy region while loading', () => {
+    render(<ApplicationsChart data={[]} isLoading />)
+
+    expect(screen.getByTestId('chart-skeleton')).toBeInTheDocument()
+    expect(screen.getByText('Applications History')).toBeInTheDocument()
+
+    const toggle = screen.getByRole('button', { name: /view table/i })
+    expect(toggle).toBeDisabled()
+
+    const region = screen.getByRole('region')
+    expect(region).toHaveAttribute('aria-busy', 'true')
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.queryByText('No application history data available.')).not.toBeInTheDocument()
+  })
+
+  it('does not expose the role="img" data summary while loading', () => {
+    render(<ApplicationsChart data={[]} isLoading />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('replaces the skeleton with the chart and summary once data resolves', () => {
+    const { rerender } = render(<ApplicationsChart data={[]} isLoading />)
+    expect(screen.getByTestId('chart-skeleton')).toBeInTheDocument()
+
+    rerender(<ApplicationsChart data={mockData} isLoading={false} />)
+
+    expect(screen.queryByTestId('chart-skeleton')).not.toBeInTheDocument()
+    const chart = screen.getByRole('img')
+    expect(chart.getAttribute('aria-label')).toContain(
+      'Applications history chart showing data for 6 months'
+    )
+    expect(screen.getByRole('region')).toHaveAttribute('aria-busy', 'false')
+  })
+
+  it('omits the shimmer animation when prefers-reduced-motion is set', () => {
+    const originalMatchMedia = window.matchMedia
+    try {
+      window.matchMedia = ((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia
+
+      const { container } = render(<ApplicationsChart data={[]} isLoading />)
+      expect(container.querySelector('.animate-shimmer')).toBeNull()
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
   })
 })

--- a/src/features/maintainers/components/dashboard/ApplicationsChart.tsx
+++ b/src/features/maintainers/components/dashboard/ApplicationsChart.tsx
@@ -10,10 +10,12 @@ import {
   LabelList,
 } from 'recharts'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
+import { ChartSkeleton } from '../../../../shared/components/ChartSkeleton'
 import { ChartDataPoint } from '../../types'
 
 interface ApplicationsChartProps {
   data: ChartDataPoint[]
+  isLoading?: boolean
 }
 
 /**
@@ -80,7 +82,7 @@ export function generateApplicationsSummary(data: ChartDataPoint[]): string {
   return `Applications history chart showing data for ${data.length} months. Total applications: ${totalApplications}, Total merged: ${totalMerged}.${peakMonthText} Monthly breakdown: ${monthBreakdown}.`
 }
 
-export function ApplicationsChart({ data }: ApplicationsChartProps) {
+export function ApplicationsChart({ data, isLoading = false }: ApplicationsChartProps) {
   const { theme } = useTheme()
   const [showTable, setShowTable] = useState(false)
   const isDark = theme === 'dark'
@@ -107,6 +109,7 @@ export function ApplicationsChart({ data }: ApplicationsChartProps) {
     <div
       role="region"
       aria-labelledby="applications-chart-title"
+      aria-busy={isLoading}
       className={`backdrop-blur-[40px] rounded-[24px] border p-8 relative overflow-hidden group/chart transition-colors ${
         theme === 'dark' ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.12] border-white/20'
       }`}
@@ -135,12 +138,21 @@ export function ApplicationsChart({ data }: ApplicationsChartProps) {
           </div>
           <button
             onClick={() => setShowTable(!showTable)}
+            disabled={isLoading}
             aria-expanded={showTable}
             aria-controls="applications-data-table"
-            className={`px-4 py-2 text-[12px] font-bold rounded-[12px] border transition-all duration-300 flex items-center gap-2 hover:scale-[1.02] active:scale-[0.98] cursor-pointer ${
+            className={`px-4 py-2 text-[12px] font-bold rounded-[12px] border transition-all duration-300 flex items-center gap-2 ${
+              isLoading
+                ? 'opacity-40 cursor-not-allowed'
+                : 'hover:scale-[1.02] active:scale-[0.98] cursor-pointer'
+            } ${
               theme === 'dark'
-                ? 'bg-white/[0.05] border-white/10 text-[#e8dfd0] hover:bg-white/[0.1]'
-                : 'bg-white/[0.6] border-[#7a6b5a]/20 text-[#2d2820] hover:bg-white/[0.8] shadow-sm'
+                ? isLoading
+                  ? 'bg-white/[0.05] border-white/10 text-[#e8dfd0]'
+                  : 'bg-white/[0.05] border-white/10 text-[#e8dfd0] hover:bg-white/[0.1]'
+                : isLoading
+                  ? 'bg-white/[0.6] border-[#7a6b5a]/20 text-[#2d2820] shadow-sm'
+                  : 'bg-white/[0.6] border-[#7a6b5a]/20 text-[#2d2820] hover:bg-white/[0.8] shadow-sm'
             }`}
           >
             {showTable ? (
@@ -190,239 +202,260 @@ export function ApplicationsChart({ data }: ApplicationsChartProps) {
         </div>
 
         {/* Bar Chart Container */}
-        <div
-          role="img"
-          aria-label={summary}
-          className={`h-[320px] backdrop-blur-[25px] rounded-[16px] border p-6 transition-colors ${
-            showTable ? 'hidden' : 'block'
-          } ${theme === 'dark' ? 'bg-white/[0.05] border-white/10' : 'bg-white/[0.08] border-white/20'}`}
-        >
-          <div aria-hidden="true" className="w-full h-full">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={escapedData} barGap={4} aria-hidden="true">
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  stroke={
-                    theme === 'dark' ? 'rgba(184, 168, 152, 0.12)' : 'rgba(122, 107, 90, 0.15)'
-                  }
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="month"
-                  stroke={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
-                  tick={{
-                    fill: theme === 'dark' ? '#b8a898' : '#7a6b5a',
-                    fontSize: 12,
-                    fontWeight: 600,
-                  }}
-                  axisLine={{
-                    stroke:
-                      theme === 'dark' ? 'rgba(184, 168, 152, 0.2)' : 'rgba(122, 107, 90, 0.2)',
-                  }}
-                />
-                <YAxis
-                  stroke={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
-                  tick={{
-                    fill: theme === 'dark' ? '#b8a898' : '#7a6b5a',
-                    fontSize: 12,
-                    fontWeight: 600,
-                  }}
-                  axisLine={{
-                    stroke:
-                      theme === 'dark' ? 'rgba(184, 168, 152, 0.2)' : 'rgba(122, 107, 90, 0.2)',
-                  }}
-                />
-                <Tooltip
-                  cursor={{ fill: 'rgba(201, 152, 58, 0.08)' }}
-                  content={({ active, payload }) => {
-                    if (active && payload && payload.length) {
-                      return (
-                        <div
-                          className={`backdrop-blur-[40px] rounded-[14px] border px-5 py-4 ${tooltipBg}`}
-                        >
-                          <div className={`text-[13px] font-bold mb-2 ${tooltipTitleText}`}>
-                            {payload[0].payload.month}
-                          </div>
+        {isLoading ? (
+          <div
+            className={`h-[320px] backdrop-blur-[25px] rounded-[16px] border p-6 transition-colors block ${
+              theme === 'dark'
+                ? 'bg-white/[0.05] border-white/10'
+                : 'bg-white/[0.08] border-white/20'
+            }`}
+          >
+            <span role="status" className="sr-only">
+              Loading applications history…
+            </span>
+            <div aria-hidden="true" className="w-full h-full">
+              <ChartSkeleton showTitle={false} showLegend={false} barAreaHeight="100%" />
+            </div>
+          </div>
+        ) : (
+          <div
+            role="img"
+            aria-label={summary}
+            className={`h-[320px] backdrop-blur-[25px] rounded-[16px] border p-6 transition-colors ${
+              showTable ? 'hidden' : 'block'
+            } ${theme === 'dark' ? 'bg-white/[0.05] border-white/10' : 'bg-white/[0.08] border-white/20'}`}
+          >
+            <div aria-hidden="true" className="w-full h-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={escapedData} barGap={4} aria-hidden="true">
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke={
+                      theme === 'dark' ? 'rgba(184, 168, 152, 0.12)' : 'rgba(122, 107, 90, 0.15)'
+                    }
+                    vertical={false}
+                  />
+                  <XAxis
+                    dataKey="month"
+                    stroke={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
+                    tick={{
+                      fill: theme === 'dark' ? '#b8a898' : '#7a6b5a',
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                    axisLine={{
+                      stroke:
+                        theme === 'dark' ? 'rgba(184, 168, 152, 0.2)' : 'rgba(122, 107, 90, 0.2)',
+                    }}
+                  />
+                  <YAxis
+                    stroke={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
+                    tick={{
+                      fill: theme === 'dark' ? '#b8a898' : '#7a6b5a',
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                    axisLine={{
+                      stroke:
+                        theme === 'dark' ? 'rgba(184, 168, 152, 0.2)' : 'rgba(122, 107, 90, 0.2)',
+                    }}
+                  />
+                  <Tooltip
+                    cursor={{ fill: 'rgba(201, 152, 58, 0.08)' }}
+                    content={({ active, payload }) => {
+                      if (active && payload && payload.length) {
+                        return (
+                          <div
+                            className={`backdrop-blur-[40px] rounded-[14px] border px-5 py-4 ${tooltipBg}`}
+                          >
+                            <div className={`text-[13px] font-bold mb-2 ${tooltipTitleText}`}>
+                              {payload[0].payload.month}
+                            </div>
 
-                          {payload.map((entry: any, index: number) => (
-                            <div
-                              key={index}
-                              className="flex items-center justify-between gap-4 mb-1"
-                            >
-                              <div className="flex items-center gap-2">
-                                <div
-                                  className="w-3 h-3 rounded-full"
-                                  style={{ backgroundColor: entry.color }}
-                                />
-                                <span className={`text-[12px] font-medium ${tooltipLabelText}`}>
-                                  {entry.dataKey === 'applications' ? 'Applications' : 'Merged'}
+                            {payload.map((entry: any, index: number) => (
+                              <div
+                                key={index}
+                                className="flex items-center justify-between gap-4 mb-1"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <div
+                                    className="w-3 h-3 rounded-full"
+                                    style={{ backgroundColor: entry.color }}
+                                  />
+                                  <span className={`text-[12px] font-medium ${tooltipLabelText}`}>
+                                    {entry.dataKey === 'applications' ? 'Applications' : 'Merged'}
+                                  </span>
+                                </div>
+
+                                <span className={`text-[14px] font-bold ${tooltipValueText}`}>
+                                  {entry.value}
                                 </span>
                               </div>
+                            ))}
+                          </div>
+                        )
+                      }
 
-                              <span className={`text-[14px] font-bold ${tooltipValueText}`}>
-                                {entry.value}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      )
-                    }
+                      return null
+                    }}
+                  />
 
-                    return null
-                  }}
-                />
-
-                <Bar
-                  dataKey="applications"
-                  fill="url(#applicationsPattern)"
-                  radius={[8, 8, 0, 0]}
-                  animationBegin={0}
-                  animationDuration={800}
-                >
-                  <LabelList
+                  <Bar
                     dataKey="applications"
-                    position="top"
-                    fill={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
-                    fontSize={10}
-                    fontWeight={600}
-                  />
-                </Bar>
-                <Bar
-                  dataKey="merged"
-                  fill="url(#mergedGradient)"
-                  radius={[8, 8, 0, 0]}
-                  animationBegin={100}
-                  animationDuration={800}
-                >
-                  <LabelList
-                    dataKey="merged"
-                    position="top"
-                    fill={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
-                    fontSize={10}
-                    fontWeight={600}
-                  />
-                </Bar>
-                <defs>
-                  <linearGradient id="applicationsGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#c9983a" stopOpacity={0.9} />
-                    <stop offset="100%" stopColor="#d4af37" stopOpacity={0.6} />
-                  </linearGradient>
-                  <linearGradient id="mergedGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#4fb37a" stopOpacity={0.9} />
-                    <stop offset="100%" stopColor="#2e6947" stopOpacity={0.6} />
-                  </linearGradient>
-                  <pattern
-                    id="applicationsPattern"
-                    width="12"
-                    height="12"
-                    patternUnits="userSpaceOnUse"
-                    patternTransform="rotate(45)"
+                    fill="url(#applicationsPattern)"
+                    radius={[8, 8, 0, 0]}
+                    animationBegin={0}
+                    animationDuration={800}
                   >
-                    <rect width="12" height="12" fill="#c9983a" />
-                    <line
-                      x1="0"
-                      y1="0"
-                      x2="0"
-                      y2="12"
-                      stroke="#e8dfd0"
-                      strokeWidth="2.5"
-                      opacity="0.4"
+                    <LabelList
+                      dataKey="applications"
+                      position="top"
+                      fill={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
+                      fontSize={10}
+                      fontWeight={600}
                     />
-                  </pattern>
-                </defs>
-              </BarChart>
-            </ResponsiveContainer>
+                  </Bar>
+                  <Bar
+                    dataKey="merged"
+                    fill="url(#mergedGradient)"
+                    radius={[8, 8, 0, 0]}
+                    animationBegin={100}
+                    animationDuration={800}
+                  >
+                    <LabelList
+                      dataKey="merged"
+                      position="top"
+                      fill={theme === 'dark' ? '#b8a898' : '#7a6b5a'}
+                      fontSize={10}
+                      fontWeight={600}
+                    />
+                  </Bar>
+                  <defs>
+                    <linearGradient id="applicationsGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#c9983a" stopOpacity={0.9} />
+                      <stop offset="100%" stopColor="#d4af37" stopOpacity={0.6} />
+                    </linearGradient>
+                    <linearGradient id="mergedGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#4fb37a" stopOpacity={0.9} />
+                      <stop offset="100%" stopColor="#2e6947" stopOpacity={0.6} />
+                    </linearGradient>
+                    <pattern
+                      id="applicationsPattern"
+                      width="12"
+                      height="12"
+                      patternUnits="userSpaceOnUse"
+                      patternTransform="rotate(45)"
+                    >
+                      <rect width="12" height="12" fill="#c9983a" />
+                      <line
+                        x1="0"
+                        y1="0"
+                        x2="0"
+                        y2="12"
+                        stroke="#e8dfd0"
+                        strokeWidth="2.5"
+                        opacity="0.4"
+                      />
+                    </pattern>
+                  </defs>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Visually-hidden table below the chart for screen-reader traversal */}
-        <table className="visually-hidden" data-testid="accessible-applications-table">
-          <caption>Applications History Data</caption>
-          <thead>
-            <tr>
-              <th>Month</th>
-              <th>Applications</th>
-              <th>Merged</th>
-            </tr>
-          </thead>
-          <tbody>
-            {escapedData.length === 0 ? (
-              <tr>
-                <td colSpan={3}>No application history data available.</td>
-              </tr>
-            ) : (
-              escapedData.map((point) => (
-                <tr key={point.month}>
-                  <td>{point.month}</td>
-                  <td>{point.applications}</td>
-                  <td>{point.merged}</td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-
-        {/* Toggleable Data Table for Sighted Users */}
-        <div
-          id="applications-data-table"
-          aria-hidden="true"
-          className={
-            showTable
-              ? `h-[320px] overflow-y-auto backdrop-blur-[25px] rounded-[16px] border p-6 transition-all duration-300 ${
-                  theme === 'dark'
-                    ? 'bg-white/[0.05] border-white/10'
-                    : 'bg-white/[0.08] border-white/20'
-                }`
-              : 'hidden'
-          }
-        >
-          <table className="w-full text-left border-collapse">
+        {!isLoading && (
+          <table className="sr-only" data-testid="accessible-applications-table">
+            <caption>Applications History Data</caption>
             <thead>
-              <tr
-                className={`border-b text-[12px] font-bold uppercase tracking-wider ${
-                  theme === 'dark'
-                    ? 'border-white/10 text-[#b8a898]'
-                    : 'border-neutral-200 text-[#7a6b5a]'
-                }`}
-              >
-                <th className="pb-3">Month</th>
-                <th className="pb-3 text-right">Applications</th>
-                <th className="pb-3 text-right">Merged</th>
+              <tr>
+                <th>Month</th>
+                <th>Applications</th>
+                <th>Merged</th>
               </tr>
             </thead>
-            <tbody
-              className={`text-[14px] font-medium ${
-                theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-              }`}
-            >
+            <tbody>
               {escapedData.length === 0 ? (
                 <tr>
-                  <td
-                    colSpan={3}
-                    className={`py-8 text-center text-sm ${
-                      theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                    }`}
-                  >
-                    No application history data available.
-                  </td>
+                  <td colSpan={3}>No application history data available.</td>
                 </tr>
               ) : (
                 escapedData.map((point) => (
-                  <tr
-                    key={point.month}
-                    className={`border-b last:border-0 hover:bg-white/[0.02] transition-colors ${
-                      theme === 'dark' ? 'border-white/5' : 'border-neutral-100'
-                    }`}
-                  >
-                    <td className="py-3 font-semibold">{point.month}</td>
-                    <td className="py-3 text-right">{point.applications}</td>
-                    <td className="py-3 text-right">{point.merged}</td>
+                  <tr key={point.month}>
+                    <td>{point.month}</td>
+                    <td>{point.applications}</td>
+                    <td>{point.merged}</td>
                   </tr>
                 ))
               )}
             </tbody>
           </table>
-        </div>
+        )}
+
+        {/* Toggleable Data Table for Sighted Users */}
+        {!isLoading && (
+          <div
+            id="applications-data-table"
+            aria-hidden="true"
+            className={
+              showTable
+                ? `h-[320px] overflow-y-auto backdrop-blur-[25px] rounded-[16px] border p-6 transition-all duration-300 ${
+                    theme === 'dark'
+                      ? 'bg-white/[0.05] border-white/10'
+                      : 'bg-white/[0.08] border-white/20'
+                  }`
+                : 'hidden'
+            }
+          >
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr
+                  className={`border-b text-[12px] font-bold uppercase tracking-wider ${
+                    theme === 'dark'
+                      ? 'border-white/10 text-[#b8a898]'
+                      : 'border-neutral-200 text-[#7a6b5a]'
+                  }`}
+                >
+                  <th className="pb-3">Month</th>
+                  <th className="pb-3 text-right">Applications</th>
+                  <th className="pb-3 text-right">Merged</th>
+                </tr>
+              </thead>
+              <tbody
+                className={`text-[14px] font-medium ${
+                  theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+                }`}
+              >
+                {escapedData.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={3}
+                      className={`py-8 text-center text-sm ${
+                        theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                      }`}
+                    >
+                      No application history data available.
+                    </td>
+                  </tr>
+                ) : (
+                  escapedData.map((point) => (
+                    <tr
+                      key={point.month}
+                      className={`border-b last:border-0 hover:bg-white/[0.02] transition-colors ${
+                        theme === 'dark' ? 'border-white/5' : 'border-neutral-100'
+                      }`}
+                    >
+                      <td className="py-3 font-semibold">{point.month}</td>
+                      <td className="py-3 text-right">{point.applications}</td>
+                      <td className="py-3 text-right">{point.merged}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
 
         {/* Legend */}
         <div className="flex items-center justify-center gap-6 mt-5" aria-hidden="true">

--- a/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
@@ -327,4 +327,24 @@ describe('DashboardTab', () => {
     // The value displayed in the card should be 0 (not NaN)
     expect(card).toHaveTextContent('0')
   })
+
+  it('shows the applications chart skeleton while projects are still loading', () => {
+    render(<DashboardTab selectedProjects={[]} isLoadingProjects={true} />)
+    expect(screen.getByTestId('chart-skeleton')).toBeInTheDocument()
+  })
+
+  it('renders the applications chart and hides the skeleton once data resolves', async () => {
+    vi.mocked(getProjectIssues).mockResolvedValue({ issues: [] } as any)
+    vi.mocked(getProjectPRs).mockResolvedValue({ prs: [] } as any)
+
+    render(<DashboardTab selectedProjects={mockProjects} isLoadingProjects={false} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Issue Views')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('chart-skeleton')).not.toBeInTheDocument()
+    // Loaded chart exposes its accessible data summary via role="img".
+    expect(screen.getByRole('img')).toBeInTheDocument()
+  })
 })

--- a/src/features/maintainers/components/dashboard/DashboardTab.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.tsx
@@ -1,20 +1,19 @@
-import { logger } from '../../../../shared/utils/logger';
-import { useEffect, useState, useMemo, useCallback } from 'react';
-import { FileText, GitPullRequest, GitMerge, AlertCircle, FolderOpen } from 'lucide-react';
-import { useTheme } from '../../../../shared/contexts/ThemeContext';
-import { StatsCard } from './StatsCard';
-import { StatsCardSkeleton } from './StatsCardSkeleton';
-import { ActivityItem } from './ActivityItem';
-import { ApplicationsChart } from './ApplicationsChart';
-import { StatCard, Activity, ChartDataPoint } from '../../types';
-import { getProjectIssues, getProjectPRs } from '../../../../shared/api/client';
-import { ActivityItemSkeleton } from '../../../../shared/components/ActivityItemSkeleton';
-import { ChartSkeleton } from '../../../../shared/components/ChartSkeleton';
+import { logger } from '../../../../shared/utils/logger'
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import { FileText, GitPullRequest, GitMerge, AlertCircle, FolderOpen } from 'lucide-react'
+import { useTheme } from '../../../../shared/contexts/ThemeContext'
+import { StatsCard } from './StatsCard'
+import { StatsCardSkeleton } from './StatsCardSkeleton'
+import { ActivityItem } from './ActivityItem'
+import { ApplicationsChart } from './ApplicationsChart'
+import { StatCard, Activity, ChartDataPoint } from '../../types'
+import { getProjectIssues, getProjectPRs } from '../../../../shared/api/client'
+import { ActivityItemSkeleton } from '../../../../shared/components/ActivityItemSkeleton'
 
 interface Project {
-  id: string;
-  github_full_name: string;
-  status: string;
+  id: string
+  github_full_name: string
+  status: string
 }
 
 /**
@@ -22,14 +21,14 @@ interface Project {
  */
 interface DashboardTabProps {
   /** The list of projects currently selected in the sidebar. */
-  selectedProjects: Project[];
+  selectedProjects: Project[]
   /** When true, parent is still loading the project list; show loading skeleton instead of empty state. */
-  isLoadingProjects?: boolean;
-  onRefresh?: () => void;
+  isLoadingProjects?: boolean
+  onRefresh?: () => void
   /** Called when the user clicks an issue activity row, with the issue id and owning project id. */
-  onNavigateToIssue?: (issueId: string, projectId: string) => void;
+  onNavigateToIssue?: (issueId: string, projectId: string) => void
   /** Called when the user clicks a PR activity row, with the PR id. */
-  onNavigateToPR?: (prId: string) => void;
+  onNavigateToPR?: (prId: string) => void
 }
 
 /**
@@ -37,7 +36,7 @@ interface DashboardTabProps {
  * Defends against NaN/Infinity leaking into displayed stats.
  */
 function safeStatValue(v: number): number {
-  return Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+  return Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0
 }
 
 /**
@@ -55,16 +54,21 @@ function safeStatValue(v: number): number {
  * Empty state:
  * - When no project is selected a CTA prompt is rendered instead of empty data.
  */
-export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNavigateToIssue, onNavigateToPR }: DashboardTabProps) {
-  const { theme } = useTheme();
-  const [issues, setIssues] = useState<any[]>([]);
-  const [prs, setPrs] = useState<any[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [showAllActivities, setShowAllActivities] = useState(false);
+export function DashboardTab({
+  selectedProjects,
+  isLoadingProjects = false,
+  onNavigateToIssue,
+  onNavigateToPR,
+}: DashboardTabProps) {
+  const { theme } = useTheme()
+  const [issues, setIssues] = useState<any[]>([])
+  const [prs, setPrs] = useState<any[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showAllActivities, setShowAllActivities] = useState(false)
 
   // Show loading when parent is loading projects OR when we're loading dashboard data
-  const showLoading = isLoadingProjects || isLoading;
+  const showLoading = isLoadingProjects || isLoading
 
   /**
    * Return a navigation handler only when the activity row has a valid destination.
@@ -72,178 +76,190 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
    */
   const getActivityClickHandler = (activity: Activity) => {
     if (activity.type === 'issue' && activity.projectId && onNavigateToIssue) {
-      return () => onNavigateToIssue(activity.id.toString(), activity.projectId!);
+      return () => onNavigateToIssue(activity.id.toString(), activity.projectId!)
     }
 
     if (activity.type === 'pr' && onNavigateToPR) {
-      return () => onNavigateToPR(activity.id.toString());
+      return () => onNavigateToPR(activity.id.toString())
     }
 
-    return undefined;
-  };
+    return undefined
+  }
 
   // Fetch data from selected projects (only when parent has finished loading and we have projects)
   useEffect(() => {
-    if (isLoadingProjects) return;
-    loadData();
+    if (isLoadingProjects) return
+    loadData()
     // Reset expanded state when projects change
-    setShowAllActivities(false);
-  }, [selectedProjects, isLoadingProjects]);
+    setShowAllActivities(false)
+  }, [selectedProjects, isLoadingProjects])
 
   const loadData = async () => {
-    setIsLoading(true);
-    setError(null);
+    setIsLoading(true)
+    setError(null)
     try {
       if (selectedProjects.length === 0) {
-        setIssues([]);
-        setPrs([]);
-        setIsLoading(false);
-        return;
+        setIssues([])
+        setPrs([])
+        setIsLoading(false)
+        return
       }
 
       // Track how many per-project fetches fail so we can surface an error
       // if every single request bounces (network down, auth expired, etc.).
-      let fetchFailures = 0;
-      const totalFetches = selectedProjects.length * 2;
+      let fetchFailures = 0
+      const totalFetches = selectedProjects.length * 2
 
       // Fetch issues and PRs from all selected projects
       const [issuesData, prsData] = await Promise.all([
-        Promise.all(selectedProjects.map(async (project) => {
-          try {
-            const response = await getProjectIssues(project.id);
-            return (response.issues || []).map((issue: any) => ({
-              ...issue,
-              projectName: project.github_full_name,
-            }));
-          } catch (err) {
-            logger.error(`Failed to fetch issues for ${project.github_full_name}:`, err);
-            fetchFailures++;
-            return [];
-          }
-        })),
-        Promise.all(selectedProjects.map(async (project) => {
-          try {
-            const response = await getProjectPRs(project.id);
-            return (response.prs || []).map((pr: any) => ({
-              ...pr,
-              projectName: project.github_full_name,
-            }));
-          } catch (err) {
-            logger.error(`Failed to fetch PRs for ${project.github_full_name}:`, err);
-            fetchFailures++;
-            return [];
-          }
-        })),
-      ]);
+        Promise.all(
+          selectedProjects.map(async (project) => {
+            try {
+              const response = await getProjectIssues(project.id)
+              return (response.issues || []).map((issue: any) => ({
+                ...issue,
+                projectName: project.github_full_name,
+              }))
+            } catch (err) {
+              logger.error(`Failed to fetch issues for ${project.github_full_name}:`, err)
+              fetchFailures++
+              return []
+            }
+          })
+        ),
+        Promise.all(
+          selectedProjects.map(async (project) => {
+            try {
+              const response = await getProjectPRs(project.id)
+              return (response.prs || []).map((pr: any) => ({
+                ...pr,
+                projectName: project.github_full_name,
+              }))
+            } catch (err) {
+              logger.error(`Failed to fetch PRs for ${project.github_full_name}:`, err)
+              fetchFailures++
+              return []
+            }
+          })
+        ),
+      ])
 
       // All fetches failed — surface an error instead of displaying empty data
       if (fetchFailures >= totalFetches) {
-        setError('Failed to load dashboard data. Please try again.');
-        setIsLoading(false);
-        return;
+        setError('Failed to load dashboard data. Please try again.')
+        setIsLoading(false)
+        return
       }
 
-      const allIssues = issuesData.flat();
-      const allPRs = prsData.flat();
+      const allIssues = issuesData.flat()
+      const allPRs = prsData.flat()
 
       // Sort by updated_at (most recent first)
       allIssues.sort((a, b) => {
-        const dateA = a.updated_at ? new Date(a.updated_at).getTime() : new Date(a.last_seen_at).getTime();
-        const dateB = b.updated_at ? new Date(b.updated_at).getTime() : new Date(b.last_seen_at).getTime();
-        return dateB - dateA;
-      });
+        const dateA = a.updated_at
+          ? new Date(a.updated_at).getTime()
+          : new Date(a.last_seen_at).getTime()
+        const dateB = b.updated_at
+          ? new Date(b.updated_at).getTime()
+          : new Date(b.last_seen_at).getTime()
+        return dateB - dateA
+      })
 
       allPRs.sort((a, b) => {
-        const dateA = a.updated_at ? new Date(a.updated_at).getTime() : new Date(a.last_seen_at).getTime();
-        const dateB = b.updated_at ? new Date(b.updated_at).getTime() : new Date(b.last_seen_at).getTime();
-        return dateB - dateA;
-      });
+        const dateA = a.updated_at
+          ? new Date(a.updated_at).getTime()
+          : new Date(a.last_seen_at).getTime()
+        const dateB = b.updated_at
+          ? new Date(b.updated_at).getTime()
+          : new Date(b.last_seen_at).getTime()
+        return dateB - dateA
+      })
 
-      setIssues(allIssues);
-      setPrs(allPRs);
-      setIsLoading(false);
+      setIssues(allIssues)
+      setPrs(allPRs)
+      setIsLoading(false)
     } catch (err) {
-      logger.error('Failed to load dashboard data:', err);
-      setError('Failed to load dashboard data. Please try again.');
-      setIsLoading(false);
+      logger.error('Failed to load dashboard data:', err)
+      setError('Failed to load dashboard data. Please try again.')
+      setIsLoading(false)
     }
-  };
+  }
 
   // Refresh data when page becomes visible (user switches back to tab)
   // And when repositories are refreshed (new repo added)
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible' && selectedProjects.length > 0) {
-        loadData();
+        loadData()
       }
-    };
+    }
 
     const handleRepositoriesRefreshed = () => {
       // Refresh dashboard data when repositories are added/updated
       if (selectedProjects.length > 0) {
-        loadData();
+        loadData()
       }
-    };
+    }
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('repositories-refreshed', handleRepositoriesRefreshed);
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('repositories-refreshed', handleRepositoriesRefreshed)
 
     return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('repositories-refreshed', handleRepositoriesRefreshed);
-    };
-  }, [selectedProjects]);
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('repositories-refreshed', handleRepositoriesRefreshed)
+    }
+  }, [selectedProjects])
 
   // Helper function to format time ago (memoized to prevent unnecessary re-renders)
   const formatTimeAgo = useCallback((date: Date): string => {
-    const timeMs = date.getTime();
+    const timeMs = date.getTime()
     if (isNaN(timeMs)) {
-      return 'unknown time';
+      return 'unknown time'
     }
-    const now = new Date();
-    const diffMs = now.getTime() - timeMs;
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-    const diffMonths = Math.floor(diffDays / 30);
+    const now = new Date()
+    const diffMs = now.getTime() - timeMs
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMs / 3600000)
+    const diffDays = Math.floor(diffMs / 86400000)
+    const diffMonths = Math.floor(diffDays / 30)
 
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`;
-    if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
-    if (diffDays < 30) return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
-    return `${diffMonths} month${diffMonths !== 1 ? 's' : ''} ago`;
-  }, []);
+    if (diffMins < 1) return 'just now'
+    if (diffMins < 60) return `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`
+    if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`
+    if (diffDays < 30) return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`
+    return `${diffMonths} month${diffMonths !== 1 ? 's' : ''} ago`
+  }, [])
 
   /**
    * Safely parses a date string, returning its Unix timestamp in milliseconds.
    * Returns 0 if the date string is null, undefined, or invalid to prevent NaN sorting issues.
-   * 
+   *
    * @param dateStr - The date string to parse.
    * @returns The parsed Unix time in milliseconds, or 0 if invalid.
    */
   const safeParseDate = useCallback((dateStr?: string | null): number => {
-    if (!dateStr) return 0;
-    const parsed = Date.parse(dateStr);
-    return isNaN(parsed) ? 0 : parsed;
-  }, []);
+    if (!dateStr) return 0
+    const parsed = Date.parse(dateStr)
+    return isNaN(parsed) ? 0 : parsed
+  }, [])
 
   // Calculate stats from real data
   const stats: StatCard[] = useMemo(() => {
-    const now = new Date();
-    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const now = new Date()
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
 
-    const recentIssues = issues.filter(issue => {
-      const updatedAt = issue.updated_at ? new Date(issue.updated_at) : new Date(issue.last_seen_at);
-      return updatedAt >= sevenDaysAgo;
-    });
+    const recentIssues = issues.filter((issue) => {
+      const updatedAt = issue.updated_at ? new Date(issue.updated_at) : new Date(issue.last_seen_at)
+      return updatedAt >= sevenDaysAgo
+    })
 
-    const recentPRs = prs.filter(pr => {
-      const updatedAt = pr.updated_at ? new Date(pr.updated_at) : new Date(pr.last_seen_at);
-      return updatedAt >= sevenDaysAgo;
-    });
+    const recentPRs = prs.filter((pr) => {
+      const updatedAt = pr.updated_at ? new Date(pr.updated_at) : new Date(pr.last_seen_at)
+      return updatedAt >= sevenDaysAgo
+    })
 
-    const openedPRs = recentPRs.filter(pr => pr.state === 'open');
-    const mergedPRs = recentPRs.filter(pr => pr.merged === true);
+    const openedPRs = recentPRs.filter((pr) => pr.state === 'open')
+    const mergedPRs = recentPRs.filter((pr) => pr.merged === true)
 
     return [
       {
@@ -258,7 +274,9 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         id: 2,
         title: 'Issue Applications',
         subtitle: 'Last 7 days',
-        value: safeStatValue(recentIssues.reduce((sum, issue) => sum + (issue.comments_count || 0), 0)),
+        value: safeStatValue(
+          recentIssues.reduce((sum, issue) => sum + (issue.comments_count || 0), 0)
+        ),
         change: 0,
         icon: FileText,
       },
@@ -278,16 +296,16 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         change: mergedPRs.length > 0 ? 100 : 0,
         icon: GitMerge,
       },
-    ];
-  }, [issues, prs]);
+    ]
+  }, [issues, prs])
 
   // Generate activity from real data
   const activities: Activity[] = useMemo(() => {
-    const combined: Activity[] = [];
+    const combined: Activity[] = []
 
     // Add recent PRs
-    prs.slice(0, 10).forEach(pr => {
-      const timestamp = pr.updated_at || pr.last_seen_at || '';
+    prs.slice(0, 10).forEach((pr) => {
+      const timestamp = pr.updated_at || pr.last_seen_at || ''
       combined.push({
         id: pr.github_pr_id,
         type: 'pr',
@@ -296,66 +314,71 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         label: pr.merged ? 'Merged' : pr.state === 'open' ? 'Open' : 'Closed',
         timestamp,
         timeAgo: timestamp ? formatTimeAgo(new Date(timestamp)) : 'unknown time',
-      });
-    });
+      })
+    })
 
     // Add recent issues
-    issues.slice(0, 10).forEach(issue => {
-      const timestamp = issue.updated_at || issue.last_seen_at || '';
+    issues.slice(0, 10).forEach((issue) => {
+      const timestamp = issue.updated_at || issue.last_seen_at || ''
       combined.push({
         id: issue.github_issue_id,
         type: 'issue',
         number: issue.number,
         title: issue.title,
-        label: issue.comments_count > 0 ? `${issue.comments_count} comment${issue.comments_count !== 1 ? 's' : ''}` : null,
+        label:
+          issue.comments_count > 0
+            ? `${issue.comments_count} comment${issue.comments_count !== 1 ? 's' : ''}`
+            : null,
         projectId: issue.projectId,
         timestamp,
         timeAgo: timestamp ? formatTimeAgo(new Date(timestamp)) : 'unknown time',
-      });
-    });
+      })
+    })
 
     // Sort by timestamp (most recent first) with stable tie-breaking
-    const indexed = combined.map((activity, idx) => ({ activity, idx }));
+    const indexed = combined.map((activity, idx) => ({ activity, idx }))
     indexed.sort((a, b) => {
-      const timeA = safeParseDate(a.activity.timestamp);
-      const timeB = safeParseDate(b.activity.timestamp);
+      const timeA = safeParseDate(a.activity.timestamp)
+      const timeB = safeParseDate(b.activity.timestamp)
       if (timeB !== timeA) {
-        return timeB - timeA;
+        return timeB - timeA
       }
-      return a.idx - b.idx; // Stable tie-breaking using original array indices
-    });
+      return a.idx - b.idx // Stable tie-breaking using original array indices
+    })
 
-    return indexed.map(item => item.activity);
-  }, [issues, prs, formatTimeAgo, safeParseDate]);
+    return indexed.map((item) => item.activity)
+  }, [issues, prs, formatTimeAgo, safeParseDate])
 
   // Generate chart data from real data (last 6 months)
   const chartData: ChartDataPoint[] = useMemo(() => {
-    const months = ['May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct'];
-    const now = new Date();
+    const months = ['May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct']
+    const now = new Date()
 
     return months.map((month, index) => {
-      const monthDate = new Date(now.getFullYear(), now.getMonth() - (5 - index), 1);
-      const nextMonth = new Date(now.getFullYear(), now.getMonth() - (4 - index), 1);
+      const monthDate = new Date(now.getFullYear(), now.getMonth() - (5 - index), 1)
+      const nextMonth = new Date(now.getFullYear(), now.getMonth() - (4 - index), 1)
 
-      const monthIssues = issues.filter(issue => {
-        const createdAt = issue.updated_at ? new Date(issue.updated_at) : new Date(issue.last_seen_at);
-        return createdAt >= monthDate && createdAt < nextMonth;
-      });
+      const monthIssues = issues.filter((issue) => {
+        const createdAt = issue.updated_at
+          ? new Date(issue.updated_at)
+          : new Date(issue.last_seen_at)
+        return createdAt >= monthDate && createdAt < nextMonth
+      })
 
-      const monthPRs = prs.filter(pr => {
-        const createdAt = pr.updated_at ? new Date(pr.updated_at) : new Date(pr.last_seen_at);
-        return createdAt >= monthDate && createdAt < nextMonth;
-      });
+      const monthPRs = prs.filter((pr) => {
+        const createdAt = pr.updated_at ? new Date(pr.updated_at) : new Date(pr.last_seen_at)
+        return createdAt >= monthDate && createdAt < nextMonth
+      })
 
-      const mergedPRs = monthPRs.filter(pr => pr.merged);
+      const mergedPRs = monthPRs.filter((pr) => pr.merged)
 
       return {
         month,
         applications: monthIssues.reduce((sum, issue) => sum + (issue.comments_count || 0), 0),
         merged: mergedPRs.length,
-      };
-    });
-  }, [issues, prs]);
+      }
+    })
+  }, [issues, prs])
 
   // No-project CTA — rendered before skeleton/error so parent loading is still covered
   if (!showLoading && !error && selectedProjects.length === 0) {
@@ -369,14 +392,16 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         data-testid="empty-state"
       >
         <FolderOpen className="w-12 h-12 mb-4 opacity-40" />
-        <h2 className={`text-[18px] font-bold mb-2 ${theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+        <h2
+          className={`text-[18px] font-bold mb-2 ${theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}
+        >
           No repository selected
         </h2>
         <p className="text-[14px] max-w-xs">
           Select one or more repositories from the sidebar to view your dashboard stats.
         </p>
       </div>
-    );
+    )
   }
 
   // Error state — replaces all content and offers a retry
@@ -391,7 +416,9 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
         data-testid="error-state"
       >
         <AlertCircle className="w-12 h-12 mb-4 text-red-400" />
-        <h2 className={`text-[18px] font-bold mb-2 ${theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}>
+        <h2
+          className={`text-[18px] font-bold mb-2 ${theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'}`}
+        >
           Failed to load dashboard
         </h2>
         <p className="text-[14px] mb-6 max-w-xs">{error}</p>
@@ -402,37 +429,39 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
           Retry
         </button>
       </div>
-    );
+    )
   }
 
   return (
     <>
       {/* Stats Cards */}
       <div className="grid grid-cols-4 gap-5">
-        {showLoading ? (
-          [...Array(4)].map((_, idx) => (
-            <StatsCardSkeleton key={idx} />
-          ))
-        ) : (
-          stats.map((stat, idx) => (
-            <StatsCard key={stat.id} stat={stat} index={idx} />
-          ))
-        )}
+        {showLoading
+          ? [...Array(4)].map((_, idx) => <StatsCardSkeleton key={idx} />)
+          : stats.map((stat, idx) => <StatsCard key={stat.id} stat={stat} index={idx} />)}
       </div>
 
       {/* Main Content: Last Activity & Applications History */}
       <div className="grid grid-cols-2 gap-6">
         {/* Last Activity */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 relative overflow-hidden group/activity transition-colors ${theme === 'dark'
-          ? 'bg-[#2d2820]/[0.4] border-white/10'
-          : 'bg-white/[0.12] border-white/20'
-          }`}>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-8 relative overflow-hidden group/activity transition-colors ${
+            theme === 'dark'
+              ? 'bg-[#2d2820]/[0.4] border-white/10'
+              : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
           {/* Background Glow */}
           <div className="absolute bottom-0 left-0 w-80 h-80 bg-gradient-to-tr from-[#c9983a]/8 to-transparent rounded-full blur-3xl pointer-events-none group-hover/activity:scale-125 transition-transform duration-1000" />
 
           <div className="relative">
-            <h2 className={`text-[20px] font-bold mb-6 transition-colors ${theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-              }`}>Last activity</h2>
+            <h2
+              className={`text-[20px] font-bold mb-6 transition-colors ${
+                theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+              }`}
+            >
+              Last activity
+            </h2>
 
             {/* Activity List */}
             {showLoading ? (
@@ -445,18 +474,22 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
               <>
                 <div className="space-y-3">
                   {activities.length === 0 ? (
-                    <div className={`text-center py-8 ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}>
+                    <div
+                      className={`text-center py-8 ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`}
+                    >
                       No recent activity found.
                     </div>
                   ) : (
-                    (showAllActivities ? activities : activities.slice(0, 5)).map((activity, idx) => (
-                      <ActivityItem
-                        key={activity.id}
-                        activity={activity}
-                        index={idx}
-                        onClick={getActivityClickHandler(activity)}
-                      />
-                    ))
+                    (showAllActivities ? activities : activities.slice(0, 5)).map(
+                      (activity, idx) => (
+                        <ActivityItem
+                          key={activity.id}
+                          activity={activity}
+                          index={idx}
+                          onClick={getActivityClickHandler(activity)}
+                        />
+                      )
+                    )
                   )}
                 </div>
                 {/* View More / Show Less Button */}
@@ -477,18 +510,10 @@ export function DashboardTab({ selectedProjects, isLoadingProjects = false, onNa
           </div>
         </div>
 
-        {/* Applications History */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 relative overflow-hidden group/chart transition-colors ${theme === 'dark'
-          ? 'bg-[#2d2820]/[0.4] border-white/10'
-          : 'bg-white/[0.12] border-white/20'
-          }`}>
-          {showLoading ? (
-            <ChartSkeleton />
-          ) : (
-            <ApplicationsChart data={chartData} />
-          )}
-        </div>
+        {/* Applications History — the chart owns its card and loading skeleton so
+            both states share one layout and cannot shift between each other. */}
+        <ApplicationsChart data={chartData} isLoading={showLoading} />
       </div>
     </>
-  );
+  )
 }

--- a/src/shared/components/ChartSkeleton.test.tsx
+++ b/src/shared/components/ChartSkeleton.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ChartSkeleton } from './ChartSkeleton'
+
+vi.mock('./SkeletonLoader', () => ({
+  SkeletonLoader: ({
+    width,
+    height,
+    className,
+  }: {
+    width?: string
+    height?: string
+    className?: string
+  }) => (
+    <div
+      data-testid="skeleton-loader"
+      data-width={width}
+      data-height={height}
+      className={className}
+    />
+  ),
+}))
+
+describe('ChartSkeleton', () => {
+  it('renders title and legend sections and six bars by default', () => {
+    const { container } = render(<ChartSkeleton />)
+
+    expect(screen.getByTestId('chart-skeleton')).toBeInTheDocument()
+
+    const barArea = container.querySelector('[data-testid="chart-skeleton"] .flex.items-end')
+    expect(barArea).not.toBeNull()
+    // Six bar columns, each wrapping a bar + an x-axis label placeholder
+    expect(barArea?.children.length).toBe(6)
+
+    // Legend row present by default
+    expect(container.querySelector('.justify-center')).not.toBeNull()
+  })
+
+  it('produces identical markup across two renders (deterministic bar heights)', () => {
+    const first = render(<ChartSkeleton />).container.innerHTML
+    const second = render(<ChartSkeleton />).container.innerHTML
+    expect(first).toBe(second)
+  })
+
+  it('omits the title section when showTitle is false', () => {
+    const { container } = render(<ChartSkeleton showTitle={false} />)
+    // With no title, the first child of the skeleton is the chart area wrapper,
+    // which contains the bar area.
+    const firstChild = container.querySelector('[data-testid="chart-skeleton"] > div:first-child')
+    expect(firstChild?.querySelector('.flex.items-end')).not.toBeNull()
+  })
+
+  it('omits the legend section when showLegend is false', () => {
+    const { container } = render(<ChartSkeleton showLegend={false} />)
+    expect(container.querySelector('.justify-center')).toBeNull()
+  })
+
+  it('applies barAreaHeight to the bar area container', () => {
+    const { container } = render(<ChartSkeleton barAreaHeight="100%" />)
+    const barArea = container.querySelector(
+      '[data-testid="chart-skeleton"] .flex.items-end'
+    ) as HTMLElement
+    expect(barArea?.style.height).toBe('100%')
+  })
+})

--- a/src/shared/components/ChartSkeleton.tsx
+++ b/src/shared/components/ChartSkeleton.tsx
@@ -1,44 +1,58 @@
 import { SkeletonLoader } from './SkeletonLoader'
 
-export function ChartSkeleton() {
-  return (
-    <div className="space-y-6" data-testid="chart-skeleton">
-      {/* Chart Title Skeleton */}
-      <div className="space-y-2">
-        <SkeletonLoader variant="text" width="200px" height="24px" />
-        <SkeletonLoader variant="text" width="150px" height="14px" />
-      </div>
+interface ChartSkeletonProps {
+  showTitle?: boolean
+  showLegend?: boolean
+  barAreaHeight?: string
+}
 
-      {/* Chart Area Skeleton */}
-      <div className="space-y-4">
-        {/* Y-axis labels skeleton */}
-        <div className="flex items-end gap-4 h-[200px]">
-          {[...Array(6)].map((_, idx) => (
-            <div key={idx} className="flex-1 flex flex-col items-center gap-2">
-              {/* Bar skeleton */}
+// Fixed heights keep the placeholder deterministic so the markup is stable
+// across re-renders and assertable in tests.
+const BAR_HEIGHTS = ['65%', '45%', '80%', '55%', '90%', '70%']
+
+export function ChartSkeleton({
+  showTitle = true,
+  showLegend = true,
+  barAreaHeight = '200px',
+}: ChartSkeletonProps) {
+  return (
+    <div className="space-y-6 h-full" data-testid="chart-skeleton">
+      {showTitle && (
+        <div className="space-y-2">
+          <SkeletonLoader variant="text" width="200px" height="24px" />
+          <SkeletonLoader variant="text" width="150px" height="14px" />
+        </div>
+      )}
+
+      <div className="space-y-4 h-full">
+        {/* Explicit bar-area height lets callers fill a fixed container; without
+            it a percentage height would collapse against the auto-sized parent. */}
+        <div className="flex items-end gap-4" style={{ height: barAreaHeight }}>
+          {BAR_HEIGHTS.map((height, idx) => (
+            <div key={idx} className="flex-1 flex flex-col items-center justify-end gap-2 h-full">
               <SkeletonLoader
                 variant="default"
                 width="100%"
-                height={`${Math.random() * 60 + 40}%`}
+                height={height}
                 className="rounded-t-[8px]"
               />
-              {/* X-axis label skeleton */}
               <SkeletonLoader variant="text" width="40px" height="12px" />
             </div>
           ))}
         </div>
 
-        {/* Legend Skeleton */}
-        <div className="flex items-center gap-4 justify-center pt-4">
-          <div className="flex items-center gap-2">
-            <SkeletonLoader variant="circle" width="12px" height="12px" />
-            <SkeletonLoader variant="text" width="80px" height="12px" />
+        {showLegend && (
+          <div className="flex items-center gap-4 justify-center pt-4">
+            <div className="flex items-center gap-2">
+              <SkeletonLoader variant="circle" width="12px" height="12px" />
+              <SkeletonLoader variant="text" width="80px" height="12px" />
+            </div>
+            <div className="flex items-center gap-2">
+              <SkeletonLoader variant="circle" width="12px" height="12px" />
+              <SkeletonLoader variant="text" width="60px" height="12px" />
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <SkeletonLoader variant="circle" width="12px" height="12px" />
-            <SkeletonLoader variant="text" width="60px" height="12px" />
-          </div>
-        </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Dear Maintainer,
First things first, thank you for the opportunity to contribute. Here's what I did:

## Summary

`ApplicationsChart` used to pop in abruptly once dashboard data resolved,
unlike `StatsCard` which already had a skeleton. This adds a dimensioned
loading skeleton so the chart animates in without a layout shift.

Closes #453.

Also fixes a pre-existing a11y defect found during visual review: the accessible
data table used an undefined `visually-hidden` class and was rendering visibly.

## What changed

- **`ChartSkeleton`** gains optional, backward-compatible props — `showTitle`,
  `showLegend` (default `true`) and `barAreaHeight` (default `'200px'`) — plus
  deterministic bar heights (replacing `Math.random()`). With the defaults its
  existing consumers (`DataPage`) render with the same structure and dimensions,
  and the placeholder is now stable across re-renders.
- **`ApplicationsChart`** takes an `isLoading` prop. While loading it renders the
  *same* card, header and legend as the loaded state, with the skeleton living
  only inside the fixed `h-[320px]` data container. This makes "no layout shift"
  a structural property (same DOM except the container interior), not a
  hand-maintained mirror.
- **`DashboardTab`** drops the extra wrapping card + ternary and passes
  `isLoading={showLoading}` straight to the chart, removing the double-nested
  card that was the actual cause of the height jump.

## Accessibility

- `aria-busy` on the chart region while loading.
- An `sr-only` `role="status"` announces the loading state to screen readers.
- The "View Table" toggle is **disabled** (not hidden) so the header doesn't move.
- The `role="img"` data summary and the data tables are suppressed while loading,
  so screen readers never hear "No application history data available" during a
  fetch.
- `prefers-reduced-motion` is respected (via `SkeletonLoader`) and covered by a test.
- Aligned the screen-reader-only text to the repo's `sr-only` convention: the
  previously used `visually-hidden` class is not defined anywhere in the codebase,
  so that content (the accessible data table and the new loading status) was
  rendering visibly. Switching to `sr-only` fixes that.

## How the acceptance criteria are met

- **Skeleton during loading instead of a blank/abrupt appearance** — `isLoading`
  renders the skeleton inside the real chart chrome.
- **No noticeable layout shift** — resolved by construction: skeleton and loaded
  states share the same card, header, legend and `h-[320px]` container.
- **Tests cover both loading and loaded scenarios** — see below.

## Tests

- New `ChartSkeleton.test.tsx`: default sections, prop toggles, deterministic markup.
- `ApplicationsChart.test.tsx`: loading renders skeleton + real title + disabled
  toggle + `aria-busy` + `role="status"` and no false "no data" text; resolving
  shows the chart + summary; `prefers-reduced-motion` omits the shimmer.
- `DashboardTab.test.tsx`: skeleton visible while loading, chart after data resolves.
- Full suite green in CI (one unrelated `DatePicker` test is timezone-sensitive
  and only fails on non-UTC local runs). `ChartSkeleton` and the new
  `ApplicationsChart` code are at 100% line coverage; `typecheck`, `lint` and
  `build` all pass.

## Note on the loaded state

Removing the double-nested card slightly changes the loaded chart's appearance
(one nested border/padding is gone). This is an intentional consistency fix that
aligns the chart with the existing `StatsCard` / `StatsCardSkeleton` pattern and
is what makes the zero-layout-shift guarantee hold.

## Demo


**Light:** 


https://github.com/user-attachments/assets/859feab3-bdd4-45fb-b871-0dc2fc3c9fd1



**Dark:** 

https://github.com/user-attachments/assets/40a3f212-c525-4c50-a28a-73af1cea74c8

