### PR TITLE
test: add localization fallback coverage for backend error-code messages

### DIFF
--- a/src/shared/i18n/errors.test.tsx
+++ b/src/shared/i18n/errors.test.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from 'react'
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { ReactIntlErrorCode } from 'react-intl'
+
+import {
+  handleIntlError,
+  getErrorCodeMessage,
+  useErrorCodeMessage,
+  ERROR_CODE_TAXONOMY,
+  I18nProvider,
+  en,
+  type Locale,
+  type Messages,
+} from './index'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>
+}
+
+describe('getErrorCodeMessage', () => {
+  it('renders correct localized message for a known error code in supported locales', () => {
+    // English default locale
+    expect(getErrorCodeMessage('UNAUTHORIZED', 'en')).toBe(en['errors.code.UNAUTHORIZED'])
+    expect(getErrorCodeMessage('FORBIDDEN', 'en')).toBe(en['errors.code.FORBIDDEN'])
+    expect(getErrorCodeMessage('NOT_FOUND', 'en')).toBe(en['errors.code.NOT_FOUND'])
+    expect(getErrorCodeMessage('RATE_LIMITED', 'en')).toBe(en['errors.code.RATE_LIMITED'])
+
+    // Spanish active locale
+    expect(getErrorCodeMessage('UNAUTHORIZED', 'es')).toBe(
+      'Su sesión ha expirado. Por favor, inicie sesión de nuevo.'
+    )
+    expect(getErrorCodeMessage('FORBIDDEN', 'es')).toBe(
+      'No tiene permiso para realizar esta acción.'
+    )
+    expect(getErrorCodeMessage('NOT_FOUND', 'es')).toBe(
+      'El recurso solicitado no se pudo encontrar.'
+    )
+  })
+
+  it('falls back to default (English) locale when translation is missing in active locale', () => {
+    // 'RATE_LIMITED' is omitted from the Spanish catalog; it must fall back to English
+    const spanishResult = getErrorCodeMessage('RATE_LIMITED', 'es')
+
+    expect(spanishResult).toBe(en['errors.code.RATE_LIMITED'])
+    expect(spanishResult).not.toBe('errors.code.RATE_LIMITED')
+    expect(spanishResult).not.toBeUndefined()
+
+    // Test with a custom partial registry where 'FORBIDDEN' is missing
+    const customRegistry: Record<string, Partial<Messages>> = {
+      es: {
+        'errors.generic': 'Error genérico',
+        // 'errors.code.FORBIDDEN' is intentionally missing
+      },
+    }
+
+    const fallbackResult = getErrorCodeMessage('FORBIDDEN', 'es' as Locale, customRegistry)
+    expect(fallbackResult).toBe(en['errors.code.FORBIDDEN'])
+    expect(fallbackResult).not.toContain('errors.code')
+  })
+
+  it('renders a safe generic fallback message for completely unknown error codes', () => {
+    const unknownEn = getErrorCodeMessage('COMPLETELY_UNKNOWN_CODE', 'en')
+    expect(unknownEn).toBe('An unexpected error occurred. Please try again.')
+    expect(unknownEn).not.toBe('COMPLETELY_UNKNOWN_CODE')
+    expect(unknownEn).not.toBe('errors.generic')
+    expect(unknownEn).not.toBeUndefined()
+
+    const unknownEs = getErrorCodeMessage('INVALID_TAXONOMY_123', 'es')
+    expect(unknownEs).toBe('Ocurrió un error inesperado. Por favor, inténtelo de nuevo.')
+    expect(unknownEs).not.toBe('INVALID_TAXONOMY_123')
+    expect(unknownEs).not.toBeUndefined()
+  })
+
+  it('handles null, undefined, and non-string error code inputs gracefully', () => {
+    expect(getErrorCodeMessage(null, 'en')).toBe('An unexpected error occurred. Please try again.')
+    expect(getErrorCodeMessage(undefined, 'en')).toBe(
+      'An unexpected error occurred. Please try again.'
+    )
+    expect(getErrorCodeMessage('' as string, 'en')).toBe(
+      'An unexpected error occurred. Please try again.'
+    )
+    expect(getErrorCodeMessage(123 as unknown as string, 'en')).toBe(
+      'An unexpected error occurred. Please try again.'
+    )
+  })
+
+  it('falls back to default English catalog when active locale itself is unsupported', () => {
+    const result = getErrorCodeMessage('UNAUTHORIZED', 'fr' as Locale)
+    expect(result).toBe(en['errors.code.UNAUTHORIZED'])
+  })
+
+  it('falls back to hardcoded string when catalog has no generic error message', () => {
+    const emptyRegistry: Record<string, Partial<Messages>> = {
+      en: {},
+      es: {},
+    }
+    const result = getErrorCodeMessage('UNKNOWN_ERROR_CODE', 'es' as Locale, emptyRegistry)
+    expect(result).toBe('An unexpected error occurred. Please try again.')
+  })
+
+  it('covers all mapped error codes in ERROR_CODE_TAXONOMY against default catalog', () => {
+    Object.keys(ERROR_CODE_TAXONOMY).forEach((code) => {
+      const msg = getErrorCodeMessage(code, 'en')
+      expect(msg).toBeTruthy()
+      expect(msg).not.toBe('errors.generic')
+      expect(msg).not.toContain('errors.code.')
+    })
+  })
+})
+
+describe('useErrorCodeMessage hook', () => {
+  it('resolves error messages using the active provider locale', () => {
+    const { result } = renderHook(() => useErrorCodeMessage(), { wrapper })
+
+    expect(result.current.locale).toBe('en')
+    expect(result.current.getErrorMessage('UNAUTHORIZED')).toBe(en['errors.code.UNAUTHORIZED'])
+    expect(result.current.getErrorMessage('UNKNOWN_CODE')).toBe(
+      'An unexpected error occurred. Please try again.'
+    )
+    expect(result.current.getErrorMessage()).toBe(
+      'An unexpected error occurred. Please try again.'
+    )
+  })
+})
+
+describe('handleIntlError', () => {
+  it('swallows non-fatal missing-translation and missing-data errors', () => {
+    expect(() =>
+      handleIntlError({ code: ReactIntlErrorCode.MISSING_TRANSLATION } as never)
+    ).not.toThrow()
+    expect(() => handleIntlError({ code: ReactIntlErrorCode.MISSING_DATA } as never)).not.toThrow()
+  })
+
+  it('re-throws unexpected error codes', () => {
+    expect(() =>
+      handleIntlError({
+        code: ReactIntlErrorCode.FORMAT_ERROR,
+        message: 'Formatting error',
+      } as never)
+    ).toThrow()
+  })
+})

--- a/src/shared/i18n/errors.ts
+++ b/src/shared/i18n/errors.ts
@@ -1,4 +1,83 @@
 import { ReactIntlErrorCode, type IntlConfig } from 'react-intl'
+import {
+  resolveMessages,
+  DEFAULT_LOCALE,
+  type Locale,
+  type MessageId,
+  type Messages,
+} from './messages'
+import { useTranslation } from './useTranslation'
+
+/**
+ * Mapping of backend API error codes (per Go backend error taxonomy)
+ * to catalog message identifiers.
+ */
+export const ERROR_CODE_TAXONOMY: Record<string, MessageId> = {
+  UNAUTHORIZED: 'errors.code.UNAUTHORIZED',
+  FORBIDDEN: 'errors.code.FORBIDDEN',
+  NOT_FOUND: 'errors.code.NOT_FOUND',
+  RATE_LIMITED: 'errors.code.RATE_LIMITED',
+  BAD_REQUEST: 'errors.code.BAD_REQUEST',
+  INTERNAL_ERROR: 'errors.code.INTERNAL_ERROR',
+  SERVICE_UNAVAILABLE: 'errors.code.SERVICE_UNAVAILABLE',
+}
+
+/**
+ * Resolves a backend error code to a localized, user-facing error message.
+ *
+ * Fallback chain:
+ * 1. Active locale translation for the error code (if present).
+ * 2. Default (English) catalog translation for the error code (if active locale is missing key).
+ * 3. Localized generic error fallback message (`errors.generic`).
+ * 4. English base generic error message ("An unexpected error occurred. Please try again.").
+ *
+ * Guarantees a safe, user-readable string is returned, never returning a raw i18n key or 'undefined'.
+ *
+ * @param code - The backend error code (e.g. `'UNAUTHORIZED'`, `'NOT_FOUND'`, or an unknown string).
+ * @param locale - Target locale code (defaults to English base locale).
+ * @param registry - Custom catalog registry (injectable for testing).
+ * @returns Localized error message string.
+ */
+export function getErrorCodeMessage(
+  code?: string | null,
+  locale: Locale = DEFAULT_LOCALE,
+  registry?: Record<string, Partial<Messages>>
+): string {
+  const messages = resolveMessages(locale, registry)
+  const defaultMessages = resolveMessages(DEFAULT_LOCALE, registry)
+  const genericFallback =
+    messages['errors.generic'] ??
+    defaultMessages['errors.generic'] ??
+    'An unexpected error occurred. Please try again.'
+
+  if (!code || typeof code !== 'string') {
+    return genericFallback
+  }
+
+  const messageId = ERROR_CODE_TAXONOMY[code]
+  if (!messageId) {
+    return genericFallback
+  }
+
+  return messages[messageId] ?? defaultMessages[messageId] ?? genericFallback
+}
+
+/**
+ * React hook that returns a function for getting localized error code messages
+ * bound to the active translation context.
+ *
+ * @example
+ * const { getErrorMessage } = useErrorCodeMessage()
+ * const message = getErrorMessage('UNAUTHORIZED')
+ */
+export function useErrorCodeMessage() {
+  const { locale } = useTranslation()
+
+  return {
+    getErrorMessage: (code?: string | null) => getErrorCodeMessage(code, locale),
+    locale,
+  }
+}
 
 /**
  * react-intl error policy.
@@ -23,3 +102,4 @@ export const handleIntlError: NonNullable<IntlConfig['onError']> = (error) => {
   }
   throw error
 }
+

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -18,7 +18,7 @@ export {
   type LocaleContextValue,
 } from './LocaleProvider'
 export { LocaleSwitcher, type LocaleSwitcherProps } from './LocaleSwitcher'
-export { handleIntlError } from './errors'
+export { handleIntlError, ERROR_CODE_TAXONOMY, getErrorCodeMessage, useErrorCodeMessage } from './errors'
 export { useTranslation, type TranslationValues, type UseTranslation } from './useTranslation'
 export { useIntlFormatters, type UseIntlFormatters, type FormatDateOptions, type FormatNumberOptions, type FormatCurrencyOptions } from './useIntlFormatters'
 export {

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -185,6 +185,16 @@ export const en = {
   'invoices.status.pending': 'pending',
   'invoices.status.overdue': 'overdue',
   'invoices.errors.downloadFailed': 'Download failed. Please try again.',
+
+  // ── Backend API Error Taxonomy ──
+  'errors.generic': 'An unexpected error occurred. Please try again.',
+  'errors.code.UNAUTHORIZED': 'Your session has expired. Please sign in again.',
+  'errors.code.FORBIDDEN': 'You do not have permission to perform this action.',
+  'errors.code.NOT_FOUND': 'The requested resource could not be found.',
+  'errors.code.RATE_LIMITED': 'Too many requests. Please try again later.',
+  'errors.code.BAD_REQUEST': 'Invalid request parameters. Please check your input and try again.',
+  'errors.code.INTERNAL_ERROR': 'Our servers are experiencing issues. Please try again later.',
+  'errors.code.SERVICE_UNAVAILABLE': 'Service is temporarily unavailable. Please try again later.',
 } as const
 
 /**
@@ -209,6 +219,10 @@ export const es: Partial<Messages> = {
   'dashboardNav.discover': 'Descubrir',
   'dashboardNav.browse': 'Explorar',
   'dashboardNav.leaderboard': 'Clasificación',
+  'errors.generic': 'Ocurrió un error inesperado. Por favor, inténtelo de nuevo.',
+  'errors.code.UNAUTHORIZED': 'Su sesión ha expirado. Por favor, inicie sesión de nuevo.',
+  'errors.code.FORBIDDEN': 'No tiene permiso para realizar esta acción.',
+  'errors.code.NOT_FOUND': 'El recurso solicitado no se pudo encontrar.',
 }
 
 /**


### PR DESCRIPTION
Closes #520 
# test: add localization fallback coverage for backend error-code messages

## 📌 Summary

This PR resolves missing localization testing and fallback handling for backend error codes mapped to user-facing messages. It introduces a structured mapping of backend error taxonomy codes to i18n catalog message keys, implements a guaranteed fallback chain in `src/shared/i18n/errors.ts`, and adds comprehensive unit test coverage in `src/shared/i18n/errors.test.tsx`.

---

## 🛠️ Changes Implemented

### 1. Catalog Updates (`src/shared/i18n/messages.ts`)
- Added backend error taxonomy message keys (`errors.code.*` and `errors.generic`) to the base English catalog (`en`):
  - `errors.generic`: `"An unexpected error occurred. Please try again."`
  - `errors.code.UNAUTHORIZED`: `"Your session has expired. Please sign in again."`
  - `errors.code.FORBIDDEN`: `"You do not have permission to perform this action."`
  - `errors.code.NOT_FOUND`: `"The requested resource could not be found."`
  - `errors.code.RATE_LIMITED`: `"Too many requests. Please try again later."`
  - `errors.code.BAD_REQUEST`: `"Invalid request parameters. Please check your input and try again."`
  - `errors.code.INTERNAL_ERROR`: `"Our servers are experiencing issues. Please try again later."`
  - `errors.code.SERVICE_UNAVAILABLE`: `"Service is temporarily unavailable. Please try again later."`
- Added partial Spanish (`es`) translations for a subset of error codes (`UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `errors.generic`), intentionally omitting `RATE_LIMITED` to test fallback to the base English catalog when active in `es`.

### 2. Error Message Resolution & Fallback Logic (`src/shared/i18n/errors.ts`)
- **`ERROR_CODE_TAXONOMY`**: Exported dictionary mapping backend error code strings to valid `MessageId` catalog keys.
- **`getErrorCodeMessage(code?, locale?, registry?)`**: Implemented a resolution function with a strict 4-step fallback chain:
  1. **Active Locale Translation**: Resolves `code` in the active locale catalog (e.g. Spanish).
  2. **Base Default Locale Translation**: If absent in active locale, resolves the English base value.
  3. **Active Locale Generic Fallback**: If `code` is unknown/unmapped, falls back to `errors.generic` in the active locale.
  4. **Base English Generic String**: Hardcoded fallback ensuring raw keys (e.g. `'errors.code.XXX'`) or `'undefined'` are **never** rendered to users.
- **`useErrorCodeMessage()`**: Added a React hook bound to the active `I18nProvider` locale context.

### 3. Module Exports (`src/shared/i18n/index.ts`)
- Re-exported `ERROR_CODE_TAXONOMY`, `getErrorCodeMessage`, and `useErrorCodeMessage` from the public i18n surface.

### 4. Unit Test Suite (`src/shared/i18n/errors.test.tsx`)
Added 10 tests in `src/shared/i18n/errors.test.tsx` verifying:
- ✅ **Known error code in supported locales**: Renders exact localized text in English & Spanish.
- ✅ **Missing translation in active locale**: `RATE_LIMITED` in Spanish falls back to English `"Too many requests. Please try again later."` without rendering a raw key.
- ✅ **Completely unknown error code**: Unmapped codes render `"An unexpected error occurred. Please try again."` (or Spanish equivalent) instead of raw code strings.
- ✅ **Edge case handling**: `null`, `undefined`, `""`, and non-string inputs gracefully fall back to generic error text.
- ✅ **Unsupported locale codes**: Unknown locale codes (e.g. `'fr'`) safely degrade to English defaults.
- ✅ **Hook & Error Policy**: Tests for `useErrorCodeMessage()` React hook integration and `handleIntlError()` non-fatal error swallowing / re-throwing.

---

## 🧪 Verification & Test Results

All 4 test suites in the `src/shared/i18n` module were executed and passed cleanly:

```bash
$ npm test -- run src/shared/i18n

 RUN  v4.1.10 C:/Users/HP/Grainlify-Frontend

 ✓ src/shared/i18n/errors.test.tsx (10 tests) 111ms
 ✓ src/shared/i18n/useIntlFormatters.test.ts (12 tests) 234ms
 ✓ src/shared/i18n/i18n.test.tsx (12 tests) 436ms
 ✓ src/shared/i18n/locale.test.tsx (10 tests) 521ms

 Test Files  4 passed (4)
      Tests  44 passed (44)
   Duration  9.51s
```

---

## 🔒 Security & UX Considerations

- Prevents raw untranslated i18n keys or `undefined` strings from leaking to users during API failures.
- Ensures critical authentication and permission error messages (`UNAUTHORIZED`, `FORBIDDEN`) remain clear and user-friendly in all supported locales.

---

## 🔗 Branch Details

- **Branch**: `test/i18n-error-message-fallback`
- **Upstream**: Set to `origin/test/i18n-error-message-fallback`
- **Commit**: `c249dc5` (`test: add localization fallback coverage for backend error-code messages`)