### PR TITLE
test: add skeleton-to-content transition coverage for maintainer StatsCard

### DIFF
--- a/src/features/maintainers/components/dashboard/DashboardTab.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState, useMemo, useCallback } from 'react'
 import { FileText, GitPullRequest, GitMerge, AlertCircle, FolderOpen } from 'lucide-react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { StatsCard } from './StatsCard'
-import { StatsCardSkeleton } from './StatsCardSkeleton'
 import { ActivityItem } from './ActivityItem'
 import { ApplicationsChart } from './ApplicationsChart'
 import { StatCard, Activity, ChartDataPoint } from '../../types'
@@ -437,7 +436,7 @@ export function DashboardTab({
       {/* Stats Cards */}
       <div className="grid grid-cols-4 gap-5">
         {showLoading
-          ? [...Array(4)].map((_, idx) => <StatsCardSkeleton key={idx} />)
+          ? [...Array(4)].map((_, idx) => <StatsCard key={idx} index={idx} loading />)
           : stats.map((stat, idx) => <StatsCard key={stat.id} stat={stat} index={idx} />)}
       </div>
 

--- a/src/features/maintainers/components/dashboard/StatsCard.test.tsx
+++ b/src/features/maintainers/components/dashboard/StatsCard.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, within } from '@testing-library/react'
+import { FileText } from 'lucide-react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { StatCard } from '../../types'
+import { StatsCard } from './StatsCard'
+
+const themeState = vi.hoisted(() => ({ current: 'dark' as 'dark' | 'light' }))
+
+vi.mock('../../../../shared/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: themeState.current }),
+}))
+
+const loadedStat: StatCard = {
+  id: 1,
+  title: 'Issue Views',
+  subtitle: 'Last 7 days',
+  value: 27,
+  change: 12,
+  icon: FileText,
+}
+
+describe('StatsCard', () => {
+  beforeEach(() => {
+    themeState.current = 'dark'
+  })
+
+  it('transitions directly from its skeleton to real data without committing a zero or empty value', async () => {
+    const { container, rerender } = render(<StatsCard loading index={0} />)
+    const committedValues = ['loading']
+    const observer = new MutationObserver(() => {
+      committedValues.push(
+        container.querySelector('[data-testid="stats-card-value"]')?.textContent ?? 'loading'
+      )
+    })
+    observer.observe(container, { childList: true, subtree: true, characterData: true })
+
+    expect(screen.getAllByTestId('skeleton-loader')).toHaveLength(5)
+    expect(screen.queryByTestId('stats-card-value')).not.toBeInTheDocument()
+    expect(container).not.toHaveTextContent(/\b0\b/)
+
+    rerender(<StatsCard loading={false} stat={loadedStat} index={0} />)
+    await Promise.resolve()
+    observer.disconnect()
+
+    expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument()
+    expect(screen.getByText('Issue Views')).toBeInTheDocument()
+    expect(screen.getByTestId('stats-card-value')).toHaveTextContent('27')
+    expect(committedValues).toContain('27')
+    expect(committedValues).not.toContain('0')
+    expect(committedValues).not.toContain('')
+  })
+
+  it('transitions from loading to a visually and semantically distinct error state', () => {
+    const { rerender } = render(<StatsCard loading />)
+
+    rerender(<StatsCard loading={false} error="Fetch failed" />)
+
+    const errorCard = screen.getByRole('alert')
+    expect(errorCard).toHaveAttribute('data-state', 'error')
+    expect(errorCard).toHaveClass('border-red-400/40')
+    expect(errorCard).toHaveTextContent('Unable to load statistic')
+    expect(errorCard).toHaveTextContent('Fetch failed')
+    expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('stats-card-value')).not.toBeInTheDocument()
+    expect(errorCard).not.toHaveTextContent(/\b0\b/)
+  })
+
+  it('defaults an uninitialized mount to the skeleton instead of a zero-value card', () => {
+    const { container } = render(<StatsCard />)
+
+    expect(screen.getAllByTestId('skeleton-loader')).toHaveLength(5)
+    expect(screen.queryByTestId('stats-card')).not.toBeInTheDocument()
+    expect(container).not.toHaveTextContent(/\b0\b/)
+  })
+
+  it.each([
+    { change: 12, label: '+12%', colourClass: 'bg-green-500/20' },
+    { change: -8, label: '-8%', colourClass: 'bg-red-500/20' },
+    { change: 0, label: '0%', colourClass: 'bg-[#7a6b5a]/20' },
+  ])('preserves loaded rendering for a $change percent trend', ({ change, label, colourClass }) => {
+    themeState.current = change === 0 ? 'light' : 'dark'
+    const stat = { ...loadedStat, value: change === 0 ? 0 : 27, change }
+
+    render(<StatsCard stat={stat} index={2} />)
+
+    const card = screen.getByTestId('stats-card')
+    expect(card).toHaveAttribute('data-state', 'loaded')
+    expect(within(card).getByTestId('stats-card-value')).toHaveTextContent(String(stat.value))
+    expect(within(card).getByText(label)).toHaveClass(colourClass)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/maintainers/components/dashboard/StatsCard.tsx
+++ b/src/features/maintainers/components/dashboard/StatsCard.tsx
@@ -1,21 +1,71 @@
-import { TrendingUp, TrendingDown } from 'lucide-react';
-import { useTheme } from '../../../../shared/contexts/ThemeContext';
-import { StatCard as StatCardType } from '../../types';
+import { AlertCircle, TrendingUp, TrendingDown } from 'lucide-react'
+import { useTheme } from '../../../../shared/contexts/ThemeContext'
+import { StatCard as StatCardType } from '../../types'
+import { StatsCardSkeleton } from './StatsCardSkeleton'
 
 interface StatsCardProps {
-  stat: StatCardType;
-  index: number;
+  /** Populated statistic. Omit it until data has been loaded successfully. */
+  stat?: StatCardType
+  index?: number
+  /** Shows the skeleton and takes precedence over stale data or errors. */
+  loading?: boolean
+  /** Fetch failure message. Rendered only after loading has finished. */
+  error?: string | null
 }
 
-export function StatsCard({ stat, index }: StatsCardProps) {
-  const { theme } = useTheme();
-  const Icon = stat.icon;
-  const isPositive = stat.change > 0;
-  const isNegative = stat.change < 0;
-  const isNeutral = stat.change === 0;
+/**
+ * Renders exactly one explicit statistic state: loading, error, or loaded.
+ *
+ * Missing data is treated as loading so an uninitialized card can never flash
+ * an invented zero value. A real loaded statistic whose value is zero remains
+ * valid and is rendered normally.
+ */
+export function StatsCard({ stat, index = 0, loading = false, error = null }: StatsCardProps) {
+  const { theme } = useTheme()
+
+  if (loading) {
+    return <StatsCardSkeleton />
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-state="error"
+        data-testid="stats-card-error"
+        className={`backdrop-blur-[40px] rounded-[18px] border p-6 relative overflow-hidden ${
+          theme === 'dark'
+            ? 'bg-red-500/10 border-red-400/40 text-red-300'
+            : 'bg-red-50/70 border-red-500/40 text-red-700'
+        }`}
+        style={{ animationDelay: `${index * 50}ms` }}
+      >
+        <div className="flex items-start gap-3">
+          <AlertCircle className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+          <div>
+            <h3 className="text-[12px] font-bold uppercase tracking-wide mb-1">
+              Unable to load statistic
+            </h3>
+            <p className="text-[11px]">{error}</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!stat) {
+    return <StatsCardSkeleton />
+  }
+
+  const Icon = stat.icon
+  const isPositive = stat.change > 0
+  const isNegative = stat.change < 0
+  const isNeutral = stat.change === 0
 
   return (
     <div
+      data-state="loaded"
+      data-testid="stats-card"
       className={`backdrop-blur-[40px] rounded-[18px] border p-6 hover:scale-105 transition-all duration-300 group relative overflow-hidden ${
         theme === 'dark'
           ? 'bg-[#2d2820]/[0.4] border-white/10 hover:bg-[#2d2820]/[0.5]'
@@ -29,27 +79,37 @@ export function StatsCard({ stat, index }: StatsCardProps) {
       {/* Header */}
       <div className="relative flex items-start justify-between mb-4">
         <div className="flex-1">
-          <h3 className={`text-[12px] font-bold uppercase tracking-wide mb-1 transition-colors ${
-            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-          }`}>
+          <h3
+            className={`text-[12px] font-bold uppercase tracking-wide mb-1 transition-colors ${
+              theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+            }`}
+          >
             {stat.title}
           </h3>
-          <p className={`text-[10px] transition-colors ${
-            theme === 'dark' ? 'text-[#9a8b7a]' : 'text-[#9a8b7a]'
-          }`}>{stat.subtitle}</p>
+          <p
+            className={`text-[10px] transition-colors ${
+              theme === 'dark' ? 'text-[#9a8b7a]' : 'text-[#9a8b7a]'
+            }`}
+          >
+            {stat.subtitle}
+          </p>
         </div>
-        
+
         {/* Icon with trend indicator */}
         <div className="relative">
           <div className="w-10 h-10 rounded-[12px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/15 border border-[#c9983a]/30 flex items-center justify-center group-hover:scale-110 transition-transform">
             <Icon className="w-5 h-5 text-[#c9983a]" />
           </div>
-          
+
           {/* Trend Arrow */}
           {!isNeutral && (
-            <div className={`absolute -top-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center ${
-              isPositive ? 'bg-gradient-to-br from-[#4ade80] to-[#22c55e]' : 'bg-gradient-to-br from-[#f87171] to-[#ef4444]'
-            }`}>
+            <div
+              className={`absolute -top-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center ${
+                isPositive
+                  ? 'bg-gradient-to-br from-[#4ade80] to-[#22c55e]'
+                  : 'bg-gradient-to-br from-[#f87171] to-[#ef4444]'
+              }`}
+            >
               {isPositive ? (
                 <TrendingUp className="w-3 h-3 text-white" strokeWidth={3} />
               ) : (
@@ -62,25 +122,31 @@ export function StatsCard({ stat, index }: StatsCardProps) {
 
       {/* Value */}
       <div className="relative">
-        <div className={`text-[42px] font-black leading-none mb-2 group-hover:scale-105 transition-all origin-left ${
-          theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
-        }`}>
+        <div
+          data-testid="stats-card-value"
+          className={`text-[42px] font-black leading-none mb-2 group-hover:scale-105 transition-all origin-left ${
+            theme === 'dark' ? 'text-[#e8dfd0]' : 'text-[#2d2820]'
+          }`}
+        >
           {stat.value}
         </div>
-        
+
         {/* Change Percentage */}
         <div className="flex items-center gap-2">
-          <div className={`px-2.5 py-1 rounded-[6px] text-[11px] font-bold ${
-            isPositive 
-              ? 'bg-green-500/20 text-green-700 border border-green-500/30' 
-              : isNegative 
-              ? 'bg-red-500/20 text-red-700 border border-red-500/30'
-              : 'bg-[#7a6b5a]/20 text-[#7a6b5a] border border-[#7a6b5a]/30'
-          }`}>
-            {isPositive && '+'}{stat.change}%
+          <div
+            className={`px-2.5 py-1 rounded-[6px] text-[11px] font-bold ${
+              isPositive
+                ? 'bg-green-500/20 text-green-700 border border-green-500/30'
+                : isNegative
+                  ? 'bg-red-500/20 text-red-700 border border-red-500/30'
+                  : 'bg-[#7a6b5a]/20 text-[#7a6b5a] border border-[#7a6b5a]/30'
+            }`}
+          >
+            {isPositive && '+'}
+            {stat.change}%
           </div>
         </div>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
Closes #516 

## Summary

Adds explicit loading, loaded, missing-data, and error-state handling to the maintainer dashboard `StatsCard`.

This prevents the card from briefly displaying a default or empty `0` value before real statistics are available.

## Changes

- Added a `loading` prop to `StatsCard`.
- Added an error state with distinct alert styling and accessible `role="alert"`.
- Treats missing statistic data as loading instead of rendering a default value.
- Preserves legitimate loaded statistics whose value is `0`.
- Updated `DashboardTab` to render loading cards through `StatsCard`.
- Added focused tests covering:
  - Loading → loaded transition.
  - Loading → error transition.
  - Initial mount without a loading flag or statistic data.
  - Valid zero-value statistics.
  - Positive, negative, and neutral trends.

## Verification

```text
npm test -- StatsCard

Test Files  1 passed (1)
Tests       6 passed (6)