### PR TITLE
fix: respect prefers-reduced-motion for the decorative falling-petals…

### DIFF
--- a/src/features/leaderboard/components/FallingPetals.test.tsx
+++ b/src/features/leaderboard/components/FallingPetals.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { FallingPetals } from './FallingPetals'
+import { Petal } from '../types'
+
+function makeMediaQuery(matches: boolean) {
+  return {
+    matches,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }
+}
+
+function mockMatchMedia(matches: boolean) {
+  const mql = makeMediaQuery(matches)
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mql),
+  })
+  return mql as unknown as MediaQueryList
+}
+
+const petals: Petal[] = [
+  {
+    id: 'petal-1',
+    left: 15,
+    delay: 0.2,
+    duration: 8,
+    size: 0.9,
+    rotation: 12,
+  },
+]
+
+describe('FallingPetals', () => {
+  beforeEach(() => {
+    mockMatchMedia(false)
+  })
+
+  it('renders decorative petals when reduced motion is not requested', () => {
+    const { container } = render(<FallingPetals petals={petals} />)
+
+    expect(container.firstChild).not.toBeNull()
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders nothing when prefers-reduced-motion: reduce is active', () => {
+    mockMatchMedia(true)
+    const { container } = render(<FallingPetals petals={petals} />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('removes the animation overlay when the OS reduced-motion preference changes at runtime', async () => {
+    const mql = mockMatchMedia(false)
+    const { container } = render(<FallingPetals petals={petals} />)
+
+    expect(container.querySelector('svg')).toBeInTheDocument()
+
+    const [, handler] = (mql.addEventListener as ReturnType<typeof vi.fn>).mock.calls[0]
+
+    await Promise.resolve()
+    handler({ matches: true } as MediaQueryListEvent)
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/features/leaderboard/components/FallingPetals.tsx
+++ b/src/features/leaderboard/components/FallingPetals.tsx
@@ -1,22 +1,29 @@
-import { useState, useEffect } from 'react';
-import { Petal } from '../types';
+import { useState, useEffect } from 'react'
+import { Petal } from '../types'
 
 interface FallingPetalsProps {
-  petals: Petal[];
+  petals: Petal[]
+}
+
+function getPrefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
 
 export function FallingPetals({ petals }: FallingPetalsProps) {
-  const [reducedMotion, setReducedMotion] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(getPrefersReducedMotion)
 
   useEffect(() => {
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReducedMotion(mql.matches);
-    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
-    mql.addEventListener('change', handler);
-    return () => mql.removeEventListener('change', handler);
-  }, []);
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
 
-  if (reducedMotion) return null;
+  if (reducedMotion) return null
 
   return (
     <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none z-10 overflow-hidden">
@@ -56,5 +63,5 @@ export function FallingPetals({ petals }: FallingPetalsProps) {
         </div>
       ))}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
Closes #513 

… animation

## PR Summary

**Title:** fix: respect prefers-reduced-motion for the decorative falling-petals animation

### What changed

- Updated FallingPetals.tsx
  - Added `prefers-reduced-motion: reduce` detection.
  - Initialized reduced-motion state synchronously from `window.matchMedia`.
  - Continued listening for runtime preference changes and disabled the animation when reduced motion is requested.
  - When reduced motion is active, the component now returns `null` instead of rendering decorative petals.

- Added new test file FallingPetals.test.tsx
  - Confirms petals render when reduced motion is not requested.
  - Confirms the component renders nothing when `prefers-reduced-motion: reduce` is active.
  - Confirms runtime changes to the media query update the rendered output.

### Why

This change ensures the leaderboard’s decorative `FallingPetals` animation respects WCAG accessibility guidance by disabling motion for users who prefer reduced motion. It also preserves existing behavior when no preference is set.

### Verification

- Branch: `AddPrefersReducedMotionSupportToSrcFeaturesLeaderboardComponensFallingPetals.tsx`
- Commit: `fix: respect prefers-reduced-motion for the decorative falling-petals animation`
- Files changed:
  - FallingPetals.tsx
  - FallingPetals.test.tsx

### Notes

- No leaderboard data or core functionality was changed.
- This is purely an accessibility improvement for decorative animation behavior.
- The new test suite is focused and keeps the component behavior secure and easy to review.