### PR TITLE
test: add multi-select filter combination coverage for IssueFilterDropdown

### DIFF
--- a/src/features/maintainers/components/issues/IssueFilterDropdown.test.tsx
+++ b/src/features/maintainers/components/issues/IssueFilterDropdown.test.tsx
@@ -234,4 +234,157 @@ describe('IssueFilterDropdown', () => {
     expect(trigger).toHaveTextContent('<img src=x onerror=alert(1)>');
     expect(trigger.querySelector('img')).toBeNull();
   });
+
+  describe('Multi-select functionality', () => {
+    const MOCK_ISSUES = [
+      { id: 1, status: 'Waiting for review' },
+      { id: 2, status: 'In progress' },
+      { id: 3, status: 'Stale' },
+      { id: 4, status: 'All' }, // matches anything or dummy
+    ];
+
+    function MultiSelectIssueFilterHarness({
+      onChange,
+      initialValue = 'All',
+    }: {
+      onChange?: (value: string) => void;
+      initialValue?: string;
+    }) {
+      const [value, setValue] = useState(initialValue);
+      const [isOpen, setIsOpen] = useState(false);
+
+      const handleFilterChange = (next: string) => {
+        let nextValue = next;
+        if (next === 'All') {
+          nextValue = 'All';
+        } else {
+          const currentSelections = value
+            .split(',')
+            .map((v) => v.trim())
+            .filter((v) => v !== 'All' && v !== '');
+
+          if (currentSelections.includes(next)) {
+            // Deselect
+            const updated = currentSelections.filter((v) => v !== next);
+            nextValue = updated.length > 0 ? updated.join(', ') : 'All';
+          } else {
+            // Select
+            currentSelections.push(next);
+            nextValue = currentSelections.join(', ');
+          }
+        }
+        setValue(nextValue);
+        onChange?.(nextValue);
+      };
+
+      // Filter semantics: OR logic between active filter values
+      const activeFilters = value.split(',').map((v) => v.trim());
+      const filteredIssues = MOCK_ISSUES.filter((issue) => {
+        if (activeFilters.includes('All')) return true;
+        return activeFilters.includes(issue.status);
+      });
+
+      return (
+        <div>
+          <IssueFilterDropdown
+            value={value}
+            onChange={handleFilterChange}
+            isOpen={isOpen}
+            onToggle={() => setIsOpen((open) => !open)}
+            onClose={() => setIsOpen(false)}
+          />
+          <div data-testid="filtered-count">{filteredIssues.length}</div>
+          <ul data-testid="filtered-list">
+            {filteredIssues.map((issue) => (
+              <li key={issue.id}>{issue.id} - {issue.status}</li>
+            ))}
+          </ul>
+          <button data-testid="clear-all" onClick={() => handleFilterChange('All')}>
+            Clear All
+          </button>
+        </div>
+      );
+    }
+
+    const getTrigger = () => screen.getAllByRole('button')[0];
+
+    it('asserts that selecting multiple filter values matches OR semantics (union of matched issues)', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithTheme(<MultiSelectIssueFilterHarness onChange={onChange} initialValue="Waiting for review" />);
+
+      // Verify initial state: only 1 issue matches "Waiting for review"
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('1');
+
+      // Open dropdown and select "In progress" to combine them
+      const trigger = getTrigger();
+      await user.click(trigger);
+      const optionInProgress = screen.getByRole('option', { name: 'In progress' });
+      await user.click(optionInProgress);
+
+      // Verify that value updated to combined list
+      expect(onChange).toHaveBeenLastCalledWith('Waiting for review, In progress');
+      expect(getTrigger()).toHaveTextContent('Waiting for review, In progress');
+
+      // Verify OR semantics: both "Waiting for review" (id 1) and "In progress" (id 2) issues match
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('2');
+      const listItems = screen.getAllByRole('listitem').map((li) => li.textContent);
+      expect(listItems).toContain('1 - Waiting for review');
+      expect(listItems).toContain('2 - In progress');
+    });
+
+    it('asserts that deselecting one of several active filters leaves the rest applied', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithTheme(
+        <MultiSelectIssueFilterHarness
+          onChange={onChange}
+          initialValue="Waiting for review, In progress"
+        />,
+      );
+
+      // Verify initial state: 2 issues match
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('2');
+
+      // Open dropdown and click "Waiting for review" to deselect it
+      const trigger = getTrigger();
+      await user.click(trigger);
+      const optionWaiting = screen.getByRole('option', { name: 'Waiting for review' });
+      await user.click(optionWaiting);
+
+      // Verify that only "In progress" remains
+      expect(onChange).toHaveBeenLastCalledWith('In progress');
+      expect(getTrigger()).toHaveTextContent('In progress');
+
+      // Verify filtered set updated to show only "In progress" issue
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('1');
+      const listItems = screen.getAllByRole('listitem').map((li) => li.textContent);
+      expect(listItems).toEqual(['2 - In progress']);
+    });
+
+    it('asserts that a clear all filters action resets to the unfiltered view', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderWithTheme(
+        <MultiSelectIssueFilterHarness
+          onChange={onChange}
+          initialValue="Waiting for review, In progress"
+        />,
+      );
+
+      // Verify initial state is filtered (2 issues match)
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('2');
+
+      // Click clear all button
+      await user.click(screen.getByTestId('clear-all'));
+
+      // Verify state reset to "All"
+      expect(onChange).toHaveBeenLastCalledWith('All');
+      expect(getTrigger()).toHaveTextContent('All');
+
+      // Verify unfiltered view: all 4 mock issues match
+      expect(screen.getByTestId('filtered-count')).toHaveTextContent('4');
+    });
+  });
 });
+

--- a/src/features/maintainers/components/issues/IssueFilterDropdown.tsx
+++ b/src/features/maintainers/components/issues/IssueFilterDropdown.tsx
@@ -178,7 +178,7 @@ export function IssueFilterDropdown({ value, onChange, isOpen, onToggle, onClose
                   }}
                   type="button"
                   role="option"
-                  aria-selected={value === option}
+                  aria-selected={value.split(',').map((v) => v.trim()).includes(option)}
                   tabIndex={-1}
                   className={`w-full px-6 py-3.5 flex items-center justify-between transition-all group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#c9983a] ${
                     isDark
@@ -194,7 +194,7 @@ export function IssueFilterDropdown({ value, onChange, isOpen, onToggle, onClose
                   }`}>
                     {option}
                   </span>
-                  {value === option && (
+                  {value.split(',').map((v) => v.trim()).includes(option) && (
                     <Check className={`w-5 h-5 ${
                       isDark ? 'text-[#e8c571]' : 'text-[#c9983a]'
                     }`} strokeWidth={2.5} aria-hidden="true" />


### PR DESCRIPTION
Closes #517 
## Overview
This PR implements comprehensive test coverage for multi-select, deselect, and clear-all operations on the `IssueFilterDropdown` component. To support these scenarios, the component itself was updated to correctly handle values representing multiple selected options.

## Changes Made
1. **[IssueFilterDropdown.tsx](file:///c:/Users/HP/drips/client/Grainlify-Frontend/src/features/maintainers/components/issues/IssueFilterDropdown.tsx)**:
   - Modified selection comparison from exact match (`value === option`) to list inclusion check (`value.split(',').map((v) => v.trim()).includes(option)`).
   - This allows multiple active filters passed as a comma-separated string to correctly display checkmarks and set correct `aria-selected` attributes.

2. **[IssueFilterDropdown.test.tsx](file:///c:/Users/HP/drips/client/Grainlify-Frontend/src/features/maintainers/components/issues/IssueFilterDropdown.test.tsx)**:
   - Added a new `MultiSelectIssueFilterHarness` to manage multi-select state transitions (selecting/deselecting multiple filters and clearing).
   - Added a test case confirming that selecting multiple filter values simultaneously matches OR semantics (retrieving the union of matched issues).
   - Added a test case confirming that deselecting one of several active filters leaves the other active filters applied.
   - Added a test case verifying that the "Clear All" action correctly resets to the unfiltered view where all issues match.

## Verification & Test Output
All 21 tests in `IssueFilterDropdown.test.tsx` pass successfully.

```
 RUN  v4.1.10 C:/Users/HP/drips/client/Grainlify-Frontend

 ✓ src/features/maintainers/components/issues/IssueFilterDropdown.test.tsx (21 tests) 5666ms
     ✓ exposes listbox aria attributes on the trigger  416ms
     ✓ updates the active filter when an option is selected and closes the menu  361ms
     ✓ reflects the new selection as selected when reopened  457ms
     ✓ resets to the default "All" filter when the All option is chosen  617ms
     ✓ moves focus to the active option on open and navigates with arrow keys  376ms
     ✓ wraps focus with ArrowUp from the first option to the last  317ms
     ✓ closes on Escape and returns focus to the trigger  574ms
     ✓ closes when the backdrop is clicked  406ms
     ...
     ✓ asserts that selecting multiple filter values matches OR semantics (union of matched issues)
     ✓ asserts that deselecting one of several active filters leaves the rest applied
     ✓ asserts that a clear all filters action resets to the unfiltered view

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  09:01:12
   Duration  17.70s (transform 2.55s, setup 3.20s, import 3.21s, tests 5.67s, environment 4.28s)
```