### PR TITLE
test: cover UserAvatar fallback behavior

### DIFF
--- a/src/shared/components/UserAvatar.test.tsx
+++ b/src/shared/components/UserAvatar.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { getUserInitials, UserAvatar } from './UserAvatar'
+
+describe('getUserInitials', () => {
+  it('uses the first letters of the first two words in a display name', () => {
+    expect(getUserInitials('Ada Lovelace', 'octocat')).toBe('AL')
+  })
+
+  it('ignores extra whitespace between display-name words', () => {
+    expect(getUserInitials('  Grace   Hopper  ', 'grace')).toBe('GH')
+  })
+
+  it('uses the first two characters of a single-word display name', () => {
+    expect(getUserInitials('ada', 'octocat')).toBe('AD')
+  })
+
+  it('uses a single-word login when the display name is empty', () => {
+    expect(getUserInitials('', 'octocat')).toBe('OC')
+  })
+
+  it('returns a neutral initial when no identity is available', () => {
+    expect(getUserInitials()).toBe('?')
+    expect(getUserInitials('  ', '')).toBe('?')
+  })
+
+  it('recognizes underscores and hyphens as word separators', () => {
+    expect(getUserInitials('ada_lovelace')).toBe('AL')
+    expect(getUserInitials('grace-hopper')).toBe('GH')
+  })
+})
+
+describe('UserAvatar', () => {
+  it('renders an accessible initials fallback when no source is provided', () => {
+    render(<UserAvatar name="Ada Lovelace" size="large" />)
+
+    expect(screen.getByLabelText('Ada Lovelace avatar fallback')).toHaveTextContent('AL')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('renders an image with an accessible name and the provided source', () => {
+    render(
+      <UserAvatar src="https://example.test/ada.png" name="Ada Lovelace" login="ada" size="small" />
+    )
+
+    expect(screen.getByRole('img', { name: 'Ada Lovelace avatar' })).toHaveAttribute(
+      'src',
+      'https://example.test/ada.png'
+    )
+  })
+
+  it('uses a generic accessible name when image identity is unavailable', () => {
+    render(<UserAvatar src="https://example.test/user.png" size="small" />)
+
+    expect(screen.getByRole('img', { name: 'User avatar' })).toHaveAttribute(
+      'src',
+      'https://example.test/user.png'
+    )
+  })
+
+  it('replaces an image with the initials fallback when loading fails', () => {
+    render(<UserAvatar src="https://example.test/broken.png" name="Ada Lovelace" size="small" />)
+
+    fireEvent.error(screen.getByRole('img', { name: 'Ada Lovelace avatar' }))
+
+    expect(screen.getByLabelText('Ada Lovelace avatar fallback')).toHaveTextContent('AL')
+    expect(screen.queryByRole('img', { name: 'Ada Lovelace avatar' })).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['small', ['w-7', 'h-7', 'text-[10px]']],
+    ['large', ['w-12', 'h-12', 'text-sm']],
+  ] as const)('applies the %s size classes', (size, expectedClasses) => {
+    render(<UserAvatar login="octocat" size={size} />)
+
+    expect(screen.getByLabelText('octocat avatar fallback')).toHaveClass(...expectedClasses)
+  })
+
+  it('retries the image when the source changes after a loading failure', () => {
+    const { rerender } = render(
+      <UserAvatar src="https://example.test/broken.png" name="Ada Lovelace" size="small" />
+    )
+
+    fireEvent.error(screen.getByRole('img', { name: 'Ada Lovelace avatar' }))
+    expect(screen.getByLabelText('Ada Lovelace avatar fallback')).toBeInTheDocument()
+
+    rerender(
+      <UserAvatar src="https://example.test/replacement.png" name="Ada Lovelace" size="small" />
+    )
+
+    expect(screen.getByRole('img', { name: 'Ada Lovelace avatar' })).toHaveAttribute(
+      'src',
+      'https://example.test/replacement.png'
+    )
+    expect(screen.queryByLabelText('Ada Lovelace avatar fallback')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add dedicated unit coverage for multi-word, single-word, empty, underscore, hyphen, and extra-whitespace initials
- verify accessible image and fallback rendering plus image-error fallback
- verify a changed `src` retries image rendering after a previous load failure
- cover both avatar size variants without changing production behavior

Closes #580

## Verification
- `TZ=UTC npm test -- run src/shared/components/UserAvatar.test.tsx src/shared/components/UserProfileDropdown.test.tsx` (18/18)
- `TZ=UTC npm run test:coverage` (1,184 passed, 4 skipped; `UserAvatar.tsx` 100% statements/branches/functions/lines)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `npx prettier --check src/shared/components/UserAvatar.test.tsx`
- `git diff --check`

## Baseline note
The repository's date-sensitive `DiscoverPage` tests fail under the local Asia/Shanghai timezone but pass under the UTC timezone used above; this test-only change does not touch those files.