### PR TITLE
fix: remove stray rendered parenthesis from BillingTab detail view #560

### DIFF
--- a/src/features/settings/components/billing/BillingTab.test.tsx
+++ b/src/features/settings/components/billing/BillingTab.test.tsx
@@ -1,68 +1,143 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BillingTab } from './BillingTab';
-import { toast } from 'sonner';
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BillingTab } from './BillingTab'
+import { toast } from 'sonner'
 
-// Mock contexts and hooks
 vi.mock('../../../../shared/contexts/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
-}));
+}))
 
-// Mock sonner toast
 vi.mock('sonner', () => ({
   toast: {
     error: vi.fn(),
   },
-}));
+}))
 
-// We'll mock the hook to control the profiles state
-const mockProfiles = [
-  { id: 1, name: 'John Doe', type: 'individual', status: 'verified' }
-];
+const mockProfiles = [{ id: 1, name: 'John Doe', type: 'individual', status: 'verified' }]
 
-const mockAddProfile = vi.fn();
+const mockAddProfile = vi.fn()
+const mockUpdateProfile = vi.fn()
 
 vi.mock('../../contexts/BillingProfilesContext', () => ({
   useBillingProfiles: () => ({
     profiles: mockProfiles,
     setProfiles: vi.fn(),
     addProfile: mockAddProfile,
-    updateProfile: vi.fn(),
+    updateProfile: mockUpdateProfile,
   }),
-}));
+}))
 
-// Mock the API client
+const mockGetKYCStatus = vi.fn().mockResolvedValue({ status: 'verified' })
+
 vi.mock('../../../../shared/api/client', () => ({
   getBillingProfiles: vi.fn().mockResolvedValue([]),
-  getKYCStatus: vi.fn().mockResolvedValue({ status: 'verified' }),
+  getKYCStatus: (...args: unknown[]) => mockGetKYCStatus(...args),
   startKYCVerification: vi.fn().mockResolvedValue({ url: 'https://example.com' }),
-}));
+}))
+
+async function navigateToDetailView() {
+  render(<BillingTab />)
+  const card = await screen.findByText('John Doe')
+  await act(async () => {
+    fireEvent.click(card)
+  })
+}
 
 describe('BillingTab', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.stubEnv('VITE_USE_MOCK_DATA', 'true');
-  });
+    vi.clearAllMocks()
+    mockGetKYCStatus.mockResolvedValue({ status: 'verified' })
+    vi.stubEnv('VITE_USE_MOCK_DATA', 'true')
+  })
 
   it('shows an error toast when trying to create a duplicate individual profile', async () => {
-    render(<BillingTab />);
-    
-    // Open modal
-    const newProfileBtn = await screen.findByText('New Profile');
-    fireEvent.click(newProfileBtn);
-    
-    // Fill in a valid name
-    const nameInput = screen.getByRole('textbox');
-    fireEvent.change(nameInput, { target: { value: 'Jane Doe' } });
-    
-    // Try to create
-    const createBtn = screen.getByRole('button', { name: 'Create' });
-    fireEvent.click(createBtn);
-    
-    // Toast should be called
-    expect(toast.error).toHaveBeenCalledWith('An individual billing profile already exists. You can only create one individual profile.');
-    
-    // addProfile should not have been called
-    expect(mockAddProfile).not.toHaveBeenCalled();
-  });
-});
+    render(<BillingTab />)
+
+    const newProfileBtn = await screen.findByText('New Profile')
+    fireEvent.click(newProfileBtn)
+
+    const nameInput = screen.getByRole('textbox')
+    fireEvent.change(nameInput, { target: { value: 'Jane Doe' } })
+
+    const createBtn = screen.getByRole('button', { name: 'Create' })
+    fireEvent.click(createBtn)
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'An individual billing profile already exists. You can only create one individual profile.'
+    )
+    expect(mockAddProfile).not.toHaveBeenCalled()
+  })
+
+  describe('Profile Detail View', () => {
+    it('renders the profile detail view without stray text nodes', async () => {
+      await navigateToDetailView()
+
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+      expect(screen.getByText('Back to billing profiles')).toBeInTheDocument()
+
+      const container = screen.getByText('John Doe').closest('.space-y-6')
+      expect(container?.textContent).not.toContain(')')
+    })
+
+    it('does not render a stray parenthesis between error banner and back button', async () => {
+      mockGetKYCStatus.mockRejectedValue(new Error('Connection failed'))
+
+      await navigateToDetailView()
+
+      expect(
+        screen.getByText(
+          'VerificationFailed: Connection to the identity server failed. Please try again.'
+        )
+      ).toBeInTheDocument()
+      expect(screen.getByText('Back to billing profiles')).toBeInTheDocument()
+
+      const container = document.querySelector('.space-y-6')
+      const children = Array.from(container?.childNodes ?? [])
+      const textNodes = children.filter(
+        (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
+      )
+      expect(textNodes).toHaveLength(0)
+    })
+
+    it('renders back button and no stray parenthesis when there is no error', async () => {
+      await navigateToDetailView()
+
+      expect(screen.getByText('Back to billing profiles')).toBeInTheDocument()
+
+      const container = document.querySelector('.space-y-6')
+      const children = Array.from(container?.childNodes ?? [])
+      const textNodes = children.filter(
+        (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
+      )
+      expect(textNodes).toHaveLength(0)
+    })
+
+    it('navigates back to list view and re-enters detail view without stray text', async () => {
+      await navigateToDetailView()
+
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+
+      const backBtn = screen.getByText('Back to billing profiles')
+      await act(async () => {
+        fireEvent.click(backBtn)
+      })
+
+      expect(screen.getByText('New Profile')).toBeInTheDocument()
+
+      const card = screen.getByText('John Doe')
+      await act(async () => {
+        fireEvent.click(card)
+      })
+
+      expect(screen.getByText('Back to billing profiles')).toBeInTheDocument()
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+
+      const container = document.querySelector('.space-y-6')
+      const children = Array.from(container?.childNodes ?? [])
+      const textNodes = children.filter(
+        (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
+      )
+      expect(textNodes).toHaveLength(0)
+    })
+  })
+})

--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -1,91 +1,104 @@
-import { logger } from '../../../../shared/utils/logger';
-import { useState, useEffect, useRef } from 'react';
-import { Plus, X, Loader2, AlertCircle, Info, ChevronDown, MessageSquare } from 'lucide-react';
-import { toast } from 'sonner';
-import { BillingProfile, BillingProfileType, BillingProfileStatus, ProfileDetailTabType, PaymentMethod } from '../../types';
-import { getBillingProfiles } from "../../../../shared/api/client";
-import { sampleInvoices } from '../../data/invoicesData';
-import { BillingProfileCard } from './BillingProfileCard';
-import { PaymentMethodsTab } from './PaymentMethodsTab';
-import { InvoicesTab } from './InvoicesTab';
-import { SkeletonLoader } from '../../../../shared/components/SkeletonLoader';
-import { useTheme } from '../../../../shared/contexts/ThemeContext';
-import { startKYCVerification, getKYCStatus } from '../../../../shared/api/client';
-import { useBillingProfiles } from '../../contexts/BillingProfilesContext';
+import { logger } from '../../../../shared/utils/logger'
+import { useState, useEffect, useRef } from 'react'
+import { Plus, X, Loader2, AlertCircle, Info, ChevronDown, MessageSquare } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  BillingProfile,
+  BillingProfileType,
+  BillingProfileStatus,
+  ProfileDetailTabType,
+  PaymentMethod,
+} from '../../types'
+import { getBillingProfiles } from '../../../../shared/api/client'
+import { sampleInvoices } from '../../data/invoicesData'
+import { BillingProfileCard } from './BillingProfileCard'
+import { PaymentMethodsTab } from './PaymentMethodsTab'
+import { InvoicesTab } from './InvoicesTab'
+import { SkeletonLoader } from '../../../../shared/components/SkeletonLoader'
+import { useTheme } from '../../../../shared/contexts/ThemeContext'
+import { startKYCVerification, getKYCStatus } from '../../../../shared/api/client'
+import { useBillingProfiles } from '../../contexts/BillingProfilesContext'
 
 interface ProfileTypeOption {
-  value: BillingProfileType;
-  label: string;
-  disabled: boolean;
-  comingSoon?: boolean;
+  value: BillingProfileType
+  label: string
+  disabled: boolean
+  comingSoon?: boolean
 }
 
 function ProfileTypeSelect({
   value,
   onChange,
   hasIndividualProfile,
-  theme
+  theme,
 }: {
-  value: BillingProfileType;
-  onChange: (val: BillingProfileType) => void;
-  hasIndividualProfile: boolean;
-  theme: string;
+  value: BillingProfileType
+  onChange: (val: BillingProfileType) => void
+  hasIndividualProfile: boolean
+  theme: string
 }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
 
   const options: ProfileTypeOption[] = [
     {
       value: 'individual',
       label: `Individual${hasIndividualProfile ? ' (Already Created)' : ''}`,
-      disabled: hasIndividualProfile
+      disabled: hasIndividualProfile,
     },
     {
       value: 'self-employed',
       label: 'Self-Employed',
       disabled: true,
-      comingSoon: true
+      comingSoon: true,
     },
     {
       value: 'organization',
       label: 'Organization',
       disabled: true,
-      comingSoon: true
-    }
-  ];
+      comingSoon: true,
+    },
+  ]
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+        setIsOpen(false)
       }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
 
-  const selectedOption = options.find(o => o.value === value) || options[0];
+  const selectedOption = options.find((o) => o.value === value) || options[0]
 
   return (
     <div className="relative" ref={dropdownRef}>
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className={`w-full flex items-center justify-between gap-3 px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none transition-all text-[14px] ${theme === 'dark'
-          ? 'bg-white/[0.08] border-white/15 text-[#f5efe5] focus:border-[#c9983a]/30'
-          : 'bg-white/[0.15] border-white/25 text-[#2d2820] focus:border-[#c9983a]/30'
-          }`}
+        className={`w-full flex items-center justify-between gap-3 px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none transition-all text-[14px] ${
+          theme === 'dark'
+            ? 'bg-white/[0.08] border-white/15 text-[#f5efe5] focus:border-[#c9983a]/30'
+            : 'bg-white/[0.15] border-white/25 text-[#2d2820] focus:border-[#c9983a]/30'
+        }`}
       >
         <span className="flex-1 text-left truncate">{selectedOption.label}</span>
-        <ChevronDown className={`w-5 h-5 flex-shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''} ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-          }`} />
+        <ChevronDown
+          className={`w-5 h-5 flex-shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''} ${
+            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+          }`}
+        />
       </button>
 
       {isOpen && (
-        <div className={`absolute z-[110] mt-2 w-full min-w-[240px] rounded-[14px] border shadow-[0_10px_30px_rgba(0,0,0,0.12)] overflow-hidden backdrop-blur-[40px] animate-in fade-in slide-in-from-top-2 duration-200 ${theme === 'dark'
-            ? 'bg-[#2d2820]/[0.95] border-white/10'
-          : 'bg-[#d5cabc] border-[#c9983a]/30'
-          }`}>
+        <div
+          className={`absolute z-[110] mt-2 w-full min-w-[240px] rounded-[14px] border shadow-[0_10px_30px_rgba(0,0,0,0.12)] overflow-hidden backdrop-blur-[40px] animate-in fade-in slide-in-from-top-2 duration-200 ${
+            theme === 'dark'
+              ? 'bg-[#2d2820]/[0.95] border-white/10'
+              : 'bg-[#d5cabc] border-[#c9983a]/30'
+          }`}
+        >
           <div className="py-1">
             {options.map((option) => (
               <button
@@ -94,25 +107,29 @@ function ProfileTypeSelect({
                 disabled={option.disabled}
                 onClick={() => {
                   if (!option.disabled) {
-                    onChange(option.value);
-                    setIsOpen(false);
+                    onChange(option.value)
+                    setIsOpen(false)
                   }
                 }}
-                className={`w-full px-4 py-3 text-left text-[14px] transition-all flex items-center justify-between group ${value === option.value
-                  ? theme === 'dark'
-                    ? 'bg-[#c9983a]/20 text-[#c9983a]'
-                    : 'bg-[#c9983a]/10 text-[#a67c2e]'
-                  : theme === 'dark'
-                    ? 'text-[#f5efe5] hover:bg-white/5'
-                    : 'text-[#2d2820] hover:bg-[#c9983a]/15'
-                  } ${option.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                className={`w-full px-4 py-3 text-left text-[14px] transition-all flex items-center justify-between group ${
+                  value === option.value
+                    ? theme === 'dark'
+                      ? 'bg-[#c9983a]/20 text-[#c9983a]'
+                      : 'bg-[#c9983a]/10 text-[#a67c2e]'
+                    : theme === 'dark'
+                      ? 'text-[#f5efe5] hover:bg-white/5'
+                      : 'text-[#2d2820] hover:bg-[#c9983a]/15'
+                } ${option.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
-                <span className="truncate mr-2">
-                  {option.label}
-                </span>
+                <span className="truncate mr-2">{option.label}</span>
                 {option.comingSoon && (
-                  <span className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full flex-shrink-0 ${theme === 'dark' ? 'bg-white/10 text-white/50' : 'bg-[#c9983a]/15 text-[#a67c2e]'
-                    }`}>
+                  <span
+                    className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full flex-shrink-0 ${
+                      theme === 'dark'
+                        ? 'bg-white/10 text-white/50'
+                        : 'bg-[#c9983a]/15 text-[#a67c2e]'
+                    }`}
+                  >
                     Soon
                   </span>
                 )}
@@ -122,41 +139,43 @@ function ProfileTypeSelect({
         </div>
       )}
     </div>
-  );
+  )
 }
 
 export function BillingTab() {
-  const { theme } = useTheme();
-  const { profiles, setProfiles, addProfile, updateProfile } = useBillingProfiles();
-  const useMock = import.meta.env.VITE_USE_MOCK_DATA === "true";
-  const [isLoading, _setIsLoading] = useState(!useMock);
-  const [loadingProfiles, setLoadingProfiles] = useState(false);
+  const { theme } = useTheme()
+  const { profiles, setProfiles, addProfile, updateProfile } = useBillingProfiles()
+  const useMock = import.meta.env.VITE_USE_MOCK_DATA === 'true'
+  const [isLoading, _setIsLoading] = useState(!useMock)
+  const [loadingProfiles, setLoadingProfiles] = useState(false)
 
-  const [selectedProfile, setSelectedProfile] = useState<BillingProfile | null>(null);
-  const [showModal, setShowModal] = useState(false);
-  const [profileName, setProfileName] = useState('');
-  const [profileType, setProfileType] = useState<BillingProfileType>('individual');
-  const [detailTab, setDetailTab] = useState<ProfileDetailTabType>('general');
-  const [isVerifying, setIsVerifying] = useState(false);
-  const [kycStatus, setKycStatus] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isCheckingKYC, setIsCheckingKYC] = useState(false);
-  const [kycWindowOpened, setKycWindowOpened] = useState(false);
+  const [selectedProfile, setSelectedProfile] = useState<BillingProfile | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [profileName, setProfileName] = useState('')
+  const [profileType, setProfileType] = useState<BillingProfileType>('individual')
+  const [detailTab, setDetailTab] = useState<ProfileDetailTabType>('general')
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [kycStatus, setKycStatus] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isCheckingKYC, setIsCheckingKYC] = useState(false)
+  const [kycWindowOpened, setKycWindowOpened] = useState(false)
 
   const handleCreateProfile = () => {
-    if (!profileName.trim()) return;
+    if (!profileName.trim()) return
 
     // Check if individual profile already exists
     if (profileType === 'individual') {
-      const existingIndividual = profiles.find(p => p.type === 'individual');
+      const existingIndividual = profiles.find((p) => p.type === 'individual')
       if (existingIndividual) {
         /**
          * Error Path: Block duplicate individual profiles.
          * Uses sonner toast instead of native alert to ensure screen readers announce
          * the error properly without blocking the main thread, maintaining visual consistency.
          */
-        toast.error('An individual billing profile already exists. You can only create one individual profile.');
-        return;
+        toast.error(
+          'An individual billing profile already exists. You can only create one individual profile.'
+        )
+        return
       }
     }
 
@@ -165,59 +184,63 @@ export function BillingTab() {
       name: profileName,
       type: profileType,
       status: 'missing-verification',
-    };
+    }
 
-    addProfile(newProfile);
-    setShowModal(false);
-    setProfileName('');
-    setProfileType('individual');
-  };
+    addProfile(newProfile)
+    setShowModal(false)
+    setProfileName('')
+    setProfileType('individual')
+  }
 
   // Check KYC status on component mount and when selected profile changes
   // Fetch billing profiles on mount when not using mock data
   useEffect(() => {
     if (!useMock) {
-      setLoadingProfiles(true);
+      setLoadingProfiles(true)
       getBillingProfiles()
         .then((data) => {
-          setProfiles(data);
+          setProfiles(data)
         })
         .catch((err) => logger.error('Failed to fetch billing profiles:', err))
-        .finally(() => setLoadingProfiles(false));
+        .finally(() => setLoadingProfiles(false))
     }
-  }, [useMock]);
+  }, [useMock])
 
   // Existing KYC effect stays unchanged
   useEffect(() => {
     if (selectedProfile) {
-      if (selectedProfile.status === 'missing-verification' ||
-        (selectedProfile.status === 'verified' && !selectedProfile.firstName)) {
-        checkKYCStatus();
+      if (
+        selectedProfile.status === 'missing-verification' ||
+        (selectedProfile.status === 'verified' && !selectedProfile.firstName)
+      ) {
+        checkKYCStatus()
       }
     }
-  }, [selectedProfile]);
+  }, [selectedProfile])
 
   const checkKYCStatus = async () => {
-    setIsCheckingKYC(true);
+    setIsCheckingKYC(true)
     try {
-      const statusResponse = await getKYCStatus();
-      setKycStatus(statusResponse.status || null);
+      const statusResponse = await getKYCStatus()
+      setKycStatus(statusResponse.status || null)
 
       // If verified, update the profile with KYC data
       if (statusResponse.status === 'verified' && statusResponse.extracted) {
-        const extracted = statusResponse.extracted as any;
-        updateProfileWithKYCData(extracted);
+        const extracted = statusResponse.extracted as any
+        updateProfileWithKYCData(extracted)
       }
     } catch (error) {
-      logger.error('Failed to check KYC status:', error);
-      setErrorMessage("VerificationFailed: Connection to the identity server failed. Please try again.");
+      logger.error('Failed to check KYC status:', error)
+      setErrorMessage(
+        'VerificationFailed: Connection to the identity server failed. Please try again.'
+      )
     } finally {
-      setIsCheckingKYC(false);
+      setIsCheckingKYC(false)
     }
-  };
+  }
 
   const updateProfileWithKYCData = (extracted: any) => {
-    if (!selectedProfile) return;
+    if (!selectedProfile) return
 
     // Preserve the original profile name
     const updates: Partial<BillingProfile> = {
@@ -230,128 +253,130 @@ export function BillingTab() {
       postalCode: extracted.postal_code || extracted.postalCode || '',
       country: extracted.country || '',
       taxId: extracted.document_number || extracted.tax_id || '',
-    };
+    }
 
-    updateProfile(selectedProfile.id, updates);
-    setSelectedProfile({ ...selectedProfile, ...updates });
-  };
+    updateProfile(selectedProfile.id, updates)
+    setSelectedProfile({ ...selectedProfile, ...updates })
+  }
 
   const handleVerifyKYC = async () => {
-    if (!selectedProfile) return;
+    if (!selectedProfile) return
 
-    setIsVerifying(true);
-    setKycWindowOpened(false);
+    setIsVerifying(true)
+    setKycWindowOpened(false)
     try {
       // Start KYC verification
-      const response = await startKYCVerification();
+      const response = await startKYCVerification()
 
       // Open the KYC URL in a new window
       if (response.url) {
-        const kycWindow = window.open(response.url, '_blank', 'width=800,height=600');
-        setErrorMessage("");
-        
+        const kycWindow = window.open(response.url, '_blank', 'width=800,height=600')
+        setErrorMessage('')
+
         // Window opened successfully - update state to reflect this
         if (kycWindow) {
-          setKycWindowOpened(true);
-          setIsVerifying(false); // Stop the "Starting Verification..." state
-          
+          setKycWindowOpened(true)
+          setIsVerifying(false) // Stop the "Starting Verification..." state
+
           // Immediately check current status
           try {
-            const initialStatus = await getKYCStatus();
-            setKycStatus(initialStatus.status || 'pending');
+            const initialStatus = await getKYCStatus()
+            setKycStatus(initialStatus.status || 'pending')
           } catch {
             // Default to pending if we can't fetch status
-            setKycStatus('pending');
+            setKycStatus('pending')
           }
         }
 
         // Poll for status updates
         const pollInterval = setInterval(async () => {
           try {
-            const statusResponse = await getKYCStatus();
-            setKycStatus(statusResponse.status || null);
+            const statusResponse = await getKYCStatus()
+            setKycStatus(statusResponse.status || null)
 
             if (statusResponse.status === 'verified') {
-              clearInterval(pollInterval);
-              setKycWindowOpened(false);
+              clearInterval(pollInterval)
+              setKycWindowOpened(false)
               if (statusResponse.extracted) {
-                updateProfileWithKYCData(statusResponse.extracted);
+                updateProfileWithKYCData(statusResponse.extracted)
               }
-            } else if (statusResponse.status === 'rejected' || statusResponse.status === 'expired') {
-              clearInterval(pollInterval);
-              setKycWindowOpened(false);
+            } else if (
+              statusResponse.status === 'rejected' ||
+              statusResponse.status === 'expired'
+            ) {
+              clearInterval(pollInterval)
+              setKycWindowOpened(false)
             }
           } catch (error) {
-            logger.error('Failed to poll KYC status:', error);
-            setErrorMessage("Connection lost. We're having trouble checking your verification status. Please refresh the page.");
+            logger.error('Failed to poll KYC status:', error)
+            setErrorMessage(
+              "Connection lost. We're having trouble checking your verification status. Please refresh the page."
+            )
           }
-        }, 3000); // Poll every 3 seconds
+        }, 3000) // Poll every 3 seconds
 
         // Stop polling after 5 minutes
-        setTimeout(() => {
-          clearInterval(pollInterval);
-          setKycWindowOpened(false);
-        }, 5 * 60 * 1000);
+        setTimeout(
+          () => {
+            clearInterval(pollInterval)
+            setKycWindowOpened(false)
+          },
+          5 * 60 * 1000
+        )
       }
     } catch (error) {
-      logger.error('Failed to start KYC verification:', error);
-      setErrorMessage("Could not start verification. Please try again later.");
-      setIsVerifying(false);
-      setKycWindowOpened(false);
+      logger.error('Failed to start KYC verification:', error)
+      setErrorMessage('Could not start verification. Please try again later.')
+      setIsVerifying(false)
+      setKycWindowOpened(false)
     }
-  };
+  }
 
   // Payment methods handlers
   const handleAddPaymentMethod = (method: PaymentMethod) => {
-    if (!selectedProfile) return;
+    if (!selectedProfile) return
 
     const updatedProfile = {
       ...selectedProfile,
       paymentMethods: [...(selectedProfile.paymentMethods || []), method],
-    };
+    }
 
-    const updatedProfiles = profiles.map(p =>
-      p.id === selectedProfile.id ? updatedProfile : p
-    );
+    const updatedProfiles = profiles.map((p) => (p.id === selectedProfile.id ? updatedProfile : p))
 
-    setProfiles(updatedProfiles);
-    setSelectedProfile(updatedProfile);
-  };
+    setProfiles(updatedProfiles)
+    setSelectedProfile(updatedProfile)
+  }
 
   const handleRemovePaymentMethod = (methodId: number) => {
-    if (!selectedProfile) return;
+    if (!selectedProfile) return
 
     const updatedProfile = {
       ...selectedProfile,
-      paymentMethods: (selectedProfile.paymentMethods || []).filter(m => m.id !== methodId),
-    };
+      paymentMethods: (selectedProfile.paymentMethods || []).filter((m) => m.id !== methodId),
+    }
 
-    const updatedProfiles = profiles.map(p =>
-      p.id === selectedProfile.id ? updatedProfile : p
-    );
+    const updatedProfiles = profiles.map((p) => (p.id === selectedProfile.id ? updatedProfile : p))
 
-    setProfiles(updatedProfiles);
-    setSelectedProfile(updatedProfile);
-  };
+    setProfiles(updatedProfiles)
+    setSelectedProfile(updatedProfile)
+  }
 
   const handleSetDefaultPaymentMethod = (methodId: number) => {
-    if (!selectedProfile) return;
+    if (!selectedProfile) return
 
     const updatedProfile = {
       ...selectedProfile,
-      paymentMethods: (selectedProfile.paymentMethods || []).map(m => ({
+      paymentMethods: (selectedProfile.paymentMethods || []).map((m) => ({
         ...m,
         isDefault: m.id === methodId,
       })),
-    };
+    }
 
-    const updatedProfiles = profiles.map(p =>
-      p.id === selectedProfile.id ? updatedProfile : p
-    );
+    const updatedProfiles = profiles.map((p) => (p.id === selectedProfile.id ? updatedProfile : p))
 
-    setProfiles(updatedProfiles);
-    setSelectedProfile(updatedProfile);
-  };
+    setProfiles(updatedProfiles)
+    setSelectedProfile(updatedProfile)
+  }
 
   if (isLoading || loadingProfiles) {
     return (
@@ -360,7 +385,7 @@ export function BillingTab() {
         <SkeletonLoader className="h-[180px]" />
         <SkeletonLoader className="h-[180px]" />
       </div>
-    );
+    )
   }
 
   if (selectedProfile) {
@@ -368,49 +393,80 @@ export function BillingTab() {
     return (
       <div className="space-y-6">
         {errorMessage && (
-                <div className="text-red-500 bg-red-100 p-2 rounded mb-4 border border-red-200">
-                        {errorMessage}
-                              </div>
-                                  )}
-                                  
-        )
+          <div className="text-red-500 bg-red-100 p-2 rounded mb-4 border border-red-200">
+            {errorMessage}
+          </div>
+        )}
         {/* Back Button */}
         <button
           onClick={() => setSelectedProfile(null)}
-          className={`flex items-center gap-2 hover:text-[#c9983a] transition-colors ${theme === 'dark' ? 'text-[#d4c5b0]' : 'text-[#2d2820]'
-            }`}
+          className={`flex items-center gap-2 hover:text-[#c9983a] transition-colors ${
+            theme === 'dark' ? 'text-[#d4c5b0]' : 'text-[#2d2820]'
+          }`}
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           <span className="text-[15px] font-medium">Back to billing profiles</span>
         </button>
 
         {/* Profile Header */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${theme === 'dark'
-          ? 'bg-[#2d2820]/[0.4] border-white/10'
-          : 'bg-white/[0.12] border-white/20'
-          }`}>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
+            theme === 'dark'
+              ? 'bg-[#2d2820]/[0.4] border-white/10'
+              : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
           <div className="flex items-start justify-between mb-6">
             <div>
-              <h2 className={`text-[28px] font-bold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                }`}>{selectedProfile.name}</h2>
-              <p className={`text-[14px] capitalize transition-colors ${theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
-                }`}>
-                {selectedProfile.type === 'organization' ? 'Company' : selectedProfile.type.replace('-', ' ')}
+              <h2
+                className={`text-[28px] font-bold mb-2 transition-colors ${
+                  theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                }`}
+              >
+                {selectedProfile.name}
+              </h2>
+              <p
+                className={`text-[14px] capitalize transition-colors ${
+                  theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
+                }`}
+              >
+                {selectedProfile.type === 'organization'
+                  ? 'Company'
+                  : selectedProfile.type.replace('-', ' ')}
               </p>
-              <p className={`text-[13px] mt-2 transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                }`}>
-                As an individual, when you reach the annual reward amount limited by your tax residency you'll need to create a dedicated entity.
+              <p
+                className={`text-[13px] mt-2 transition-colors ${
+                  theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                }`}
+              >
+                As an individual, when you reach the annual reward amount limited by your tax
+                residency you'll need to create a dedicated entity.
               </p>
             </div>
 
             {/* Reward Limit */}
             <div className="text-right">
-              <div className={`text-[24px] font-bold transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                }`}>5000.00 USD</div>
-              <div className={`text-[13px] transition-colors ${theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
-                }`}>left</div>
+              <div
+                className={`text-[24px] font-bold transition-colors ${
+                  theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                }`}
+              >
+                5000.00 USD
+              </div>
+              <div
+                className={`text-[13px] transition-colors ${
+                  theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
+                }`}
+              >
+                left
+              </div>
             </div>
           </div>
 
@@ -418,34 +474,37 @@ export function BillingTab() {
           <div className="flex items-center gap-2">
             <button
               onClick={() => setDetailTab('general')}
-              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${detailTab === 'general'
-                ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
-                : theme === 'dark'
-                  ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
-                  : 'text-[#6b5d4d] hover:bg-white/[0.1]'
-                }`}
+              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${
+                detailTab === 'general'
+                  ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
+                  : theme === 'dark'
+                    ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
+                    : 'text-[#6b5d4d] hover:bg-white/[0.1]'
+              }`}
             >
               General Information
             </button>
             <button
               onClick={() => setDetailTab('payment')}
-              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${detailTab === 'payment'
-                ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
-                : theme === 'dark'
-                  ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
-                  : 'text-[#6b5d4d] hover:bg-white/[0.1]'
-                }`}
+              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${
+                detailTab === 'payment'
+                  ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
+                  : theme === 'dark'
+                    ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
+                    : 'text-[#6b5d4d] hover:bg-white/[0.1]'
+              }`}
             >
               Payment Methods
             </button>
             <button
               onClick={() => setDetailTab('invoices')}
-              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${detailTab === 'invoices'
-                ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
-                : theme === 'dark'
-                  ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
-                  : 'text-[#6b5d4d] hover:bg-white/[0.1]'
-                }`}
+              className={`px-5 py-2.5 rounded-[12px] text-[14px] font-medium transition-all ${
+                detailTab === 'invoices'
+                  ? 'bg-[#a2792c] text-white shadow-[0_4px_16px_rgba(162,121,44,0.25)]'
+                  : theme === 'dark'
+                    ? 'text-[#d4c5b0] hover:bg-white/[0.1]'
+                    : 'text-[#6b5d4d] hover:bg-white/[0.1]'
+              }`}
             >
               Invoices
             </button>
@@ -454,56 +513,104 @@ export function BillingTab() {
 
         {/* General Information Tab */}
         {detailTab === 'general' && (
-          <div className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${theme === 'dark'
-            ? 'bg-[#2d2820]/[0.4] border-white/10'
-            : 'bg-white/[0.12] border-white/20'
-            }`}>
+          <div
+            className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-8 transition-colors ${
+              theme === 'dark'
+                ? 'bg-[#2d2820]/[0.4] border-white/10'
+                : 'bg-white/[0.12] border-white/20'
+            }`}
+          >
             <div className="flex items-center justify-between mb-6">
-              <h3 className={`text-[20px] font-bold transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                }`}>General Information</h3>
+              <h3
+                className={`text-[20px] font-bold transition-colors ${
+                  theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                }`}
+              >
+                General Information
+              </h3>
 
               {/* Status Badge */}
               {selectedProfile.status === 'missing-verification' && kycStatus === null && (
-                <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${theme === 'dark'
-                  ? 'bg-gradient-to-br from-[#f59e0b]/20 to-[#d97706]/15 border-[#f59e0b]/40'
-                  : 'bg-gradient-to-br from-[#f59e0b]/15 to-[#d97706]/10 border-[#f59e0b]/35'
-                  }`}>
-                  <AlertCircle className={`w-4 h-4 ${theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'}`} />
-                  <span className={`text-[13px] font-medium transition-colors ${theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'
-                    }`}>Missing Verification</span>
+                <div
+                  className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-gradient-to-br from-[#f59e0b]/20 to-[#d97706]/15 border-[#f59e0b]/40'
+                      : 'bg-gradient-to-br from-[#f59e0b]/15 to-[#d97706]/10 border-[#f59e0b]/35'
+                  }`}
+                >
+                  <AlertCircle
+                    className={`w-4 h-4 ${theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'}`}
+                  />
+                  <span
+                    className={`text-[13px] font-medium transition-colors ${
+                      theme === 'dark' ? 'text-[#f59e0b]' : 'text-[#d97706]'
+                    }`}
+                  >
+                    Missing Verification
+                  </span>
                 </div>
               )}
 
               {kycStatus === 'in_review' && (
-                <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${theme === 'dark'
-                  ? 'bg-gradient-to-br from-[#c9983a]/20 to-[#d4af37]/15 border-[#c9983a]/40'
-                  : 'bg-gradient-to-br from-[#c9983a]/15 to-[#d4af37]/10 border-[#c9983a]/35'
-                  }`}>
-                  <MessageSquare className={`w-4 h-4 ${theme === 'dark' ? 'text-[#c9983a]' : 'text-[#a67c2e]'}`} />
-                  <span className={`text-[13px] font-medium transition-colors ${theme === 'dark' ? 'text-[#c9983a]' : 'text-[#a67c2e]'
-                    }`}>In Review</span>
+                <div
+                  className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-gradient-to-br from-[#c9983a]/20 to-[#d4af37]/15 border-[#c9983a]/40'
+                      : 'bg-gradient-to-br from-[#c9983a]/15 to-[#d4af37]/10 border-[#c9983a]/35'
+                  }`}
+                >
+                  <MessageSquare
+                    className={`w-4 h-4 ${theme === 'dark' ? 'text-[#c9983a]' : 'text-[#a67c2e]'}`}
+                  />
+                  <span
+                    className={`text-[13px] font-medium transition-colors ${
+                      theme === 'dark' ? 'text-[#c9983a]' : 'text-[#a67c2e]'
+                    }`}
+                  >
+                    In Review
+                  </span>
                 </div>
               )}
 
               {kycStatus === 'rejected' && (
-                <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${theme === 'dark'
-                  ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/50'
-                  : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/50'
-                  }`}>
-                  <AlertCircle className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`} />
-                  <span className={`text-[13px] font-medium transition-colors ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
-                    }`}>Verification Rejected</span>
+                <div
+                  className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/50'
+                      : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/50'
+                  }`}
+                >
+                  <AlertCircle
+                    className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`}
+                  />
+                  <span
+                    className={`text-[13px] font-medium transition-colors ${
+                      theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
+                    }`}
+                  >
+                    Verification Rejected
+                  </span>
                 </div>
               )}
 
               {selectedProfile.status === 'limit-reached' && (
-                <div className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${theme === 'dark'
-                  ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/40'
-                  : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/35'
-                  }`}>
-                  <AlertCircle className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`} />
-                  <span className={`text-[13px] font-medium transition-colors ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
-                    }`}>Individual Limit Reached</span>
+                <div
+                  className={`flex items-center gap-2 px-4 py-2 rounded-[12px] backdrop-blur-[20px] border transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-gradient-to-br from-[#ef4444]/20 to-[#dc2626]/15 border-[#ef4444]/40'
+                      : 'bg-gradient-to-br from-[#ef4444]/15 to-[#dc2626]/10 border-[#ef4444]/35'
+                  }`}
+                >
+                  <AlertCircle
+                    className={`w-4 h-4 ${theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'}`}
+                  />
+                  <span
+                    className={`text-[13px] font-medium transition-colors ${
+                      theme === 'dark' ? 'text-[#ef4444]' : 'text-[#dc2626]'
+                    }`}
+                  >
+                    Individual Limit Reached
+                  </span>
                 </div>
               )}
             </div>
@@ -511,119 +618,169 @@ export function BillingTab() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* First Name */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
                   {selectedProfile.type === 'organization' ? 'Company Name' : 'First Name'}
                 </label>
                 <input
                   type="text"
                   value={selectedProfile.firstName || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* Last Name */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
                   {selectedProfile.type === 'organization' ? 'Legal Form' : 'Last Name'}
                 </label>
                 <input
                   type="text"
                   value={selectedProfile.lastName || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* Address */}
               <div className="md:col-span-2">
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>Address</label>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  Address
+                </label>
                 <input
                   type="text"
                   value={selectedProfile.address || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* City */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>City</label>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  City
+                </label>
                 <input
                   type="text"
                   value={selectedProfile.city || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* Postal Code */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>Postal Code</label>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  Postal Code
+                </label>
                 <input
                   type="text"
                   value={selectedProfile.postalCode || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* Country */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>Country</label>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  Country
+                </label>
                 <input
                   type="text"
                   value={selectedProfile.country || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
 
               {/* Tax ID */}
               <div>
-                <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>
+                <label
+                  className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
                   {selectedProfile.type === 'organization' ? 'Company ID Number' : 'Tax ID'}
                 </label>
                 <input
                   type="text"
                   value={selectedProfile.taxId || ''}
-                  placeholder={selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'}
+                  placeholder={
+                    selectedProfile.status === 'verified' ? '' : 'Will be filled after KYC'
+                  }
                   readOnly
-                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${theme === 'dark'
-                    ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
-                    : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
-                    }`}
+                  className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none text-[14px] transition-colors ${
+                    theme === 'dark'
+                      ? 'bg-[#3d342c]/[0.4] border-white/15 text-[#f5efe5] placeholder-[#8a7e70]/50'
+                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a]/50'
+                  }`}
                 />
               </div>
             </div>
@@ -652,10 +809,10 @@ export function BillingTab() {
                     ) : kycWindowOpened ? (
                       <>
                         <Loader2 className="w-5 h-5 animate-spin" />
-                        {kycStatus === 'pending' || kycStatus === 'not_started' 
-                          ? 'Verification in Progress...' 
-                          : kycStatus === 'in_review' 
-                            ? 'Under Review...' 
+                        {kycStatus === 'pending' || kycStatus === 'not_started'
+                          ? 'Verification in Progress...'
+                          : kycStatus === 'in_review'
+                            ? 'Under Review...'
                             : 'Awaiting Completion...'}
                       </>
                     ) : (
@@ -663,9 +820,12 @@ export function BillingTab() {
                     )}
                   </button>
                   {(isVerifying || kycWindowOpened) && (
-                    <span className={`text-[14px] transition-colors ${theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
-                      }`}>
-                      {isVerifying 
+                    <span
+                      className={`text-[14px] transition-colors ${
+                        theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
+                      }`}
+                    >
+                      {isVerifying
                         ? 'A new window will open for verification. Please complete the process there.'
                         : 'Please complete the verification in the opened window.'}
                     </span>
@@ -675,26 +835,40 @@ export function BillingTab() {
 
             {/* In Review Message */}
             {kycStatus === 'in_review' && (
-              <div className={`mt-8 p-4 rounded-[14px] backdrop-blur-[30px] border transition-colors ${theme === 'dark'
-                ? 'bg-gradient-to-br from-[#2d2820]/[0.4] to-[#3d342c]/[0.3] border-[#c9983a]/30'
-                : 'bg-gradient-to-br from-white/[0.12] to-white/[0.08] border-[#c9983a]/30'
-                }`}>
-                <p className={`text-[14px] transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                  }`}>
-                  Your KYC verification is currently under review. Please wait while we process your information.
+              <div
+                className={`mt-8 p-4 rounded-[14px] backdrop-blur-[30px] border transition-colors ${
+                  theme === 'dark'
+                    ? 'bg-gradient-to-br from-[#2d2820]/[0.4] to-[#3d342c]/[0.3] border-[#c9983a]/30'
+                    : 'bg-gradient-to-br from-white/[0.12] to-white/[0.08] border-[#c9983a]/30'
+                }`}
+              >
+                <p
+                  className={`text-[14px] transition-colors ${
+                    theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                  }`}
+                >
+                  Your KYC verification is currently under review. Please wait while we process your
+                  information.
                 </p>
               </div>
             )}
 
             {/* Rejected Message */}
             {kycStatus === 'rejected' && (
-              <div className={`mt-8 p-4 rounded-[14px] backdrop-blur-[30px] border transition-colors ${theme === 'dark'
-                ? 'bg-gradient-to-br from-[#2d2820]/[0.4] to-[#3d342c]/[0.3] border-[#ef4444]/50'
-                : 'bg-gradient-to-br from-white/[0.12] to-white/[0.08] border-[#ef4444]/50'
-                }`}>
-                <p className={`text-[14px] transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                  }`}>
-                  Your KYC verification was rejected. Please try again or contact support for assistance.
+              <div
+                className={`mt-8 p-4 rounded-[14px] backdrop-blur-[30px] border transition-colors ${
+                  theme === 'dark'
+                    ? 'bg-gradient-to-br from-[#2d2820]/[0.4] to-[#3d342c]/[0.3] border-[#ef4444]/50'
+                    : 'bg-gradient-to-br from-white/[0.12] to-white/[0.08] border-[#ef4444]/50'
+                }`}
+              >
+                <p
+                  className={`text-[14px] transition-colors ${
+                    theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                  }`}
+                >
+                  Your KYC verification was rejected. Please try again or contact support for
+                  assistance.
                 </p>
               </div>
             )}
@@ -703,9 +877,13 @@ export function BillingTab() {
             {selectedProfile.status === 'verified' && (
               <div className="mt-6 flex items-start gap-2 p-4 rounded-[14px] backdrop-blur-[30px] bg-[#c9983a]/10 border border-[#c9983a]/20">
                 <Info className="w-5 h-5 text-[#c9983a] flex-shrink-0 mt-0.5" />
-                <p className={`text-[13px] transition-colors ${theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
-                  }`}>
-                  This profile has been verified. All information is populated from your government ID.
+                <p
+                  className={`text-[13px] transition-colors ${
+                    theme === 'dark' ? 'text-[#c5b5a2]' : 'text-[#6b5d4d]'
+                  }`}
+                >
+                  This profile has been verified. All information is populated from your government
+                  ID.
                 </p>
               </div>
             )}
@@ -723,11 +901,9 @@ export function BillingTab() {
         )}
 
         {/* Invoices Tab */}
-        {detailTab === 'invoices' && (
-          <InvoicesTab invoices={sampleInvoices} />
-        )}
+        {detailTab === 'invoices' && <InvoicesTab invoices={sampleInvoices} />}
       </div>
-    );
+    )
   }
 
   // Profile List View
@@ -736,10 +912,20 @@ export function BillingTab() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className={`text-[28px] font-bold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-            }`}>Billing Profiles</h2>
-          <p className={`text-[14px] transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-            }`}>Manage your billing profiles and payment information.</p>
+          <h2
+            className={`text-[28px] font-bold mb-2 transition-colors ${
+              theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Billing Profiles
+          </h2>
+          <p
+            className={`text-[14px] transition-colors ${
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+            }`}
+          >
+            Manage your billing profiles and payment information.
+          </p>
         </div>
         <button
           onClick={() => setShowModal(true)}
@@ -762,21 +948,32 @@ export function BillingTab() {
           ))}
         </div>
       ) : (
-        <div className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-12 text-center transition-colors ${theme === 'dark'
-          ? 'bg-[#2d2820]/[0.4] border-white/10'
-          : 'bg-white/[0.12] border-white/20'
-          }`}>
-          <div className={`w-16 h-16 rounded-full mx-auto mb-4 flex items-center justify-center ${theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.15]'
-            }`}>
-            <Plus className={`w-8 h-8 ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-              }`} />
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] p-12 text-center transition-colors ${
+            theme === 'dark'
+              ? 'bg-[#2d2820]/[0.4] border-white/10'
+              : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <div
+            className={`w-16 h-16 rounded-full mx-auto mb-4 flex items-center justify-center ${
+              theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.15]'
+            }`}
+          >
+            <Plus className={`w-8 h-8 ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'}`} />
           </div>
-          <p className={`text-[16px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-            }`}>
+          <p
+            className={`text-[16px] font-semibold mb-2 transition-colors ${
+              theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+            }`}
+          >
             No billing profiles yet
           </p>
-          <p className={`text-[14px] transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-            }`}>
+          <p
+            className={`text-[14px] transition-colors ${
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+            }`}
+          >
             Create your first billing profile to start receiving payments
           </p>
         </div>
@@ -785,10 +982,13 @@ export function BillingTab() {
       {/* Create Profile Modal */}
       {showModal && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-          <div className={`relative w-full max-w-md rounded-[24px] border shadow-[0_20px_60px_rgba(0,0,0,0.15)] p-8 backdrop-blur-[40px] ${theme === 'dark'
-            ? 'bg-gradient-to-br from-[#2d2820]/[0.4] via-[#3d342c]/[0.4] to-[#2d2820]/[0.4] border-white/10'
-            : 'bg-gradient-to-br from-white/[0.12] via-white/[0.15] to-white/[0.12] border-white/20'
-            }`}>
+          <div
+            className={`relative w-full max-w-md rounded-[24px] border shadow-[0_20px_60px_rgba(0,0,0,0.15)] p-8 backdrop-blur-[40px] ${
+              theme === 'dark'
+                ? 'bg-gradient-to-br from-[#2d2820]/[0.4] via-[#3d342c]/[0.4] to-[#2d2820]/[0.4] border-white/10'
+                : 'bg-gradient-to-br from-white/[0.12] via-white/[0.15] to-white/[0.12] border-white/20'
+            }`}
+          >
             {/* Golden Glow Effects */}
             <div className="absolute inset-0 opacity-15 pointer-events-none">
               <div className="absolute top-1/4 left-1/4 w-32 h-32 bg-[#c9983a]/30 rounded-full blur-[60px]" />
@@ -797,39 +997,62 @@ export function BillingTab() {
 
             <div className="relative z-10">
               <div className="flex items-center justify-between mb-6">
-                <h3 className={`text-[20px] font-bold transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                  }`}>Create Billing Profile</h3>
-                <button onClick={() => setShowModal(false)} className={`w-8 h-8 rounded-[10px] backdrop-blur-[20px] border flex items-center justify-center transition-all ${theme === 'dark'
-                  ? 'bg-white/[0.1] hover:bg-white/[0.15] border-white/20'
-                  : 'bg-white/[0.3] hover:bg-white/[0.5] border-white/40'
-                  }`}>
-                  <X className={`w-4 h-4 transition-colors ${theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                    }`} />
+                <h3
+                  className={`text-[20px] font-bold transition-colors ${
+                    theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  Create Billing Profile
+                </h3>
+                <button
+                  onClick={() => setShowModal(false)}
+                  className={`w-8 h-8 rounded-[10px] backdrop-blur-[20px] border flex items-center justify-center transition-all ${
+                    theme === 'dark'
+                      ? 'bg-white/[0.1] hover:bg-white/[0.15] border-white/20'
+                      : 'bg-white/[0.3] hover:bg-white/[0.5] border-white/40'
+                  }`}
+                >
+                  <X
+                    className={`w-4 h-4 transition-colors ${
+                      theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                    }`}
+                  />
                 </button>
               </div>
 
               <div className="space-y-4">
                 <div>
-                  <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                    }`}>Profile Name</label>
+                  <label
+                    className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                      theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    Profile Name
+                  </label>
                   <input
                     type="text"
                     value={profileName}
                     onChange={(e) => setProfileName(e.target.value)}
                     placeholder="Enter profile name"
-                    className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:border-[#c9983a]/30 transition-all text-[14px] ${theme === 'dark'
-                      ? 'bg-white/[0.08] border-white/15 text-[#f5efe5] placeholder-[#8a7e70] focus:bg-white/[0.12]'
-                      : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a] focus:bg-white/[0.2]'
-                      }`}
+                    className={`w-full px-4 py-3 rounded-[14px] backdrop-blur-[30px] border focus:outline-none focus:border-[#c9983a]/30 transition-all text-[14px] ${
+                      theme === 'dark'
+                        ? 'bg-white/[0.08] border-white/15 text-[#f5efe5] placeholder-[#8a7e70] focus:bg-white/[0.12]'
+                        : 'bg-white/[0.15] border-white/25 text-[#2d2820] placeholder-[#7a6b5a] focus:bg-white/[0.2]'
+                    }`}
                   />
                 </div>
 
                 <div>
-                  <label className={`block text-[14px] font-semibold mb-2 transition-colors ${theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
-                    }`}>Profile Type</label>
+                  <label
+                    className={`block text-[14px] font-semibold mb-2 transition-colors ${
+                      theme === 'dark' ? 'text-[#f5efe5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    Profile Type
+                  </label>
                   <div className="relative">
                     {(() => {
-                      const hasIndividualProfile = profiles.some(p => p.type === 'individual');
+                      const hasIndividualProfile = profiles.some((p) => p.type === 'individual')
                       return (
                         <ProfileTypeSelect
                           value={profileType}
@@ -837,13 +1060,17 @@ export function BillingTab() {
                           hasIndividualProfile={hasIndividualProfile}
                           theme={theme}
                         />
-                      );
+                      )
                     })()}
                   </div>
-                  {profiles.some(p => p.type === 'individual') && (
-                    <p className={`text-[12px] mt-2 transition-colors ${theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#6b7280]'
-                      }`}>
-                      An individual profile already exists. You can only create one individual profile.
+                  {profiles.some((p) => p.type === 'individual') && (
+                    <p
+                      className={`text-[12px] mt-2 transition-colors ${
+                        theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#6b7280]'
+                      }`}
+                    >
+                      An individual profile already exists. You can only create one individual
+                      profile.
                     </p>
                   )}
                 </div>
@@ -852,10 +1079,11 @@ export function BillingTab() {
               <div className="flex items-center gap-3 mt-6">
                 <button
                   onClick={() => setShowModal(false)}
-                  className={`flex-1 px-6 py-3 rounded-[12px] backdrop-blur-[30px] border font-medium text-[14px] transition-all ${theme === 'dark'
-                    ? 'bg-white/[0.1] border-white/20 text-[#d4c5b0] hover:bg-white/[0.15]'
-                    : 'bg-white/[0.2] border-white/30 text-[#2d2820] hover:bg-white/[0.25]'
-                    }`}
+                  className={`flex-1 px-6 py-3 rounded-[12px] backdrop-blur-[30px] border font-medium text-[14px] transition-all ${
+                    theme === 'dark'
+                      ? 'bg-white/[0.1] border-white/20 text-[#d4c5b0] hover:bg-white/[0.15]'
+                      : 'bg-white/[0.2] border-white/30 text-[#2d2820] hover:bg-white/[0.25]'
+                  }`}
                 >
                   Cancel
                 </button>
@@ -871,5 +1099,5 @@ export function BillingTab() {
         </div>
       )}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary

This PR fixes a rendering issue in the Billing Profile Detail View where a stray `)` character was unintentionally rendered due to an orphaned JSX text node.
fixes #560 

The issue occurred immediately after the conditional `errorMessage` block, causing the parenthesis to appear every time a billing profile was opened, regardless of whether an error message was present.

## Changes

- Removed the orphaned JSX `)` from the Billing Profile Detail View.
- Added regression tests covering:
  - Rendering the profile detail view without unexpected text.
  - Rendering with an active error message.
  - Verifying the error banner and "Back to billing profiles" button remain correctly rendered and adjacent.
- Preserved all existing BillingTab functionality and styling.

## Testing

```bash
npm test -- --run BillingTab
```

## Result

- ✅ The stray `)` no longer renders in the profile detail view.
- ✅ Error banner and Back button render correctly.
- ✅ Existing behavior remains unchanged.
- ✅ Regression tests prevent this issue from recurring.