### PR TITLE
test: add cancellation and confirmation-failure coverage to the GitHu…

### DIFF
--- a/src/features/maintainers/components/InstallGitHubAppModal.test.tsx
+++ b/src/features/maintainers/components/InstallGitHubAppModal.test.tsx
@@ -207,4 +207,156 @@ describe('InstallGitHubAppModal', () => {
       expect(toast.error).not.toHaveBeenCalled()
     })
   })
+
+  describe('cancellation, confirmation failure, and retry flows', () => {
+    it('displays a clear, non-error cancelled state when user cancels on GitHub', async () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, search: '?setup_action=cancel' } as Location,
+      })
+
+      render(
+        <InstallGitHubAppModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('github-app-cancelled-state')).toBeInTheDocument()
+        expect(screen.getByText('Installation Cancelled')).toBeInTheDocument()
+      })
+
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(toast.error).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+
+    it('surfaces an actionable error and prevents false success when backend confirmation fails', async () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, search: '?installation_id=12345' } as Location,
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ message: 'Confirmation backend error' }),
+      })
+
+      render(
+        <InstallGitHubAppModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+      )
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/github/app/install/confirm'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ installation_id: '12345' }),
+          })
+        )
+        expect(screen.getByTestId('github-app-error-state')).toBeInTheDocument()
+        expect(screen.getByText('Confirmation backend error')).toBeInTheDocument()
+        expect(toast.error).toHaveBeenCalledWith('Confirmation backend error')
+      })
+
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+
+    it('calls onSuccess when backend confirmation succeeds', async () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, search: '?installation_id=12345' } as Location,
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'success' }),
+      })
+
+      render(
+        <InstallGitHubAppModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+      )
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/github/app/install/confirm'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ installation_id: '12345' }),
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(toast.error).not.toHaveBeenCalled()
+      })
+    })
+
+    it('allows retrying after cancellation without restarting modal flow', async () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, search: '?setup_action=cancel' } as Location,
+      })
+
+      render(
+        <InstallGitHubAppModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+      )
+
+      const retryBtn = await screen.findByRole('button', { name: /retry/i })
+      expect(screen.getByTestId('github-app-cancelled-state')).toBeInTheDocument()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ install_url: 'https://github.com/apps/test/install' }),
+      })
+
+      fireEvent.click(retryBtn)
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/github/app/install/start'),
+          expect.anything()
+        )
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+        expect(window.location.href).toBe('https://github.com/apps/test/install')
+      })
+    })
+
+    it('allows retrying after confirmation failure without restarting modal flow', async () => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, search: '?installation_id=99999' } as Location,
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ message: 'Server temp unavailable' }),
+      })
+
+      render(
+        <InstallGitHubAppModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('github-app-error-state')).toBeInTheDocument()
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'success' }),
+      })
+
+      const retryBtn = screen.getByRole('button', { name: /retry/i })
+      fireEvent.click(retryBtn)
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        expect(mockFetch).toHaveBeenLastCalledWith(
+          expect.stringContaining('/auth/github/app/install/confirm'),
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ installation_id: '99999' }),
+          })
+        )
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
 })

--- a/src/features/maintainers/components/InstallGitHubAppModal.tsx
+++ b/src/features/maintainers/components/InstallGitHubAppModal.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
-import { X, FileText, Code, GitBranch, Users, Loader2 } from 'lucide-react'
+import {
+  X,
+  FileText,
+  Code,
+  GitBranch,
+  Users,
+  Loader2,
+  AlertCircle,
+  Info,
+  RefreshCw,
+} from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { API_BASE_URL } from '../../../shared/config/api'
 import { getAuthToken } from '../../../shared/api/client'
@@ -18,16 +28,23 @@ interface InstallGitHubAppModalProps {
   onSuccess: () => void
 }
 
+type InstallStatus = 'idle' | 'installing' | 'confirming' | 'cancelled' | 'error'
+
 /**
  * Modal component for guiding users to install the Grainlify GitHub App.
- * Handles the installation flow, permissions display, and dismissal preferences.
+ * Handles the installation flow, permissions display, cancellation states,
+ * backend confirmation validation, and dismissal preferences.
  */
 export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGitHubAppModalProps) {
   const { theme } = useTheme()
   const darkTheme = theme === 'dark'
-  const [isInstalling, setIsInstalling] = useState(false)
+  const [status, setStatus] = useState<InstallStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [dontShowAgain, setDontShowAgain] = useState(false)
+  const [lastInstallationId, setLastInstallationId] = useState<string | null>(null)
   const installAbortControllerRef = useRef<AbortController | null>(null)
+
+  const isInstalling = status === 'installing' || status === 'confirming'
 
   useEffect(() => {
     if (!isOpen) return
@@ -35,17 +52,41 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
       const isDismissed = localStorage.getItem('github_app_modal_dismissed')
       if (isDismissed === 'true') {
         onClose()
+        return
       }
     } catch {
       // Ignore localStorage errors if access is denied
     }
-  }, [isOpen, onClose])
+
+    try {
+      const urlParams = new URLSearchParams(window.location.search)
+      const setupAction = urlParams.get('setup_action')
+      const installationId = urlParams.get('installation_id')
+      const errorParam = urlParams.get('error')
+      const isCancelled = urlParams.get('cancelled') === 'true'
+
+      if (setupAction === 'cancel' || errorParam === 'access_denied' || isCancelled) {
+        setStatus('cancelled')
+        setErrorMessage(null)
+        return
+      }
+
+      if (installationId) {
+        setLastInstallationId(installationId)
+        confirmInstallation(installationId)
+      }
+    } catch {
+      // Ignore URL parsing errors
+    }
+  }, [isOpen])
 
   useEffect(() => {
     if (!isOpen) {
       installAbortControllerRef.current?.abort()
       installAbortControllerRef.current = null
-      setIsInstalling(false)
+      setStatus('idle')
+      setErrorMessage(null)
+      setLastInstallationId(null)
     }
 
     return () => {
@@ -54,11 +95,66 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
     }
   }, [isOpen])
 
+  const confirmInstallation = async (installationId: string) => {
+    installAbortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    installAbortControllerRef.current = abortController
+    setStatus('confirming')
+    setErrorMessage(null)
+
+    try {
+      const token = getAuthToken()
+      if (!token) {
+        throw new Error('Please sign in to confirm the GitHub App installation')
+      }
+
+      const response = await fetch(`${API_BASE_URL}/auth/github/app/install/confirm`, {
+        method: 'POST',
+        signal: abortController.signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ installation_id: installationId }),
+      })
+
+      if (abortController.signal.aborted) return
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}))
+        if (abortController.signal.aborted) return
+        throw new Error(error.message || error.error || 'Failed to confirm installation')
+      }
+
+      try {
+        window.history.replaceState({}, '', window.location.pathname)
+      } catch {
+        // ignore history errors
+      }
+
+      setStatus('idle')
+      onSuccess()
+    } catch (err) {
+      if (abortController.signal.aborted) return
+
+      logger.error('Failed to confirm GitHub App installation:', err)
+      const msg = err instanceof Error ? err.message : 'Failed to confirm installation'
+      setErrorMessage(msg)
+      setStatus('error')
+      toast.error(msg)
+    } finally {
+      if (installAbortControllerRef.current === abortController) {
+        installAbortControllerRef.current = null
+      }
+    }
+  }
+
   const handleInstall = async () => {
     installAbortControllerRef.current?.abort()
     const abortController = new AbortController()
     installAbortControllerRef.current = abortController
-    setIsInstalling(true)
+    setStatus('installing')
+    setErrorMessage(null)
 
     try {
       const token = getAuthToken()
@@ -79,7 +175,7 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
       if (abortController.signal.aborted) return
 
       if (!response.ok) {
-        const error = await response.json()
+        const error = await response.json().catch(() => ({}))
         if (abortController.signal.aborted) return
         throw new Error(error.message || error.error || 'Failed to start installation')
       }
@@ -105,12 +201,22 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
       if (abortController.signal.aborted) return
 
       logger.error('Failed to start GitHub App installation:', err)
-      toast.error(err instanceof Error ? err.message : 'Failed to start installation')
-      setIsInstalling(false)
+      const msg = err instanceof Error ? err.message : 'Failed to start installation'
+      setErrorMessage(msg)
+      setStatus('error')
+      toast.error(msg)
     } finally {
       if (installAbortControllerRef.current === abortController) {
         installAbortControllerRef.current = null
       }
+    }
+  }
+
+  const handleRetry = () => {
+    if (status === 'error' && lastInstallationId) {
+      confirmInstallation(lastInstallationId)
+    } else {
+      handleInstall()
     }
   }
 
@@ -179,6 +285,62 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
               data.
             </p>
           </div>
+
+          {/* Status Banners */}
+          {status === 'cancelled' && (
+            <div
+              data-testid="github-app-cancelled-state"
+              className={`p-3.5 rounded-[12px] border transition-colors flex items-start gap-3 ${
+                darkTheme
+                  ? 'bg-blue-500/10 border-blue-500/30 text-blue-300'
+                  : 'bg-blue-50 border-blue-200 text-blue-800'
+              }`}
+            >
+              <Info className="w-5 h-5 flex-shrink-0 mt-0.5" />
+              <div>
+                <h4 className="text-[13px] font-semibold">Installation Cancelled</h4>
+                <p className="text-[12px] mt-0.5">
+                  You cancelled the GitHub App installation. No changes were made to your account.
+                  You can retry whenever you're ready.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div
+              data-testid="github-app-error-state"
+              className={`p-3.5 rounded-[12px] border transition-colors flex items-start gap-3 ${
+                darkTheme
+                  ? 'bg-red-500/10 border-red-500/30 text-red-300'
+                  : 'bg-red-50 border-red-200 text-red-800'
+              }`}
+            >
+              <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+              <div>
+                <h4 className="text-[13px] font-semibold">Installation Failed</h4>
+                <p className="text-[12px] mt-0.5">
+                  {errorMessage || 'Failed to complete GitHub App installation. Please try again.'}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {status === 'confirming' && (
+            <div
+              data-testid="github-app-confirming-state"
+              className={`p-3.5 rounded-[12px] border transition-colors flex items-center justify-center gap-2.5 ${
+                darkTheme
+                  ? 'bg-amber-500/10 border-amber-500/30 text-amber-300'
+                  : 'bg-amber-50 border-amber-200 text-amber-800'
+              }`}
+            >
+              <Loader2 className="w-4 h-4 animate-spin flex-shrink-0" />
+              <span className="text-[13px] font-medium">
+                Confirming installation with backend...
+              </span>
+            </div>
+          )}
 
           {/* Required Permissions */}
           <div>
@@ -416,7 +578,7 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
               Cancel
             </button>
             <button
-              onClick={handleInstall}
+              onClick={status === 'cancelled' || status === 'error' ? handleRetry : handleInstall}
               disabled={isInstalling}
               className={`flex-1 px-4 py-2.5 rounded-[10px] border-2 font-semibold text-[13px] transition-all ${
                 darkTheme
@@ -424,10 +586,20 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
                   : 'bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/25 border-[#c9983a]/50 text-[#2d2820] hover:from-[#c9983a]/40 hover:to-[#d4af37]/35 shadow-[0_4px_16px_rgba(201,152,58,0.25)]'
               } ${isInstalling ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
-              {isInstalling ? (
+              {status === 'confirming' ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Confirming...
+                </span>
+              ) : status === 'installing' ? (
                 <span className="flex items-center justify-center gap-2">
                   <Loader2 className="w-4 h-4 animate-spin" />
                   Redirecting...
+                </span>
+              ) : status === 'cancelled' || status === 'error' ? (
+                <span className="flex items-center justify-center gap-2">
+                  <RefreshCw className="w-4 h-4" />
+                  Retry
                 </span>
               ) : (
                 'Install GitHub App'


### PR DESCRIPTION
Closes #521 

# test: add cancellation and confirmation-failure coverage to the GitHub App install modal

## 📌 Summary

This PR resolves an issue where the `InstallGitHubAppModal` component lacked explicit state management and test coverage for edge cases occurring during the GitHub App installation flow:
1. The maintainer cancels the installation on GitHub's side midway through the setup.
2. The backend confirmation API call (`/auth/github/app/install/confirm`) fails after GitHub redirects back to the application.
3. The maintainer retries the operation from either failure/cancellation state without having to close and restart the modal.

---

## 🧩 Key Changes Made

### 1. Component Logic (`src/features/maintainers/components/InstallGitHubAppModal.tsx`)

- **State Management**:
  - Introduced `InstallStatus` enum/union state (`'idle' | 'installing' | 'confirming' | 'cancelled' | 'error'`) to explicitly represent all modal lifecycle stages.
  - Added tracking for `errorMessage` and `lastInstallationId`.

- **URL Query Parameter Parsing on Mount/Open**:
  - Automatically inspects `window.location.search` when the modal opens for GitHub redirect parameters: `setup_action`, `installation_id`, `error`, and `cancelled`.
  - When `setup_action === 'cancel'` or `error === 'access_denied'` or `cancelled === 'true'`, the modal transitions to the `'cancelled'` state.
  - When `installation_id` is present, the modal enters `'confirming'` state and sends a POST request to `${API_BASE_URL}/auth/github/app/install/confirm`.

- **UI & Error Handling (Preventing False Success)**:
  - **Cancelled State**: Renders a clear, non-error info notification banner (`data-testid="github-app-cancelled-state"`) reassuring the maintainer that no changes were made to their account or repositories.
  - **Error State**: If backend confirmation fails or returns a non-OK status, the modal transitions to the `'error'` state (`data-testid="github-app-error-state"`), displays the backend error message, triggers `toast.error()`, and **never** invokes `onSuccess()`.
  - **Confirming State**: Displays an in-progress indicator while the backend confirmation request is in flight.

- **In-Modal Retry Flow**:
  - Implemented `handleRetry()`. When in `'cancelled'` or `'error'` state, the primary action button transitions to a "Retry" button.
  - Clicking "Retry" re-initiates the confirmation or installation flow directly without requiring the maintainer to dismiss and re-open the modal.

---

### 2. Unit Test Coverage (`src/features/maintainers/components/InstallGitHubAppModal.test.tsx`)

Added a dedicated test suite `cancellation, confirmation failure, and retry flows` containing 5 comprehensive test cases:

1. `displays a clear, non-error cancelled state when user cancels on GitHub`:
   - Mocks URL query `?setup_action=cancel`.
   - Verifies the non-error cancelled state banner is displayed.
   - Verifies `onSuccess` and `toast.error` are **not** called.

2. `surfaces an actionable error and prevents false success when backend confirmation fails`:
   - Mocks URL query `?installation_id=12345` and a failing backend response (500/error message).
   - Verifies POST request is dispatched to `/auth/github/app/install/confirm`.
   - Verifies actionable error banner is rendered and `toast.error` is triggered.
   - Verifies `onSuccess` is **not** called (preventing false success).

3. `calls onSuccess when backend confirmation succeeds`:
   - Mocks URL query `?installation_id=12345` and a successful backend response.
   - Verifies POST request to `/auth/github/app/install/confirm` succeeds and `onSuccess` is called once.

4. `allows retrying after cancellation without restarting modal flow`:
   - Renders modal in cancelled state.
   - Clicks the "Retry" button.
   - Verifies install start request (`/auth/github/app/install/start`) is triggered and user is redirected.

5. `allows retrying after confirmation failure without restarting modal flow`:
   - Renders modal with an initial failing backend confirmation request.
   - Mocks second attempt as successful and clicks "Retry".
   - Verifies confirmation request is re-attempted and `onSuccess` is called upon resolution.

---

## ✅ Acceptance Criteria Checklist

- [x] **Cancellation State**: Cancellation on GitHub displays a clear non-error notice distinct from a genuine failure.
- [x] **No False Success**: A backend confirmation failure surfaces an actionable error and never triggers `onSuccess`.
- [x] **In-Modal Retry**: Retry is available and fully functional from either failure state without a full modal restart.
- [x] **Security**: Validated that maintainers will never see a false success state when backend access confirmation fails.

---

## 🧪 Test Execution Output

```bash
$ npx vitest run InstallGitHubAppModal

 RUN  v4.1.10 C:/Users/HP/Grainlify-Frontend

 ✓ src/features/maintainers/components/InstallGitHubAppModal.test.tsx (14 tests) 1482ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  23:03:02
   Duration  4.92s (transform 464ms, setup 565ms, import 942ms, tests 1.48s, environment 1.42s)
```

---

## 📁 Modified Files

- [`src/features/maintainers/components/InstallGitHubAppModal.tsx`](file:///c:/Users/HP/Grainlify-Frontend/src/features/maintainers/components/InstallGitHubAppModal.tsx)
- [`src/features/maintainers/components/InstallGitHubAppModal.test.tsx`](file:///c:/Users/HP/Grainlify-Frontend/src/features/maintainers/components/InstallGitHubAppModal.test.tsx)

---

## 🌿 Branch & Commit Details

- **Branch**: `test/install-github-app-modal-failure-states`
- **Upstream**: `origin/test/install-github-app-modal-failure-states`
- **Commit**: `test: add cancellation and confirmation-failure coverage to the GitHub App install modal` (`60dae4a5459b422da507f3fe4fce621950f147c0`)