### PR TITLE
Fix/ecosystem detail language category filters #562

### DIFF
--- a/.opencode/plans/prefers-reduced-motion-leaderboard-hero.md
+++ b/.opencode/plans/prefers-reduced-motion-leaderboard-hero.md
@@ -1,0 +1,182 @@
+# Plan: Add `prefers-reduced-motion` Support to `LeaderboardHero`
+
+## Context
+
+`LeaderboardHero.tsx` renders 8 decorative CSS animation classes (`animate-twinkle-slow`, `animate-glow-pulse`, `animate-glow-pulse-delayed`, `animate-float`, `animate-float-delayed`, `animate-float-slow`, `animate-shimmer`, `animate-bounce-slow`, `animate-wiggle`, `animate-wiggle-delayed`, `animate-pulse-slow`) and entrance animations via `isLoaded` (`translate-y`, `scale`) regardless of the user's motion preference. Other components in the codebase (`FallingPetals`, `SkeletonLoader`) already detect `prefers-reduced-motion: reduce` inline — there is no shared hook. This task adds the same detection to `LeaderboardHero` using the existing project pattern.
+
+---
+
+## Files to Modify
+
+1. **`src/features/leaderboard/components/LeaderboardHero.tsx`** — Add reduced-motion detection and conditional classes
+2. **`src/features/leaderboard/components/LeaderboardHero.test.tsx`** — New test file (does not exist yet)
+
+---
+
+## Step 1: Modify `LeaderboardHero.tsx`
+
+### Add reduced-motion detection (reusing the `FallingPetals` pattern)
+
+Add at the top of the file, before the component:
+
+```tsx
+function getPrefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+```
+
+Add `useState`/`useEffect` hooks inside the component:
+
+```tsx
+import { useState, useEffect } from 'react'
+// ... existing imports ...
+
+export function LeaderboardHero({ leaderboardType, isLoaded, children }: LeaderboardHeroProps) {
+  const { theme } = useTheme()
+  const [reducedMotion, setReducedMotion] = useState(getPrefersReducedMotion)
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  // ... rest of component
+}
+```
+
+### Disable decorative animations conditionally
+
+When `reducedMotion` is true, omit the `animate-*` classes from decorative elements. The elements themselves remain visible (static). Specific changes:
+
+| Element | Normal | Reduced Motion |
+|---|---|---|
+| Outer container (line 16) | `isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'` | `isLoaded ? 'opacity-100' : 'opacity-0'` (fade only, no translate) |
+| Glow divs (lines 22-25) | `animate-glow-pulse` / `animate-glow-pulse-delayed` | Remove `animate-*` class |
+| Sparkle divs (line 33) | `animate-twinkle-slow` | Remove `animate-*` class |
+| Floating rings (lines 45-47) | `animate-float` / `animate-float-delayed` / `animate-float-slow` | Remove `animate-*` class |
+| Title section (line 52) | `isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'` | `isLoaded ? 'opacity-100' : 'opacity-0'` (fade only, no translate) |
+| Shimmer underline (line 62) | `animate-shimmer` | Remove `animate-*` class |
+| Crown (line 66) | `animate-bounce-slow` | Remove `animate-*` class |
+| Podium section (line 88) | `isLoaded ? 'opacity-100 scale-100' : 'opacity-0 scale-95'` | `isLoaded ? 'opacity-100' : 'opacity-0'` (fade only, no scale) |
+| Trophy icons (lines 97-99) | `animate-wiggle` / `animate-wiggle-delayed` | Remove `animate-*` class |
+| Star icons (line 103, 109) | `animate-pulse-slow` | Remove `animate-*` class |
+
+### Implementation approach
+
+Use conditional class strings with ternary expressions based on `reducedMotion`:
+
+```tsx
+const outerClass = reducedMotion
+  ? `... ${isLoaded ? 'opacity-100' : 'opacity-0'}`
+  : `... ${isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`
+
+// Similarly for sparkle div:
+className={`absolute w-1 h-1 bg-[#c9983a]/50 rounded-full${reducedMotion ? '' : ' animate-twinkle-slow'}`}
+```
+
+Also add `transition-none` when `reducedMotion` is true to remove the CSS transition effects on the entrance animation containers (which currently use `transition-all duration-1000`).
+
+---
+
+## Step 2: Create `LeaderboardHero.test.tsx`
+
+Follow the `FallingPetals.test.tsx` testing conventions:
+
+- `// @vitest-environment jsdom` docblock
+- Import from `vitest` (`describe`, `it`, `expect`, `vi`, `beforeEach`)
+- Import from `@testing-library/react` (`render`, `screen`, `waitFor`)
+- Use `renderWithTheme` wrapper (since component uses `useTheme`)
+- Reuse `makeMediaQuery` + `mockMatchMedia` helper pattern from `FallingPetals.test.tsx`
+
+### Test 1 — Reduced Motion (decorative animations absent)
+
+```tsx
+it('removes decorative animation classes when reduced motion is preferred', () => {
+  mockMatchMedia(true)
+  renderWithTheme(<LeaderboardHero leaderboardType="contributors" isLoaded={true}><div /></LeaderboardHero>)
+
+  // Verify animation classes are not present
+  const container = document.querySelector('[class*="animate-twinkle"]')
+  expect(container).toBeNull()
+  // Also verify specific elements don't have animation classes
+  // Check glow divs, sparkle divs, etc.
+})
+```
+
+### Test 2 — Normal Motion (animations present)
+
+```tsx
+it('keeps animation classes when reduced motion is not preferred', () => {
+  mockMatchMedia(false)
+  renderWithTheme(<LeaderboardHero leaderboardType="contributors" isLoaded={true}><div /></LeaderboardHero>)
+
+  // Verify animation classes ARE present on relevant elements
+  expect(document.querySelector('.animate-twinkle-slow')).toBeInTheDocument()
+  expect(document.querySelector('.animate-glow-pulse')).toBeInTheDocument()
+  // etc.
+})
+```
+
+### Test 3 — Content Reveal (reduced motion uses opacity only)
+
+```tsx
+it('uses opacity-only reveal when reduced motion is enabled', () => {
+  mockMatchMedia(true)
+  renderWithTheme(<LeaderboardHero leaderboardType="contributors" isLoaded={true}><div /></LeaderboardHero>)
+
+  // The outer container should be visible (opacity-100) without translate/scale
+  const outer = document.querySelector('[class*="min-h-"]')
+  expect(outer).toHaveClass('opacity-100')
+  expect(outer?.className).not.toMatch(/translate/)
+  expect(outer?.className).not.toMatch(/scale/)
+
+  // Content should still be visible
+  expect(screen.getByRole('heading', { name: /seasonal contributors/i })).toBeInTheDocument()
+})
+```
+
+### Test 4 — Edge case: isLoaded false → true under reduced motion
+
+```tsx
+it('shows content with opacity fade when isLoaded transitions under reduced motion', async () => {
+  mockMatchMedia(true)
+  const { rerender } = renderWithTheme(
+    <LeaderboardHero leaderboardType="contributors" isLoaded={false}><div>child</div></LeaderboardHero>
+  )
+  // Initially not visible
+  const outer = document.querySelector('[class*="min-h-"]')
+  expect(outer?.className).toContain('opacity-0')
+
+  rerender(
+    <LeaderboardHero leaderboardType="contributors" isLoaded={true}><div>child</div></LeaderboardHero>
+  )
+  // Now visible with opacity-100, no translate/scale
+  expect(outer?.className).toContain('opacity-100')
+  expect(outer?.className).not.toMatch(/translate/)
+  expect(outer?.className).not.toMatch(/scale/)
+})
+```
+
+---
+
+## Step 3: Run Validation
+
+```bash
+npm test -- --run LeaderboardHero
+```
+
+Ensure all new tests pass and no existing tests break.
+
+---
+
+## Summary
+
+- **Detection**: Reuses the same inline `getPrefersReducedMotion` + `matchMedia` pattern from `FallingPetals.tsx` (no new utility, consistent with codebase conventions)
+- **Decorative animations**: All `animate-*` classes are conditionally omitted when reduced motion is active; elements remain visible but static
+- **Content reveal**: `translate` and `scale` transforms are replaced with simple opacity fade
+- **Tests**: 4 tests covering reduced-motion, normal-motion, content visibility, and runtime transition — following existing `FallingPetals.test.tsx` patterns

--- a/src/features/dashboard/components/ProjectCard.tsx
+++ b/src/features/dashboard/components/ProjectCard.tsx
@@ -14,6 +14,8 @@ export interface Project {
   description: string
   tags: string[]
   color: string
+  language?: string | null
+  category?: string | null
 }
 
 interface ProjectCardProps {

--- a/src/features/dashboard/pages/EcosystemDetailPage.test.tsx
+++ b/src/features/dashboard/pages/EcosystemDetailPage.test.tsx
@@ -1,0 +1,632 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { EcosystemDetailPage } from './EcosystemDetailPage'
+
+const mockGetPublicProjects = vi.fn()
+const mockGetEcosystemDetail = vi.fn()
+
+vi.mock('../../../shared/api/client', () => ({
+  getPublicProjects: (...a: unknown[]) => mockGetPublicProjects(...a),
+  getEcosystemDetail: (...a: unknown[]) => mockGetEcosystemDetail(...a),
+}))
+
+vi.mock('lucide-react', () => {
+  const noop = () => null
+  return {
+    ChevronRight: noop,
+    ExternalLink: noop,
+    Users: noop,
+    FolderGit2: noop,
+    AlertCircle: noop,
+    GitPullRequest: noop,
+    Star: noop,
+    GitFork: noop,
+    Package: noop,
+    Filter: noop,
+    Search: noop,
+    X: noop,
+    Circle: noop,
+    ChevronDown: noop,
+    Check: noop,
+  }
+})
+
+const onBack = vi.fn()
+const onProjectClick = vi.fn()
+
+const mockProjects = [
+  {
+    id: 'p1',
+    github_full_name: 'owner/ts-project',
+    language: 'typescript',
+    category: 'frontend',
+    tags: ['React'],
+    stars_count: 100,
+    forks_count: 10,
+    contributors_count: 5,
+    open_issues_count: 2,
+    open_prs_count: 1,
+    ecosystem_name: 'TestEco',
+    description: 'TypeScript frontend project',
+  },
+  {
+    id: 'p2',
+    github_full_name: 'owner/js-project',
+    language: 'javascript',
+    category: 'backend',
+    tags: ['Node'],
+    stars_count: 200,
+    forks_count: 20,
+    contributors_count: 8,
+    open_issues_count: 3,
+    open_prs_count: 2,
+    ecosystem_name: 'TestEco',
+    description: 'JavaScript backend project',
+  },
+  {
+    id: 'p3',
+    github_full_name: 'owner/py-project',
+    language: 'python',
+    category: 'fullstack',
+    tags: ['Django'],
+    stars_count: 300,
+    forks_count: 30,
+    contributors_count: 12,
+    open_issues_count: 5,
+    open_prs_count: 3,
+    ecosystem_name: 'TestEco',
+    description: 'Python fullstack project',
+  },
+  {
+    id: 'p4',
+    github_full_name: 'owner/rust-project',
+    language: 'rust',
+    category: 'devops',
+    tags: ['CLI'],
+    stars_count: 400,
+    forks_count: 40,
+    contributors_count: 15,
+    open_issues_count: 1,
+    open_prs_count: 0,
+    ecosystem_name: 'TestEco',
+    description: 'Rust devops project',
+  },
+  {
+    id: 'p5',
+    github_full_name: 'owner/null-lang-project',
+    language: null,
+    category: 'frontend',
+    tags: [],
+    stars_count: 50,
+    forks_count: 5,
+    contributors_count: 2,
+    open_issues_count: 0,
+    open_prs_count: 0,
+    ecosystem_name: 'TestEco',
+    description: 'Project with null language',
+  },
+  {
+    id: 'p6',
+    github_full_name: 'owner/null-cat-project',
+    language: 'typescript',
+    category: null,
+    tags: [],
+    stars_count: 60,
+    forks_count: 6,
+    contributors_count: 3,
+    open_issues_count: 1,
+    open_prs_count: 1,
+    ecosystem_name: 'TestEco',
+    description: 'Project with null category',
+  },
+  {
+    id: 'p7',
+    github_full_name: 'owner/both-null-project',
+    language: null,
+    category: null,
+    tags: [],
+    stars_count: 70,
+    forks_count: 7,
+    contributors_count: 4,
+    open_issues_count: 0,
+    open_prs_count: 0,
+    ecosystem_name: 'TestEco',
+    description: 'Project with both null',
+  },
+]
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <EcosystemDetailPage
+        ecosystemId="eco-1"
+        ecosystemName="TestEco"
+        onBack={onBack}
+        onProjectClick={onProjectClick}
+      />
+    </ThemeProvider>
+  )
+}
+
+async function switchToProjectsTab() {
+  await userEvent.click(screen.getByRole('button', { name: /projects/i }))
+}
+
+async function waitForProjectsLoaded() {
+  await waitFor(() => {
+    expect(screen.getByText('ts-project')).toBeInTheDocument()
+  })
+}
+
+function openFilterPanel() {
+  // The SearchWithFilter bar contains a search input and a filter button.
+  // The filter button is a sibling of the search input's container.
+  // Since lucide icons are mocked to null, the filter button is empty.
+  // We find it by locating the search input, then finding the button that's
+  // the previous sibling of its parent.
+  const searchInput = screen.getByPlaceholderText('Search')
+  const searchContainer = searchInput.closest('div.relative')!
+  const filterBar = searchContainer.parentElement!
+  const filterButton = filterBar.querySelector('button')!
+  fireEvent.click(filterButton)
+}
+
+function toggleFilterOption(label: string) {
+  const option = screen.getByRole('button', { name: label })
+  fireEvent.click(option)
+}
+
+beforeEach(() => {
+  mockGetPublicProjects.mockReset()
+  mockGetEcosystemDetail.mockReset()
+  onBack.mockReset()
+  onProjectClick.mockReset()
+  mockGetEcosystemDetail.mockResolvedValue({
+    id: 'eco-1',
+    name: 'TestEco',
+    description: 'Test ecosystem',
+    logo_url: null,
+    project_count: 7,
+    contributors_count: 50,
+    open_issues_count: 10,
+    open_prs_count: 8,
+    links: [],
+    key_areas: [],
+    technologies: [],
+    about: '',
+  })
+  mockGetPublicProjects.mockResolvedValue({ projects: mockProjects })
+})
+
+describe('EcosystemDetailPage — filtering', () => {
+  describe('search only', () => {
+    it('shows all projects initially', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+      expect(screen.getByText('ts-project')).toBeInTheDocument()
+      expect(screen.getByText('js-project')).toBeInTheDocument()
+      expect(screen.getByText('py-project')).toBeInTheDocument()
+      expect(screen.getByText('rust-project')).toBeInTheDocument()
+      expect(screen.getByText('null-lang-project')).toBeInTheDocument()
+      expect(screen.getByText('null-cat-project')).toBeInTheDocument()
+      expect(screen.getByText('both-null-project')).toBeInTheDocument()
+    })
+
+    it('filters projects by name search', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      await userEvent.type(searchInput, 'ts-project')
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('filters projects by description search', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      await userEvent.type(searchInput, 'Rust devops')
+
+      await waitFor(() => {
+        expect(screen.getByText('rust-project')).toBeInTheDocument()
+        expect(screen.queryByText('ts-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('language filter', () => {
+    it('filters by selected language', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('rust-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('excludes projects with null language when language filter is active', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('null-lang-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('both-null-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows all projects when no language is selected', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.getByText('js-project')).toBeInTheDocument()
+        expect(screen.getByText('null-lang-project')).toBeInTheDocument()
+      })
+    })
+
+    it('filters by multiple selected languages', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      toggleFilterOption('JavaScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.getByText('js-project')).toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('rust-project')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('category filter', () => {
+    it('filters by selected category', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('rust-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('excludes projects with null category when category filter is active', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('null-cat-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('both-null-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows all projects when no category is selected', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Categories'))
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.getByText('js-project')).toBeInTheDocument()
+        expect(screen.getByText('null-cat-project')).toBeInTheDocument()
+      })
+    })
+
+    it('filters by multiple selected categories', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      toggleFilterOption('Backend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.getByText('js-project')).toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('rust-project')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('combined filters', () => {
+    it('applies language + category with AND semantics', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('py-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('rust-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('applies search + language with AND semantics', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      await userEvent.type(searchInput, 'frontend')
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('null-lang-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('applies search + category with AND semantics', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      await userEvent.type(searchInput, 'TypeScript')
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('null-cat-project')).not.toBeInTheDocument()
+      })
+    })
+
+    it('applies search + language + category with AND semantics', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search')
+      await userEvent.type(searchInput, 'TypeScript frontend')
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.queryByText('null-lang-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('null-cat-project')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('reset', () => {
+    it('clears all filters and restores full project list', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('js-project')).not.toBeInTheDocument()
+      })
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Reset')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Reset'))
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.getByText('ts-project')).toBeInTheDocument()
+        expect(screen.getByText('js-project')).toBeInTheDocument()
+        expect(screen.getByText('py-project')).toBeInTheDocument()
+        expect(screen.getByText('rust-project')).toBeInTheDocument()
+        expect(screen.getByText('null-lang-project')).toBeInTheDocument()
+        expect(screen.getByText('null-cat-project')).toBeInTheDocument()
+        expect(screen.getByText('both-null-project')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('null values', () => {
+    it('projects with null language are excluded under active language filter', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('null-lang-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('both-null-project')).not.toBeInTheDocument()
+        expect(screen.getByText('null-cat-project')).toBeInTheDocument()
+      })
+    })
+
+    it('projects with null category are excluded under active category filter', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Categories')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Categories'))
+      toggleFilterOption('Frontend')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('null-cat-project')).not.toBeInTheDocument()
+        expect(screen.queryByText('both-null-project')).not.toBeInTheDocument()
+        expect(screen.getByText('null-lang-project')).toBeInTheDocument()
+      })
+    })
+
+    it('projects with both null language and category are excluded under any active filter', async () => {
+      renderPage()
+      await switchToProjectsTab()
+      await waitForProjectsLoaded()
+
+      openFilterPanel()
+      await waitFor(() => {
+        expect(screen.getByText('Languages')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByText('Languages'))
+      toggleFilterOption('TypeScript')
+      fireEvent.click(screen.getByText('Save'))
+
+      await waitFor(() => {
+        expect(screen.queryByText('both-null-project')).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/features/dashboard/pages/EcosystemDetailPage.tsx
+++ b/src/features/dashboard/pages/EcosystemDetailPage.tsx
@@ -120,6 +120,8 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
             description: (p.description && p.description.trim()) || `${repoName} project`,
             tags: Array.isArray(p.tags) ? p.tags.slice(0, 4) : [],
             color: getProjectColor(repoName),
+            language: p.language ?? null,
+            category: p.category ?? null,
           };
         });
         setEcosystemProjects(mapped);
@@ -204,9 +206,22 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
   };
 
   const filteredProjects = ecosystemProjects.filter(
-    (project) =>
-      project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      project.description.toLowerCase().includes(searchQuery.toLowerCase())
+    (project) => {
+      const matchesSearch =
+        searchQuery === '' ||
+        project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        project.description.toLowerCase().includes(searchQuery.toLowerCase());
+
+      const matchesLanguage =
+        selectedLanguages.length === 0 ||
+        (project.language != null && selectedLanguages.includes(project.language));
+
+      const matchesCategory =
+        selectedCategories.length === 0 ||
+        (project.category != null && selectedCategories.includes(project.category));
+
+      return matchesSearch && matchesLanguage && matchesCategory;
+    }
   );
 
   const isDark = theme === 'dark';


### PR DESCRIPTION
## Summary

This PR fixes the project filtering logic in `EcosystemDetailPage` by applying the selected **language** and **category** filters to the displayed project grid.

Previously, the filter UI updated correctly, but the selected values were never used when deriving `filteredProjects`, causing the checkboxes to have no effect on the rendered results.
closes #562 
fixes #562 
## Changes

- Applied `selectedLanguages` filtering to `filteredProjects`.
- Applied `selectedCategories` filtering to `filteredProjects`.
- Combined search, language, and category filters using **AND semantics**.
- Excluded projects with `null` language/category when the corresponding filter is active.
- Added comprehensive tests covering:
  - Language filtering
  - Category filtering
  - Combined language and category filters
  - Search + filter combinations
  - Reset behavior
  - Projects with `null` language/category

## Testing

```bash
npm test -- --run EcosystemDetailPage
```

## Result

- ✅ Language filters now narrow the project grid correctly.
- ✅ Category filters now narrow the project grid correctly.
- ✅ Filters compose correctly with search using AND semantics.
- ✅ Reset restores the full project list.
- ✅ Existing functionality remains unchanged.