### PR TITLE
fix: surface a clear error and preserve form state when adding a dupl…

### DIFF
--- a/src/features/maintainers/components/AddRepositoryModal.test.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.test.tsx
@@ -61,7 +61,9 @@ describe('AddRepositoryModal', () => {
     await user.clear(screen.getByPlaceholderText(/owner\/repo/i))
     await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'invalidname')
 
-    expect(await screen.findByText('Repository name must be in format: owner/repo')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Repository name must be in format: owner/repo')
+    ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /add repository/i })).toBeDisabled()
     expect(mockCreateProject).not.toHaveBeenCalled()
   })
@@ -131,9 +133,7 @@ describe('AddRepositoryModal', () => {
     const user = userEvent.setup()
     const onSuccess = vi.fn()
     const onClose = vi.fn()
-    renderWithTheme(
-      <AddRepositoryModal isOpen={true} onClose={onClose} onSuccess={onSuccess} />,
-    )
+    renderWithTheme(<AddRepositoryModal isOpen={true} onClose={onClose} onSuccess={onSuccess} />)
     await waitFor(() => {
       expect(screen.getByText('Ethereum')).toBeInTheDocument()
     })
@@ -152,7 +152,75 @@ describe('AddRepositoryModal', () => {
         expect(onSuccess).toHaveBeenCalled()
         expect(onClose).toHaveBeenCalled()
       },
-      { timeout: 2000 },
+      { timeout: 2000 }
     )
+  })
+
+  it('surfaces a clear error and preserves form state on duplicate repository submission', async () => {
+    mockCreateProject.mockRejectedValue(new Error('Project already exists in this ecosystem'))
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText(/owner\/repo/i)
+    await user.type(input, 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+
+    const submitButton = screen.getByRole('button', { name: /add repository/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('This repository is already added')).toBeInTheDocument()
+    })
+
+    // Form data is preserved
+    expect(input).toHaveValue('facebook/react')
+    expect(screen.getByRole('combobox')).toHaveValue('Ethereum')
+
+    // Submit button returns to enabled/idle state
+    expect(submitButton).not.toBeDisabled()
+    expect(submitButton).toHaveTextContent('Add Repository')
+  })
+
+  it('surfaces generic error on 500 failure', async () => {
+    mockCreateProject.mockRejectedValue(new Error('Internal Server Error'))
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+    await user.click(screen.getByRole('button', { name: /add repository/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal Server Error')).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces generic error on network failure', async () => {
+    mockCreateProject.mockRejectedValue(
+      new Error('Network error: Unable to connect to the server. Please check your connection.')
+    )
+    const user = userEvent.setup()
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/owner\/repo/i), 'facebook/react')
+    await user.selectOptions(screen.getByRole('combobox'), 'Ethereum')
+    await user.click(screen.getByRole('button', { name: /add repository/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Network error: Unable to connect to the server. Please check your connection.'
+        )
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/features/maintainers/components/AddRepositoryModal.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.tsx
@@ -96,7 +96,17 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
         setSuccess(false)
       }, 1500)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add repository')
+      let errorMessage = err instanceof Error ? err.message : 'Failed to add repository'
+      const lowerError = errorMessage.toLowerCase()
+      if (
+        lowerError.includes('already exists') ||
+        lowerError.includes('duplicate') ||
+        lowerError.includes('conflict') ||
+        lowerError.includes('unique constraint')
+      ) {
+        errorMessage = 'This repository is already added'
+      }
+      setError(errorMessage)
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
…icate repository

 ## Title: fix: improve error handling and form state preservation for duplicate repository submissions

### 📝 Description
This PR enhances the error handling in the `AddRepositoryModal` component to provide a better user experience when adding a repository that already exists. Previously, backend conflict errors might have surfaced technical or generic messages. This update intercepts common conflict keywords and translates them into a user-friendly "This repository is already added" message. Additionally, it ensures that when an error occurs, the form state is preserved and the submit button is properly re-enabled to allow for corrections.

### 🎯 Motivation & Context
When users attempted to submit a repository that was already tracked, the application wasn't handling the duplicate submission gracefully. We needed to ensure that:
1. The error message is clear and non-technical.
2. The user's input isn't completely wiped out upon a failed submission.
3. The UI recovers cleanly so the user can modify their input and try again without closing the modal.

### 🛠️ Changes Made
* **`AddRepositoryModal.tsx`**: 
  * Added logic in the `catch` block to inspect the error message string for keywords like `'already exists'`, `'duplicate'`, `'conflict'`, or `'unique constraint'`.
  * Transformed these specific backend errors into a clear, user-facing `'This repository is already added'` message.
* **`AddRepositoryModal.test.tsx`**: 
  * Fixed formatting on existing tests.
  * Added a new test to specifically verify that duplicate repository submissions surface the correct error message, preserve the inputted repository name and ecosystem, and return the submit button to an idle state.
  * Added tests to verify that generic `500 Internal Server Error` and network failures are surfaced properly.

### ✅ Testing & Verification
* **Duplicate Submission Test**: Verified that mocking a "Project already exists" error triggers the new UI state and maintains the form data.
* **Generic Error Tests**: Ensured standard 500 errors and network failures still correctly display their underlying messages.
* **Manual Verification**: (Recommended) Attempt to add a known existing repository locally to confirm the modal displays the custom error and form fields aren't wiped.

closes #531 