### PR TITLE
test: Extract the EcosystemDetailPage project filter into a reusable filterProjects() utility and add combined multi-criteria test coverage.

### DIFF
--- a/src/features/dashboard/pages/EcosystemDetailPage.tsx
+++ b/src/features/dashboard/pages/EcosystemDetailPage.tsx
@@ -1,22 +1,34 @@
-import React, { useState, useEffect } from 'react';
-import { ChevronRight, ExternalLink, Users, FolderGit2, AlertCircle, GitPullRequest } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { ProjectCard, Project } from '../components/ProjectCard';
-import { SearchWithFilter } from '../components/SearchWithFilter';
-import { getPublicProjects, getEcosystemDetail, type EcosystemDetail } from '../../../shared/api/client';
-import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
+import React, { useState, useEffect } from 'react'
+import {
+  ChevronRight,
+  ExternalLink,
+  Users,
+  FolderGit2,
+  AlertCircle,
+  GitPullRequest,
+} from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { ProjectCard, Project } from '../components/ProjectCard'
+import { SearchWithFilter } from '../components/SearchWithFilter'
+import {
+  getPublicProjects,
+  getEcosystemDetail,
+  type EcosystemDetail,
+} from '../../../shared/api/client'
+import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
+import { filterProjects } from '../../../shared/utils/projectFilter'
 
 const formatNumber = (num: number): string => {
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-  return num.toString();
-};
+  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`
+  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`
+  return num.toString()
+}
 
 const getProjectIcon = (githubFullName: string): string => {
-  const [owner] = githubFullName.split('/');
+  const [owner] = githubFullName.split('/')
   // Use higher‑resolution owner avatar so cards look crisp
-  return `https://github.com/${owner}.png?size=200`;
-};
+  return `https://github.com/${owner}.png?size=200`
+}
 
 const getProjectColor = (name: string): string => {
   const colors = [
@@ -28,148 +40,200 @@ const getProjectColor = (name: string): string => {
     'from-gray-600 to-gray-800',
     'from-green-600 to-green-800',
     'from-cyan-500 to-blue-600',
-  ];
-  const hash = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-  return colors[hash % colors.length];
-};
-
-interface EcosystemDetailPageProps {
-  ecosystemId: string;
-  ecosystemName: string;
-  /** From list page (GET /ecosystems) so detail page shows same icon/description when detail fetch is pending or empty */
-  initialDescription?: string | null;
-  initialLogoUrl?: string | null;
-  onBack: () => void;
-  onProjectClick?: (id: string) => void;
+  ]
+  const hash = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  return colors[hash % colors.length]
 }
 
-export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescription, initialLogoUrl, onBack, onProjectClick }: EcosystemDetailPageProps) {
-  const { theme } = useTheme();
-  const [activeTab, setActiveTab] = useState<'overview' | 'projects' | 'community'>('overview');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([]);
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [ecosystemProjects, setEcosystemProjects] = useState<Project[]>([]);
-  const [isLoadingProjects, setIsLoadingProjects] = useState(true);
-  const [ecosystemDetail, setEcosystemDetail] = useState<EcosystemDetail | null>(null);
-  const [isLoadingDetail, setIsLoadingDetail] = useState(true);
+interface EcosystemDetailPageProps {
+  ecosystemId: string
+  ecosystemName: string
+  /** From list page (GET /ecosystems) so detail page shows same icon/description when detail fetch is pending or empty */
+  initialDescription?: string | null
+  initialLogoUrl?: string | null
+  onBack: () => void
+  onProjectClick?: (id: string) => void
+}
+
+export function EcosystemDetailPage({
+  ecosystemId,
+  ecosystemName,
+  initialDescription,
+  initialLogoUrl,
+  onBack,
+  onProjectClick,
+}: EcosystemDetailPageProps) {
+  const { theme } = useTheme()
+  const [activeTab, setActiveTab] = useState<'overview' | 'projects' | 'community'>('overview')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([])
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+  const [ecosystemProjects, setEcosystemProjects] = useState<Project[]>([])
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true)
+  const [ecosystemDetail, setEcosystemDetail] = useState<EcosystemDetail | null>(null)
+  const [isLoadingDetail, setIsLoadingDetail] = useState(true)
 
   const fetchEcosystemDetail = React.useCallback(async () => {
     if (!ecosystemId) {
-      setEcosystemDetail(null);
-      setIsLoadingDetail(false);
-      return;
+      setEcosystemDetail(null)
+      setIsLoadingDetail(false)
+      return
     }
-    setIsLoadingDetail(true);
+    setIsLoadingDetail(true)
     try {
-      const detail = await getEcosystemDetail(ecosystemId);
-      setEcosystemDetail(detail);
+      const detail = await getEcosystemDetail(ecosystemId)
+      setEcosystemDetail(detail)
     } catch {
-      setEcosystemDetail(null);
+      setEcosystemDetail(null)
     } finally {
-      setIsLoadingDetail(false);
+      setIsLoadingDetail(false)
     }
-  }, [ecosystemId]);
+  }, [ecosystemId])
 
   useEffect(() => {
-    fetchEcosystemDetail();
-  }, [fetchEcosystemDetail]);
+    fetchEcosystemDetail()
+  }, [fetchEcosystemDetail])
 
   // Refetch when user returns to this tab (e.g. after editing in admin) so logo/description stay in sync
   useEffect(() => {
     const handleVisibility = () => {
       if (document.visibilityState === 'visible' && ecosystemId) {
-        fetchEcosystemDetail();
+        fetchEcosystemDetail()
       }
-    };
-    document.addEventListener('visibilitychange', handleVisibility);
-    return () => document.removeEventListener('visibilitychange', handleVisibility);
-  }, [ecosystemId, fetchEcosystemDetail]);
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => document.removeEventListener('visibilitychange', handleVisibility)
+  }, [ecosystemId, fetchEcosystemDetail])
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
     const load = async () => {
-      setIsLoadingProjects(true);
+      setIsLoadingProjects(true)
       try {
-        const res = await getPublicProjects({ ecosystem: ecosystemName, limit: 100 });
-        if (cancelled || !res?.projects) return;
-        const mapped: Project[] = (res.projects as Array<{
-          id: string;
-          github_full_name: string;
-          language: string | null;
-          tags: string[];
-          category: string | null;
-          stars_count: number;
-          forks_count: number;
-          contributors_count: number;
-          open_issues_count: number;
-          open_prs_count: number;
-          ecosystem_name: string | null;
-          description?: string | null;
-        }>).filter((p) => (p.github_full_name.split('/')[1] || '') !== '.github').map((p) => {
-          const repoName = p.github_full_name.split('/')[1] || p.github_full_name;
-          return {
-            id: p.id,
-            name: repoName,
-            icon: getProjectIcon(p.github_full_name),
-            stars: formatNumber(p.stars_count || 0),
-            forks: formatNumber(p.forks_count || 0),
-            contributors: p.contributors_count || 0,
-            openIssues: p.open_issues_count || 0,
-            prs: p.open_prs_count || 0,
-            description: (p.description && p.description.trim()) || `${repoName} project`,
-            tags: Array.isArray(p.tags) ? p.tags.slice(0, 4) : [],
-            color: getProjectColor(repoName),
-            language: p.language ?? null,
-            category: p.category ?? null,
-          };
-        });
-        setEcosystemProjects(mapped);
+        const res = await getPublicProjects({ ecosystem: ecosystemName, limit: 100 })
+        if (cancelled || !res?.projects) return
+        const mapped: Project[] = (
+          res.projects as Array<{
+            id: string
+            github_full_name: string
+            language: string | null
+            tags: string[]
+            category: string | null
+            stars_count: number
+            forks_count: number
+            contributors_count: number
+            open_issues_count: number
+            open_prs_count: number
+            ecosystem_name: string | null
+            description?: string | null
+          }>
+        )
+          .filter((p) => (p.github_full_name.split('/')[1] || '') !== '.github')
+          .map((p) => {
+            const repoName = p.github_full_name.split('/')[1] || p.github_full_name
+            return {
+              id: p.id,
+              name: repoName,
+              icon: getProjectIcon(p.github_full_name),
+              stars: formatNumber(p.stars_count || 0),
+              forks: formatNumber(p.forks_count || 0),
+              contributors: p.contributors_count || 0,
+              openIssues: p.open_issues_count || 0,
+              prs: p.open_prs_count || 0,
+              description: (p.description && p.description.trim()) || `${repoName} project`,
+              tags: Array.isArray(p.tags) ? p.tags.slice(0, 4) : [],
+              color: getProjectColor(repoName),
+              language: p.language ?? null,
+              category: p.category ?? null,
+            }
+          })
+        setEcosystemProjects(mapped)
       } catch {
-        if (!cancelled) setEcosystemProjects([]);
+        if (!cancelled) setEcosystemProjects([])
       } finally {
-        if (!cancelled) setIsLoadingProjects(false);
+        if (!cancelled) setIsLoadingProjects(false)
       }
-    };
-    load();
-    return () => { cancelled = true; };
-  }, [ecosystemName]);
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [ecosystemName])
 
   // Prefer API detail when loaded; use hardcoded fallbacks only when detail is null (loading/error)
-  const detail = ecosystemDetail;
-  const hasDetail = detail != null;
+  const detail = ecosystemDetail
+  const hasDetail = detail != null
 
   const normalizeLinks = (raw: unknown): Array<{ label: string; url: string }> => {
-    if (!Array.isArray(raw) || raw.length === 0) return [];
-    return raw.map((l) => ({
-      label: (l && typeof l === 'object' && 'label' in l && typeof (l as { label?: unknown }).label === 'string') ? (l as { label: string }).label : '',
-      url: (l && typeof l === 'object' && 'url' in l && typeof (l as { url?: unknown }).url === 'string') ? (l as { url: string }).url : '',
-    })).filter((l) => l.label.trim() || l.url.trim());
-  };
+    if (!Array.isArray(raw) || raw.length === 0) return []
+    return raw
+      .map((l) => ({
+        label:
+          l &&
+          typeof l === 'object' &&
+          'label' in l &&
+          typeof (l as { label?: unknown }).label === 'string'
+            ? (l as { label: string }).label
+            : '',
+        url:
+          l &&
+          typeof l === 'object' &&
+          'url' in l &&
+          typeof (l as { url?: unknown }).url === 'string'
+            ? (l as { url: string }).url
+            : '',
+      }))
+      .filter((l) => l.label.trim() || l.url.trim())
+  }
   const normalizeKeyAreas = (raw: unknown): Array<{ title: string; description: string }> => {
-    if (!Array.isArray(raw) || raw.length === 0) return [];
-    return raw.map((k) => ({
-      title: (k && typeof k === 'object' && 'title' in k && typeof (k as { title?: unknown }).title === 'string') ? (k as { title: string }).title : '',
-      description: (k && typeof k === 'object' && 'description' in k && typeof (k as { description?: unknown }).description === 'string') ? (k as { description: string }).description : '',
-    })).filter((k) => k.title.trim() || k.description.trim());
-  };
+    if (!Array.isArray(raw) || raw.length === 0) return []
+    return raw
+      .map((k) => ({
+        title:
+          k &&
+          typeof k === 'object' &&
+          'title' in k &&
+          typeof (k as { title?: unknown }).title === 'string'
+            ? (k as { title: string }).title
+            : '',
+        description:
+          k &&
+          typeof k === 'object' &&
+          'description' in k &&
+          typeof (k as { description?: unknown }).description === 'string'
+            ? (k as { description: string }).description
+            : '',
+      }))
+      .filter((k) => k.title.trim() || k.description.trim())
+  }
   const normalizeTechnologies = (raw: unknown): string[] => {
-    if (!Array.isArray(raw) || raw.length === 0) return [];
-    return raw.map((t) => (typeof t === 'string' ? t.trim() : '')).filter(Boolean);
-  };
+    if (!Array.isArray(raw) || raw.length === 0) return []
+    return raw.map((t) => (typeof t === 'string' ? t.trim() : '')).filter(Boolean)
+  }
 
-  const apiLinks = normalizeLinks(detail?.links);
-  const apiKeyAreas = normalizeKeyAreas(detail?.key_areas);
-  const apiTechnologies = normalizeTechnologies(detail?.technologies);
+  const apiLinks = normalizeLinks(detail?.links)
+  const apiKeyAreas = normalizeKeyAreas(detail?.key_areas)
+  const apiTechnologies = normalizeTechnologies(detail?.technologies)
 
   // Prefer API (detail fetch) for logo/description; fall back to list data (initialDescription/initialLogoUrl) so same icon/description as list page
-  const apiDescription = hasDetail && detail?.description != null ? String(detail.description).trim() : '';
-  const apiLogoUrl = hasDetail && detail?.logo_url != null && String(detail.logo_url).trim() !== '' ? String(detail.logo_url).trim() : null;
-  const displayDescription = apiDescription || (initialDescription != null && initialDescription !== '' ? String(initialDescription).trim() : '') || 'No description provided';
-  const displayLogoUrl = apiLogoUrl || (initialLogoUrl != null && initialLogoUrl !== '' ? String(initialLogoUrl).trim() : null);
+  const apiDescription =
+    hasDetail && detail?.description != null ? String(detail.description).trim() : ''
+  const apiLogoUrl =
+    hasDetail && detail?.logo_url != null && String(detail.logo_url).trim() !== ''
+      ? String(detail.logo_url).trim()
+      : null
+  const displayDescription =
+    apiDescription ||
+    (initialDescription != null && initialDescription !== ''
+      ? String(initialDescription).trim()
+      : '') ||
+    'No description provided'
+  const displayLogoUrl =
+    apiLogoUrl ||
+    (initialLogoUrl != null && initialLogoUrl !== '' ? String(initialLogoUrl).trim() : null)
 
   const ecosystemData = {
-    name: (hasDetail && detail?.name) ? detail.name : ecosystemName,
+    name: hasDetail && detail?.name ? detail.name : ecosystemName,
     logo: displayLogoUrl ? undefined : ecosystemName.charAt(0).toUpperCase(),
     logoUrl: displayLogoUrl,
     description: displayDescription,
@@ -177,54 +241,61 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
     links: hasDetail && apiLinks.length > 0 ? apiLinks : [],
     // Use detail API counts when available; when detail returns 0 but we have projects (from Projects tab), use aggregated counts so Overview matches what user sees
     stats: (() => {
-      const fromDetail = hasDetail && detail != null;
-      const detailProjects = fromDetail ? Number(detail?.project_count) || 0 : 0;
-      const detailContributors = fromDetail ? Number(detail?.contributors_count) || 0 : 0;
-      const detailIssues = fromDetail ? Number(detail?.open_issues_count) || 0 : 0;
-      const detailPrs = fromDetail ? Number(detail?.open_prs_count) || 0 : 0;
+      const fromDetail = hasDetail && detail != null
+      const detailProjects = fromDetail ? Number(detail?.project_count) || 0 : 0
+      const detailContributors = fromDetail ? Number(detail?.contributors_count) || 0 : 0
+      const detailIssues = fromDetail ? Number(detail?.open_issues_count) || 0 : 0
+      const detailPrs = fromDetail ? Number(detail?.open_prs_count) || 0 : 0
       const fromProjects = {
         projects: ecosystemProjects.length,
         contributors: ecosystemProjects.reduce((s, p) => s + (p.contributors || 0), 0),
         issues: ecosystemProjects.reduce((s, p) => s + p.openIssues, 0),
         prs: ecosystemProjects.reduce((s, p) => s + (p.prs || 0), 0),
-      };
-      const useProjectsFallback = fromProjects.projects > 0 && detailProjects === 0;
+      }
+      const useProjectsFallback = fromProjects.projects > 0 && detailProjects === 0
       return {
-        activeContributors: { value: useProjectsFallback ? fromProjects.contributors : (fromDetail ? detailContributors : fromProjects.contributors), change: '' },
-        activeProjects: { value: useProjectsFallback ? fromProjects.projects : (fromDetail ? detailProjects : fromProjects.projects), change: '' },
-        availableIssues: { value: useProjectsFallback ? fromProjects.issues : (fromDetail ? detailIssues : fromProjects.issues), change: '' },
-        mergedPullRequests: { value: useProjectsFallback ? fromProjects.prs : (fromDetail ? detailPrs : fromProjects.prs), change: '' },
-      };
+        activeContributors: {
+          value: useProjectsFallback
+            ? fromProjects.contributors
+            : fromDetail
+              ? detailContributors
+              : fromProjects.contributors,
+          change: '',
+        },
+        activeProjects: {
+          value: useProjectsFallback
+            ? fromProjects.projects
+            : fromDetail
+              ? detailProjects
+              : fromProjects.projects,
+          change: '',
+        },
+        availableIssues: {
+          value: useProjectsFallback
+            ? fromProjects.issues
+            : fromDetail
+              ? detailIssues
+              : fromProjects.issues,
+          change: '',
+        },
+        mergedPullRequests: {
+          value: useProjectsFallback ? fromProjects.prs : fromDetail ? detailPrs : fromProjects.prs,
+          change: '',
+        },
+      }
     })(),
-    about: hasDetail
-      ? (detail?.about?.trim() || '')
-      : '',
+    about: hasDetail ? detail?.about?.trim() || '' : '',
     keyAreas: hasDetail ? apiKeyAreas : [],
-    technologies: hasDetail && apiTechnologies.length > 0
-      ? apiTechnologies
-      : [],
-  };
+    technologies: hasDetail && apiTechnologies.length > 0 ? apiTechnologies : [],
+  }
 
-  const filteredProjects = ecosystemProjects.filter(
-    (project) => {
-      const matchesSearch =
-        searchQuery === '' ||
-        project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        project.description.toLowerCase().includes(searchQuery.toLowerCase());
+  const filteredProjects = filterProjects(ecosystemProjects, {
+    searchQuery,
+    languages: selectedLanguages,
+    categories: selectedCategories,
+  })
 
-      const matchesLanguage =
-        selectedLanguages.length === 0 ||
-        (project.language != null && selectedLanguages.includes(project.language));
-
-      const matchesCategory =
-        selectedCategories.length === 0 ||
-        (project.category != null && selectedCategories.includes(project.category));
-
-      return matchesSearch && matchesLanguage && matchesCategory;
-    }
-  );
-
-  const isDark = theme === 'dark';
+  const isDark = theme === 'dark'
 
   return (
     <div className="h-full overflow-y-auto px-4 md:px-0">
@@ -233,23 +304,31 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
         <button
           onClick={onBack}
           className={`text-[12px] md:text-[14px] font-semibold transition-colors touch-manipulation whitespace-nowrap flex-shrink-0 ${
-            isDark 
-              ? 'text-[#d4d4d4] hover:text-[#c9983a] active:text-[#c9983a]' 
+            isDark
+              ? 'text-[#d4d4d4] hover:text-[#c9983a] active:text-[#c9983a]'
               : 'text-[#7a6b5a] hover:text-[#a67c2a] active:text-[#a67c2a]'
           }`}
         >
           Ecosystems
         </button>
-        <ChevronRight className={`w-3 h-3 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`} />
-        <span className={`text-[12px] md:text-[14px] font-bold transition-colors whitespace-nowrap flex-shrink-0 ${
-          isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-        }`}>
+        <ChevronRight
+          className={`w-3 h-3 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+        />
+        <span
+          className={`text-[12px] md:text-[14px] font-bold transition-colors whitespace-nowrap flex-shrink-0 ${
+            isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+          }`}
+        >
           {ecosystemName}
         </span>
-        <ChevronRight className={`w-3 h-3 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`} />
-        <span className={`text-[12px] md:text-[14px] font-semibold transition-colors whitespace-nowrap flex-shrink-0 ${
-          isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'
-        }`}>
+        <ChevronRight
+          className={`w-3 h-3 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+        />
+        <span
+          className={`text-[12px] md:text-[14px] font-semibold transition-colors whitespace-nowrap flex-shrink-0 ${
+            isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'
+          }`}
+        >
           Overview
         </span>
       </div>
@@ -260,29 +339,47 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
           {/* Ecosystem Header */}
           <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
             <div className="flex items-center gap-3 md:gap-4 mb-3 md:mb-4">
-              <div className={`w-12 h-12 md:w-16 md:h-16 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${ecosystemData.logoUrl ? 'bg-white' : 'bg-gradient-to-br from-[#c9983a] to-[#d4af37]'}`}>
+              <div
+                className={`w-12 h-12 md:w-16 md:h-16 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${ecosystemData.logoUrl ? 'bg-white' : 'bg-gradient-to-br from-[#c9983a] to-[#d4af37]'}`}
+              >
                 {ecosystemData.logoUrl ? (
-                  <img src={ecosystemData.logoUrl} alt="" className="w-full h-full object-contain p-0.5" />
+                  <img
+                    src={ecosystemData.logoUrl}
+                    alt=""
+                    className="w-full h-full object-contain p-0.5"
+                  />
                 ) : (
-                  <span className="text-[18px] md:text-[24px] font-bold text-white">{ecosystemData.logo}</span>
+                  <span className="text-[18px] md:text-[24px] font-bold text-white">
+                    {ecosystemData.logo}
+                  </span>
                 )}
               </div>
               <div className="flex-1 min-w-0">
-                <h1 className={`text-[16px] md:text-[20px] font-bold transition-colors ${
-                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>
+                <h1
+                  className={`text-[16px] md:text-[20px] font-bold transition-colors ${
+                    isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                  }`}
+                >
                   {ecosystemData.name} Ecosystem
                 </h1>
                 <div className="flex items-center gap-3 md:gap-4 mt-1">
                   <div className="flex items-center gap-1.5 md:gap-2">
-                    <Users className={`w-3 h-3 md:w-3.5 md:h-3.5 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`} />
-                    <span className={`text-[11px] md:text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}>
+                    <Users
+                      className={`w-3 h-3 md:w-3.5 md:h-3.5 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}
+                    />
+                    <span
+                      className={`text-[11px] md:text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}
+                    >
                       {isLoadingDetail ? '—' : ecosystemData.stats.activeContributors.value}
                     </span>
                   </div>
                   <div className="flex items-center gap-1.5 md:gap-2">
-                    <FolderGit2 className={`w-3 h-3 md:w-3.5 md:h-3.5 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`} />
-                    <span className={`text-[11px] md:text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}>
+                    <FolderGit2
+                      className={`w-3 h-3 md:w-3.5 md:h-3.5 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}
+                    />
+                    <span
+                      className={`text-[11px] md:text-[13px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#8b6914]'}`}
+                    >
                       {isLoadingDetail ? '—' : ecosystemData.stats.activeProjects.value}
                     </span>
                   </div>
@@ -293,14 +390,18 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
 
           {/* Description */}
           <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-            <h2 className={`text-[14px] md:text-[16px] font-bold mb-2 md:mb-3 transition-colors ${
-              isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+            <h2
+              className={`text-[14px] md:text-[16px] font-bold mb-2 md:mb-3 transition-colors ${
+                isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               Description
             </h2>
-            <p className={`text-[12px] md:text-[13px] leading-relaxed transition-colors ${
-              isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-            }`}>
+            <p
+              className={`text-[12px] md:text-[13px] leading-relaxed transition-colors ${
+                isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
               {ecosystemData.description}
             </p>
           </div>
@@ -308,9 +409,11 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
           {/* Languages - only show when configured (optional for future) */}
           {ecosystemData.languages.length > 0 && (
             <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-              <h2 className={`text-[14px] md:text-[16px] font-bold mb-2 md:mb-3 transition-colors ${
-                isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-              }`}>
+              <h2
+                className={`text-[14px] md:text-[16px] font-bold mb-2 md:mb-3 transition-colors ${
+                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                }`}
+              >
                 Languages
               </h2>
               <div className="flex flex-wrap gap-2 md:gap-3">
@@ -319,8 +422,12 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
                     key={idx}
                     className="px-2.5 md:px-3 py-1 md:py-1.5 rounded-[6px] md:rounded-[8px] backdrop-blur-[20px] border border-white/25 bg-white/[0.08]"
                   >
-                    <span className="text-[11px] md:text-[12px] font-semibold text-[#c9983a]">{lang.name}</span>
-                    <span className={`ml-1.5 md:ml-2 text-[10px] md:text-[11px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
+                    <span className="text-[11px] md:text-[12px] font-semibold text-[#c9983a]">
+                      {lang.name}
+                    </span>
+                    <span
+                      className={`ml-1.5 md:ml-2 text-[10px] md:text-[11px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                    >
                       {lang.percentage}%
                     </span>
                   </div>
@@ -331,336 +438,405 @@ export function EcosystemDetailPage({ ecosystemId, ecosystemName, initialDescrip
 
           {/* Links */}
           <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-          <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
-            <h2 className={`text-[14px] md:text-[16px] font-bold mb-3 md:mb-4 transition-colors ${
-              isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
-              Links
-            </h2>
-            {ecosystemData.links && ecosystemData.links.length > 0 ? (
-              <div className="space-y-2 md:space-y-3">
-                {ecosystemData.links.map((link, idx) => (
-                  <a
-                    key={idx}
-                    href={/^https?:\/\//i.test(link.url) ? link.url : `https://${link.url}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center justify-between p-2.5 md:p-3 rounded-[10px] md:rounded-[12px] backdrop-blur-[20px] border border-white/25 bg-white/[0.08] hover:bg-white/[0.15] active:bg-white/[0.2] transition-all group touch-manipulation min-h-[44px]"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className={`text-[12px] md:text-[13px] font-semibold transition-colors truncate ${
-                        isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                      }`}
-                      >{link.label}</div>
-                      <div className={`text-[10px] md:text-[11px] transition-colors truncate ${
-                        isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                      }`}
-                      >{link.url}</div>
+            <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
+              <h2
+                className={`text-[14px] md:text-[16px] font-bold mb-3 md:mb-4 transition-colors ${
+                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                }`}
+              >
+                Links
+              </h2>
+              {ecosystemData.links && ecosystemData.links.length > 0 ? (
+                <div className="space-y-2 md:space-y-3">
+                  {ecosystemData.links.map((link, idx) => (
+                    <a
+                      key={idx}
+                      href={/^https?:\/\//i.test(link.url) ? link.url : `https://${link.url}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center justify-between p-2.5 md:p-3 rounded-[10px] md:rounded-[12px] backdrop-blur-[20px] border border-white/25 bg-white/[0.08] hover:bg-white/[0.15] active:bg-white/[0.2] transition-all group touch-manipulation min-h-[44px]"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div
+                          className={`text-[12px] md:text-[13px] font-semibold transition-colors truncate ${
+                            isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                          }`}
+                        >
+                          {link.label}
+                        </div>
+                        <div
+                          className={`text-[10px] md:text-[11px] transition-colors truncate ${
+                            isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                          }`}
+                        >
+                          {link.url}
+                        </div>
+                      </div>
+                      <ExternalLink className="w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 group-active:opacity-100 transition-opacity flex-shrink-0 ml-2" />
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <p
+                  className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                >
+                  No links available
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Main Content Area */}
+          <div className="flex-[3] min-w-0">
+            {/* Tabs */}
+            <div className="flex items-center gap-2 md:gap-3 mb-4 md:mb-6 overflow-x-auto scrollbar-hide">
+              <button
+                onClick={() => setActiveTab('overview')}
+                className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
+                  activeTab === 'overview'
+                    ? 'bg-[#c9983a] text-white shadow-lg'
+                    : isDark
+                      ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
+                      : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
+                }`}
+              >
+                Overview
+              </button>
+              <button
+                onClick={() => setActiveTab('projects')}
+                className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
+                  activeTab === 'projects'
+                    ? 'bg-[#c9983a] text-white shadow-lg'
+                    : isDark
+                      ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
+                      : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
+                }`}
+              >
+                Projects
+              </button>
+              <button
+                onClick={() => setActiveTab('community')}
+                className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
+                  activeTab === 'community'
+                    ? 'bg-[#c9983a] text-white shadow-lg'
+                    : isDark
+                      ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
+                      : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
+                }`}
+              >
+                Community
+              </button>
+            </div>
+
+            {activeTab === 'overview' && (
+              <div className="space-y-4 md:space-y-6">
+                {/* Stats Grid */}
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
+                  <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
+                    <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
+                      <Users
+                        className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      />
+                      <span
+                        className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
+                          isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        Active Contributors
+                      </span>
                     </div>
-                    <ExternalLink className="w-4 h-4 text-[#c9983a] opacity-0 group-hover:opacity-100 group-active:opacity-100 transition-opacity flex-shrink-0 ml-2" />
-                  </a>
-                ))}
+                    <div className="flex items-end gap-2">
+                      <span
+                        className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      >
+                        {isLoadingDetail ? '—' : ecosystemData.stats.activeContributors.value}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
+                    <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
+                      <FolderGit2
+                        className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      />
+                      <span
+                        className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
+                          isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        Active Projects
+                      </span>
+                    </div>
+                    <div className="flex items-end gap-2">
+                      <span
+                        className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      >
+                        {isLoadingDetail ? '—' : ecosystemData.stats.activeProjects.value}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
+                    <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
+                      <AlertCircle
+                        className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      />
+                      <span
+                        className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
+                          isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        Available Issues
+                      </span>
+                    </div>
+                    <div className="flex items-end gap-2">
+                      <span
+                        className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      >
+                        {isLoadingDetail ? '—' : ecosystemData.stats.availableIssues.value}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
+                    <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
+                      <GitPullRequest
+                        className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      />
+                      <span
+                        className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
+                          isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        Open PRs
+                      </span>
+                    </div>
+                    <div className="flex items-end gap-2">
+                      <span
+                        className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                      >
+                        {isLoadingDetail ? '—' : ecosystemData.stats.mergedPullRequests.value}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* About Section */}
+                <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
+                  <h2
+                    className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
+                      isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    About {ecosystemName}
+                  </h2>
+                  <p
+                    className={`text-[12px] md:text-[14px] leading-relaxed transition-colors ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                  >
+                    {ecosystemData.about?.trim() ? ecosystemData.about : 'No description provided'}
+                  </p>
+                </div>
+
+                {/* Key Areas */}
+                <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
+                  <h2
+                    className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
+                      isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    Key Areas
+                  </h2>
+                  <ul className="space-y-2 md:space-y-3">
+                    {ecosystemData.keyAreas && ecosystemData.keyAreas.length > 0 ? (
+                      <ul className="space-y-2 md:space-y-3">
+                        {ecosystemData.keyAreas.map((area, idx) => (
+                          <li key={idx} className="flex gap-2 md:gap-3">
+                            <span
+                              className={`mt-0.5 md:mt-1 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                            >
+                              •
+                            </span>
+                            <div className="flex-1 min-w-0">
+                              <span
+                                className={`font-bold text-[12px] md:text-[14px] ${isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'}`}
+                              >
+                                {area.title}:
+                              </span>{' '}
+                              <span
+                                className={`text-[12px] md:text-[14px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                              >
+                                {area.description}
+                              </span>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p
+                        className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                      >
+                        No key areas available
+                      </p>
+                    )}
+                  </ul>
+                </div>
+
+                {/* Technologies */}
+                <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
+                  <h2
+                    className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
+                      isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    Technologies
+                  </h2>
+                  <p
+                    className={`text-[11px] md:text-[13px] mb-2 md:mb-3 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                  >
+                    Supported technologies for ecosystem projects:
+                  </p>
+                  <ul className="space-y-1.5 md:space-y-2">
+                    {ecosystemData.technologies && ecosystemData.technologies.length > 0 ? (
+                      <ul className="space-y-1.5 md:space-y-2">
+                        {ecosystemData.technologies.map((tech, idx) => (
+                          <li key={idx} className="flex gap-2 md:gap-3">
+                            <span
+                              className={`mt-0.5 md:mt-1 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}
+                            >
+                              •
+                            </span>
+                            <span
+                              className={`text-[12px] md:text-[14px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                            >
+                              {tech}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p
+                        className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+                      >
+                        No technologies available
+                      </p>
+                    )}
+                  </ul>
+                </div>
               </div>
-            ) : (
-              <p className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                No links available
-              </p>
+            )}
+
+            {activeTab === 'projects' && (
+              <div className="space-y-4 md:space-y-6">
+                {/* Search and Filter */}
+                <SearchWithFilter
+                  searchPlaceholder="Search"
+                  searchValue={searchQuery}
+                  onSearchChange={setSearchQuery}
+                  filterSections={[
+                    {
+                      title: 'Languages',
+                      hasSearch: true,
+                      options: [
+                        { label: 'TypeScript', value: 'typescript' },
+                        { label: 'JavaScript', value: 'javascript' },
+                        { label: 'Python', value: 'python' },
+                        { label: 'Rust', value: 'rust' },
+                      ],
+                      selectedValues: selectedLanguages,
+                      onToggle: (value) => {
+                        setSelectedLanguages((prev) =>
+                          prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+                        )
+                      },
+                    },
+                    {
+                      title: 'Categories',
+                      hasSearch: false,
+                      options: [
+                        { label: 'Frontend', value: 'frontend' },
+                        { label: 'Backend', value: 'backend' },
+                        { label: 'Full Stack', value: 'fullstack' },
+                        { label: 'DevOps', value: 'devops' },
+                      ],
+                      selectedValues: selectedCategories,
+                      onToggle: (value) => {
+                        setSelectedCategories((prev) =>
+                          prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+                        )
+                      },
+                    },
+                  ]}
+                  onReset={() => {
+                    setSearchQuery('')
+                    setSelectedLanguages([])
+                    setSelectedCategories([])
+                  }}
+                />
+
+                {/* Projects Grid */}
+                {isLoadingProjects ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+                    {[1, 2, 3, 4].map((i) => (
+                      <div
+                        key={i}
+                        className={`rounded-[18px] border p-5 ${isDark ? 'bg-white/[0.08] border-white/15' : 'bg-white/[0.15] border-white/25'}`}
+                      >
+                        <SkeletonLoader className="h-11 w-11 rounded-[12px] mb-4" />
+                        <SkeletonLoader className="h-4 w-3/4 mb-2" />
+                        <SkeletonLoader className="h-3 w-full mb-1" />
+                        <SkeletonLoader className="h-3 w-5/6 mb-4" />
+                        <div className="flex gap-2 mb-4">
+                          <SkeletonLoader className="h-4 w-12" />
+                          <SkeletonLoader className="h-4 w-12" />
+                        </div>
+                        <div className="flex gap-2">
+                          <SkeletonLoader className="h-7 w-16 rounded-[8px]" />
+                          <SkeletonLoader className="h-7 w-20 rounded-[8px]" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : filteredProjects.length === 0 ? (
+                  <div
+                    className={`rounded-[16px] border p-8 text-center ${isDark ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]' : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'}`}
+                  >
+                    <FolderGit2
+                      className={`w-10 h-10 mx-auto mb-3 ${isDark ? 'text-[#b8a898]' : 'text-[#8a7b6a]'}`}
+                    />
+                    <p className="text-[14px] font-semibold">No projects in {ecosystemName} yet</p>
+                    <p className="text-[12px] mt-1">
+                      Projects added under this ecosystem will appear here.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+                    {filteredProjects.map((project) => (
+                      <ProjectCard key={project.id} project={project} onClick={onProjectClick} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {activeTab === 'community' && (
+              <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-6 md:p-8 text-center">
+                <Users
+                  className={`w-10 h-10 md:w-12 md:h-12 mx-auto mb-3 md:mb-4 ${
+                    isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                  }`}
+                />
+                <p
+                  className={`text-[12px] md:text-[14px] ${
+                    isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                  }`}
+                >
+                  Community view coming soon
+                </p>
+              </div>
             )}
           </div>
         </div>
-
-        {/* Main Content Area */}
-        <div className="flex-[3] min-w-0">
-          {/* Tabs */}
-          <div className="flex items-center gap-2 md:gap-3 mb-4 md:mb-6 overflow-x-auto scrollbar-hide">
-            <button
-              onClick={() => setActiveTab('overview')}
-              className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
-                activeTab === 'overview'
-                  ? 'bg-[#c9983a] text-white shadow-lg'
-                  : isDark
-                    ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
-                    : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
-              }`}
-            >
-              Overview
-            </button>
-            <button
-              onClick={() => setActiveTab('projects')}
-              className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
-                activeTab === 'projects'
-                  ? 'bg-[#c9983a] text-white shadow-lg'
-                  : isDark
-                    ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
-                    : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
-              }`}
-            >
-              Projects
-            </button>
-            <button
-              onClick={() => setActiveTab('community')}
-              className={`px-4 md:px-5 py-2 md:py-2.5 rounded-[10px] md:rounded-[12px] text-[12px] md:text-[14px] font-semibold transition-all touch-manipulation whitespace-nowrap flex-shrink-0 min-h-[44px] ${
-                activeTab === 'community'
-                  ? 'bg-[#c9983a] text-white shadow-lg'
-                  : isDark
-                    ? 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#d4d4d4] hover:bg-white/[0.15] active:bg-white/[0.18]'
-                    : 'backdrop-blur-[40px] bg-white/[0.12] border border-white/20 text-[#7a6b5a] hover:bg-white/[0.15] active:bg-white/[0.2]'
-              }`}
-            >
-              Community
-            </button>
-          </div>
-
-          {activeTab === 'overview' && (
-            <div className="space-y-4 md:space-y-6">
-              {/* Stats Grid */}
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
-                <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
-                  <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
-                    <Users className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`} />
-                    <span className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
-                      isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                    }`}>
-                      Active Contributors
-                    </span>
-                  </div>
-                  <div className="flex items-end gap-2">
-                    <span className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>
-                      {isLoadingDetail ? '—' : ecosystemData.stats.activeContributors.value}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
-                  <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
-                    <FolderGit2 className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`} />
-                    <span className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
-                      isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                    }`}>
-                      Active Projects
-                    </span>
-                  </div>
-                  <div className="flex items-end gap-2">
-                    <span className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>
-                      {isLoadingDetail ? '—' : ecosystemData.stats.activeProjects.value}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
-                  <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
-                    <AlertCircle className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`} />
-                    <span className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
-                      isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                    }`}>
-                      Available Issues
-                    </span>
-                  </div>
-                  <div className="flex items-end gap-2">
-                    <span className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>
-                      {isLoadingDetail ? '—' : ecosystemData.stats.availableIssues.value}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="backdrop-blur-[40px] rounded-[12px] md:rounded-[16px] border bg-white/[0.12] border-white/20 p-3 md:p-5">
-                  <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2 mb-1.5 md:mb-2">
-                    <GitPullRequest className={`w-3.5 h-3.5 md:w-4 md:h-4 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`} />
-                    <span className={`text-[9px] md:text-[11px] font-bold uppercase tracking-wide leading-tight ${
-                      isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                    }`}>
-                      Open PRs
-                    </span>
-                  </div>
-                  <div className="flex items-end gap-2">
-                    <span className={`text-[20px] md:text-[28px] font-bold ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>
-                      {isLoadingDetail ? '—' : ecosystemData.stats.mergedPullRequests.value}
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              {/* About Section */}
-              <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-                <h2 className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
-                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>
-                  About {ecosystemName}
-                </h2>
-                <p className={`text-[12px] md:text-[14px] leading-relaxed transition-colors ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                  {ecosystemData.about?.trim()
-                    ? ecosystemData.about
-                    : 'No description provided'}
-                </p>
-              </div>
-
-              {/* Key Areas */}
-              <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-                <h2 className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
-                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>
-                  Key Areas
-                </h2>
-                <ul className="space-y-2 md:space-y-3">
-                {ecosystemData.keyAreas && ecosystemData.keyAreas.length > 0 ? (
-                  <ul className="space-y-2 md:space-y-3">
-                    {ecosystemData.keyAreas.map((area, idx) => (
-                      <li key={idx} className="flex gap-2 md:gap-3">
-                        <span className={`mt-0.5 md:mt-1 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>•</span>
-                        <div className="flex-1 min-w-0">
-                          <span className={`font-bold text-[12px] md:text-[14px] ${isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'}`}>
-                            {area.title}:
-                          </span>{' '}
-                          <span className={`text-[12px] md:text-[14px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                            {area.description}
-                          </span>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                    No key areas available
-                  </p>
-                )}
-                </ul>
-              </div>
-
-              {/* Technologies */}
-              <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-4 md:p-6">
-                <h2 className={`text-[16px] md:text-[18px] font-bold mb-3 md:mb-4 transition-colors ${
-                  isDark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>
-                  Technologies
-                </h2>
-                <p className={`text-[11px] md:text-[13px] mb-2 md:mb-3 ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                  Supported technologies for ecosystem projects:
-                </p>
-                <ul className="space-y-1.5 md:space-y-2">
-                {ecosystemData.technologies && ecosystemData.technologies.length > 0 ? (
-                  <ul className="space-y-1.5 md:space-y-2">
-                    {ecosystemData.technologies.map((tech, idx) => (
-                      <li key={idx} className="flex gap-2 md:gap-3">
-                        <span className={`mt-0.5 md:mt-1 flex-shrink-0 ${isDark ? 'text-[#c9983a]' : 'text-[#a67c2a]'}`}>•</span>
-                        <span className={`text-[12px] md:text-[14px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                          {tech}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className={`text-[12px] md:text-[13px] ${isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
-                    No technologies available
-                  </p>
-                )}
-                </ul>
-              </div>
-            </div>
-          )}
-
-          {activeTab === 'projects' && (
-            <div className="space-y-4 md:space-y-6">
-              {/* Search and Filter */}
-              <SearchWithFilter
-                searchPlaceholder="Search"
-                searchValue={searchQuery}
-                onSearchChange={setSearchQuery}
-                filterSections={[
-                  {
-                    title: 'Languages',
-                    hasSearch: true,
-                    options: [
-                      { label: 'TypeScript', value: 'typescript' },
-                      { label: 'JavaScript', value: 'javascript' },
-                      { label: 'Python', value: 'python' },
-                      { label: 'Rust', value: 'rust' },
-                    ],
-                    selectedValues: selectedLanguages,
-                    onToggle: (value) => {
-                      setSelectedLanguages(prev =>
-                        prev.includes(value)
-                          ? prev.filter(v => v !== value)
-                          : [...prev, value]
-                      );
-                    },
-                  },
-                  {
-                    title: 'Categories',
-                    hasSearch: false,
-                    options: [
-                      { label: 'Frontend', value: 'frontend' },
-                      { label: 'Backend', value: 'backend' },
-                      { label: 'Full Stack', value: 'fullstack' },
-                      { label: 'DevOps', value: 'devops' },
-                    ],
-                    selectedValues: selectedCategories,
-                    onToggle: (value) => {
-                      setSelectedCategories(prev =>
-                        prev.includes(value)
-                          ? prev.filter(v => v !== value)
-                          : [...prev, value]
-                      );
-                    },
-                  },
-                ]}
-                onReset={() => {
-                  setSearchQuery('');
-                  setSelectedLanguages([]);
-                  setSelectedCategories([]);
-                }}
-              />
-
-              {/* Projects Grid */}
-              {isLoadingProjects ? (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
-                  {[1, 2, 3, 4].map((i) => (
-                    <div key={i} className={`rounded-[18px] border p-5 ${isDark ? 'bg-white/[0.08] border-white/15' : 'bg-white/[0.15] border-white/25'}`}>
-                      <SkeletonLoader className="h-11 w-11 rounded-[12px] mb-4" />
-                      <SkeletonLoader className="h-4 w-3/4 mb-2" />
-                      <SkeletonLoader className="h-3 w-full mb-1" />
-                      <SkeletonLoader className="h-3 w-5/6 mb-4" />
-                      <div className="flex gap-2 mb-4">
-                        <SkeletonLoader className="h-4 w-12" />
-                        <SkeletonLoader className="h-4 w-12" />
-                      </div>
-                      <div className="flex gap-2">
-                        <SkeletonLoader className="h-7 w-16 rounded-[8px]" />
-                        <SkeletonLoader className="h-7 w-20 rounded-[8px]" />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : filteredProjects.length === 0 ? (
-                <div className={`rounded-[16px] border p-8 text-center ${isDark ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]' : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'}`}>
-                  <FolderGit2 className={`w-10 h-10 mx-auto mb-3 ${isDark ? 'text-[#b8a898]' : 'text-[#8a7b6a]'}`} />
-                  <p className="text-[14px] font-semibold">No projects in {ecosystemName} yet</p>
-                  <p className="text-[12px] mt-1">Projects added under this ecosystem will appear here.</p>
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
-                  {filteredProjects.map((project) => (
-                    <ProjectCard key={project.id} project={project} onClick={onProjectClick} />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-
-          {activeTab === 'community' && (
-            <div className="backdrop-blur-[40px] rounded-[16px] md:rounded-[24px] border bg-white/[0.12] border-white/20 p-6 md:p-8 text-center">
-              <Users className={`w-10 h-10 md:w-12 md:h-12 mx-auto mb-3 md:mb-4 ${
-                isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-              }`} />
-              <p className={`text-[12px] md:text-[14px] ${
-                isDark ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-              }`}>
-                Community view coming soon
-              </p>
-            </div>
-          )}
-        </div>
       </div>
     </div>
-      </div>
-  );
+  )
 }

--- a/src/shared/utils/projectFilter.test.ts
+++ b/src/shared/utils/projectFilter.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { getRepoName, isValidProject } from "./projectFilter";
+import { describe, it, expect } from 'vitest'
+import {
+  getRepoName,
+  isValidProject,
+  filterProjects,
+  type FilterableProject,
+  type ProjectFilterCriteria,
+} from './projectFilter'
 
 /**
  * Minimal shape of a project record as consumed by {@link isValidProject}.
@@ -8,8 +14,8 @@ import { getRepoName, isValidProject } from "./projectFilter";
  * exercises.
  */
 interface ProjectFixture {
-  id?: unknown;
-  github_full_name?: unknown;
+  id?: unknown
+  github_full_name?: unknown
 }
 
 /**
@@ -19,144 +25,323 @@ interface ProjectFixture {
  */
 function makeProject(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
   return {
-    id: "proj-1",
-    github_full_name: "grainlify/grainlify-frontend",
+    id: 'proj-1',
+    github_full_name: 'grainlify/grainlify-frontend',
     ...overrides,
-  };
+  }
 }
 
-describe("getRepoName", () => {
+describe('getRepoName', () => {
   /**
    * Table of inputs and the repo segment we expect to be extracted. Covers the
    * happy "owner/repo" path, the `?? githubFullName` fallback branch, and a
    * handful of malformed strings.
    */
   const cases: ReadonlyArray<{
-    name: string;
-    input: string;
-    expected: string;
+    name: string
+    input: string
+    expected: string
   }> = [
     {
-      name: "extracts the repo segment from owner/repo",
-      input: "grainlify/grainlify-frontend",
-      expected: "grainlify-frontend",
+      name: 'extracts the repo segment from owner/repo',
+      input: 'grainlify/grainlify-frontend',
+      expected: 'grainlify-frontend',
     },
     {
-      name: "returns the original string when there is no slash",
-      input: "grainlify-frontend",
-      expected: "grainlify-frontend",
+      name: 'returns the original string when there is no slash',
+      input: 'grainlify-frontend',
+      expected: 'grainlify-frontend',
     },
     {
-      name: "returns the original string for an empty string",
-      input: "",
-      expected: "",
+      name: 'returns the original string for an empty string',
+      input: '',
+      expected: '',
     },
     {
-      name: "returns an empty repo segment for a trailing slash",
-      input: "owner/",
-      expected: "",
+      name: 'returns an empty repo segment for a trailing slash',
+      input: 'owner/',
+      expected: '',
     },
     {
-      name: "treats a leading slash as an empty owner",
-      input: "/repo",
-      expected: "repo",
+      name: 'treats a leading slash as an empty owner',
+      input: '/repo',
+      expected: 'repo',
     },
     {
-      name: "keeps only the second segment when there are extra slashes",
-      input: "owner/repo/extra",
-      expected: "repo",
+      name: 'keeps only the second segment when there are extra slashes',
+      input: 'owner/repo/extra',
+      expected: 'repo',
     },
     {
-      name: "is case-preserving (does not normalise casing)",
-      input: "Owner/Repo-Name",
-      expected: "Repo-Name",
+      name: 'is case-preserving (does not normalise casing)',
+      input: 'Owner/Repo-Name',
+      expected: 'Repo-Name',
     },
-  ];
+  ]
 
-  it.each(cases)("$name", ({ input, expected }) => {
-    expect(getRepoName(input)).toBe(expected);
-  });
-});
+  it.each(cases)('$name', ({ input, expected }) => {
+    expect(getRepoName(input)).toBe(expected)
+  })
+})
 
-describe("isValidProject", () => {
-  describe("rejects falsy or incomplete projects", () => {
+describe('isValidProject', () => {
+  describe('rejects falsy or incomplete projects', () => {
     /**
      * Each case targets one short-circuit in the guard
      * `!project || !project.id || !project.github_full_name`.
      */
     const invalidCases: ReadonlyArray<{ name: string; project: unknown }> = [
-      { name: "null", project: null },
-      { name: "undefined", project: undefined },
-      { name: "false", project: false },
-      { name: "missing id", project: { github_full_name: "owner/repo" } },
-      { name: "empty-string id", project: makeProject({ id: "" }) },
-      { name: "zero id", project: makeProject({ id: 0 }) },
+      { name: 'null', project: null },
+      { name: 'undefined', project: undefined },
+      { name: 'false', project: false },
+      { name: 'missing id', project: { github_full_name: 'owner/repo' } },
+      { name: 'empty-string id', project: makeProject({ id: '' }) },
+      { name: 'zero id', project: makeProject({ id: 0 }) },
       {
-        name: "missing github_full_name",
-        project: { id: "proj-1" },
+        name: 'missing github_full_name',
+        project: { id: 'proj-1' },
       },
       {
-        name: "empty-string github_full_name",
-        project: makeProject({ github_full_name: "" }),
+        name: 'empty-string github_full_name',
+        project: makeProject({ github_full_name: '' }),
       },
-    ];
+    ]
 
-    it.each(invalidCases)("returns false for $name", ({ project }) => {
-      expect(isValidProject(project)).toBe(false);
-    });
-  });
+    it.each(invalidCases)('returns false for $name', ({ project }) => {
+      expect(isValidProject(project)).toBe(false)
+    })
+  })
 
-  describe("excludes special GitHub repositories", () => {
-    it("returns false when the repo is the .github special repo", () => {
-      expect(
-        isValidProject(makeProject({ github_full_name: "grainlify/.github" })),
-      ).toBe(false);
-    });
+  describe('excludes special GitHub repositories', () => {
+    it('returns false when the repo is the .github special repo', () => {
+      expect(isValidProject(makeProject({ github_full_name: 'grainlify/.github' }))).toBe(false)
+    })
 
-    it("is case-sensitive: .GitHub is not treated as the special repo", () => {
-      expect(
-        isValidProject(makeProject({ github_full_name: "grainlify/.GitHub" })),
-      ).toBe(true);
-    });
+    it('is case-sensitive: .GitHub is not treated as the special repo', () => {
+      expect(isValidProject(makeProject({ github_full_name: 'grainlify/.GitHub' }))).toBe(true)
+    })
 
     it("does not exclude repos that merely contain '.github'", () => {
-      expect(
-        isValidProject(
-          makeProject({ github_full_name: "grainlify/.github-actions" }),
-        ),
-      ).toBe(true);
-    });
+      expect(isValidProject(makeProject({ github_full_name: 'grainlify/.github-actions' }))).toBe(
+        true
+      )
+    })
 
     it("treats a bare '.github' (no owner) as the special repo", () => {
-      expect(isValidProject(makeProject({ github_full_name: ".github" }))).toBe(
-        false,
-      );
-    });
-  });
+      expect(isValidProject(makeProject({ github_full_name: '.github' }))).toBe(false)
+    })
+  })
 
-  describe("accepts well-formed projects", () => {
+  describe('accepts well-formed projects', () => {
     /**
      * Valid projects spanning string and numeric ids and varied repo names,
      * confirming the function returns `true` once every guard passes.
      */
-    const validCases: ReadonlyArray<{ name: string; project: ProjectFixture }> =
-      [
-        {
-          name: "a standard owner/repo project",
-          project: makeProject(),
-        },
-        {
-          name: "a numeric id",
-          project: makeProject({ id: 42 }),
-        },
-        {
-          name: "a github_full_name without a slash",
-          project: makeProject({ github_full_name: "standalone-repo" }),
-        },
-      ];
+    const validCases: ReadonlyArray<{ name: string; project: ProjectFixture }> = [
+      {
+        name: 'a standard owner/repo project',
+        project: makeProject(),
+      },
+      {
+        name: 'a numeric id',
+        project: makeProject({ id: 42 }),
+      },
+      {
+        name: 'a github_full_name without a slash',
+        project: makeProject({ github_full_name: 'standalone-repo' }),
+      },
+    ]
 
-    it.each(validCases)("returns true for $name", ({ project }) => {
-      expect(isValidProject(project)).toBe(true);
-    });
-  });
-});
+    it.each(validCases)('returns true for $name', ({ project }) => {
+      expect(isValidProject(project)).toBe(true)
+    })
+  })
+})
+
+describe('filterProjects', () => {
+  /**
+   * Fixed fixture spanning every dimension exercised below: names/descriptions
+   * that do or don't contain "atlas", three languages, and both fully
+   * overlapping and disjoint categories. Ids double as a quick way to assert
+   * *which* projects survived a given combination.
+   */
+  const projects: ReadonlyArray<FilterableProject & { id: number }> = [
+    {
+      id: 1,
+      name: 'atlas-ui',
+      description: 'Frontend dashboard toolkit',
+      language: 'typescript',
+      category: 'frontend',
+    },
+    {
+      id: 2,
+      name: 'atlas-api',
+      description: 'Backend service for atlas',
+      language: 'python',
+      category: 'backend',
+    },
+    {
+      id: 3,
+      name: 'nebula',
+      description: 'Full stack starter kit',
+      language: 'typescript',
+      category: 'fullstack',
+    },
+    {
+      id: 4,
+      name: 'forge-cli',
+      description: 'DevOps automation tool',
+      language: 'rust',
+      category: 'devops',
+    },
+    {
+      id: 5,
+      name: 'atlas-docs',
+      description: 'Documentation site for the atlas ecosystem',
+      language: 'javascript',
+      category: 'frontend',
+    },
+    {
+      id: 6,
+      name: 'quasar',
+      description: 'Backend queue processor',
+      language: 'python',
+      category: 'backend',
+    },
+  ]
+
+  const ids = (result: ReadonlyArray<{ id: number }>) => result.map((p) => p.id)
+
+  describe('single-criterion filtering', () => {
+    it('matches on name or description substring, case-insensitively', () => {
+      expect(ids(filterProjects(projects, { searchQuery: 'ATLAS' }))).toEqual([1, 2, 5])
+    })
+
+    it('matches by language alone', () => {
+      expect(ids(filterProjects(projects, { languages: ['python'] }))).toEqual([2, 6])
+    })
+
+    it('matches by category alone', () => {
+      expect(ids(filterProjects(projects, { categories: ['frontend'] }))).toEqual([1, 5])
+    })
+  })
+
+  describe('combined-criterion filtering', () => {
+    /**
+     * Table-driven combined scenarios. Each case AND-combines two or three
+     * dimensions and asserts the exact surviving id set, so every row also
+     * proves projects that satisfy only *some* of the criteria are excluded.
+     */
+    const cases: ReadonlyArray<{
+      name: string
+      criteria: ProjectFilterCriteria
+      expectedIds: number[]
+    }> = [
+      {
+        name: 'two-way: search AND language narrows to their intersection',
+        criteria: { searchQuery: 'atlas', languages: ['typescript'] },
+        expectedIds: [1],
+      },
+      {
+        name: 'two-way: search AND category narrows to their intersection',
+        criteria: { searchQuery: 'atlas', categories: ['backend'] },
+        expectedIds: [2],
+      },
+      {
+        name: 'two-way: language AND category narrows to their intersection',
+        criteria: { languages: ['typescript'], categories: ['frontend'] },
+        expectedIds: [1],
+      },
+      {
+        name: 'three-way: search AND language AND category narrows to a single project',
+        criteria: {
+          searchQuery: 'atlas',
+          languages: ['typescript'],
+          categories: ['frontend'],
+        },
+        expectedIds: [1],
+      },
+      {
+        name: 'three-way combination with no matches yields the empty state',
+        criteria: {
+          searchQuery: 'atlas',
+          languages: ['rust'],
+          categories: ['frontend'],
+        },
+        expectedIds: [],
+      },
+      {
+        name: 'two-way combination with no overlap yields the empty state',
+        criteria: { languages: ['rust'], categories: ['backend'] },
+        expectedIds: [],
+      },
+      {
+        name: 'no-op filters (all empty/default) yield the full set',
+        criteria: {},
+        expectedIds: [1, 2, 3, 4, 5, 6],
+      },
+      {
+        name: 'explicitly empty search/language/category values yield the full set',
+        criteria: { searchQuery: '', languages: [], categories: [] },
+        expectedIds: [1, 2, 3, 4, 5, 6],
+      },
+    ]
+
+    it.each(cases)('$name', ({ criteria, expectedIds }) => {
+      expect(ids(filterProjects(projects, criteria))).toEqual(expectedIds)
+    })
+  })
+
+  describe('filter order independence', () => {
+    /**
+     * Standalone predicates mirroring each individual criterion. Chaining
+     * them in every permutation and comparing against `filterProjects`
+     * proves the AND-combination is commutative: since none of the
+     * predicates depend on another field, applying them in any order (or all
+     * at once) must yield the same surviving set.
+     */
+    const bySearch = (query: string) => (p: FilterableProject) =>
+      query === '' ||
+      p.name.toLowerCase().includes(query.toLowerCase()) ||
+      p.description.toLowerCase().includes(query.toLowerCase())
+
+    const byLanguage = (languages: string[]) => (p: FilterableProject) =>
+      languages.length === 0 || (p.language != null && languages.includes(p.language))
+
+    const byCategory = (categories: string[]) => (p: FilterableProject) =>
+      categories.length === 0 || (p.category != null && categories.includes(p.category))
+
+    it('yields the same result regardless of which predicate is applied first', () => {
+      const criteria: ProjectFilterCriteria = {
+        searchQuery: 'atlas',
+        languages: ['typescript', 'javascript'],
+        categories: ['frontend'],
+      }
+
+      const searchP = bySearch(criteria.searchQuery ?? '')
+      const languageP = byLanguage(criteria.languages ?? [])
+      const categoryP = byCategory(criteria.categories ?? [])
+
+      const searchFirst = projects.filter(searchP).filter(languageP).filter(categoryP)
+      const categoryFirst = projects.filter(categoryP).filter(languageP).filter(searchP)
+      const languageFirst = projects.filter(languageP).filter(categoryP).filter(searchP)
+
+      const combined = filterProjects(projects, criteria)
+
+      expect(ids(searchFirst)).toEqual(ids(combined))
+      expect(ids(categoryFirst)).toEqual(ids(combined))
+      expect(ids(languageFirst)).toEqual(ids(combined))
+    })
+
+    it('is unaffected by the order of values within a multi-value criterion', () => {
+      const forward = filterProjects(projects, {
+        languages: ['python', 'typescript'],
+      })
+      const reversed = filterProjects(projects, {
+        languages: ['typescript', 'python'],
+      })
+
+      expect(ids(reversed)).toEqual(ids(forward))
+    })
+  })
+})

--- a/src/shared/utils/projectFilter.ts
+++ b/src/shared/utils/projectFilter.ts
@@ -1,20 +1,61 @@
 export function getRepoName(githubFullName: string): string {
   // Handles "owner/repo" and edge cases
-  const parts = githubFullName.split("/");
-  return parts[1] ?? githubFullName;
+  const parts = githubFullName.split('/')
+  return parts[1] ?? githubFullName
+}
+
+export interface FilterableProject {
+  name: string
+  description: string
+  language?: string | null
+  category?: string | null
+}
+
+export interface ProjectFilterCriteria {
+  searchQuery?: string
+  languages?: string[]
+  categories?: string[]
+}
+
+/**
+ * AND-combines search/language/category criteria. Each predicate is
+ * independent (no cross-field dependency), so combined results are the same
+ * regardless of the order criteria are applied in.
+ */
+export function filterProjects<T extends FilterableProject>(
+  projects: readonly T[],
+  criteria: ProjectFilterCriteria
+): T[] {
+  const { searchQuery = '', languages = [], categories = [] } = criteria
+  const query = searchQuery.toLowerCase()
+
+  return projects.filter((project) => {
+    const matchesSearch =
+      query === '' ||
+      project.name.toLowerCase().includes(query) ||
+      project.description.toLowerCase().includes(query)
+
+    const matchesLanguage =
+      languages.length === 0 || (project.language != null && languages.includes(project.language))
+
+    const matchesCategory =
+      categories.length === 0 || (project.category != null && categories.includes(project.category))
+
+    return matchesSearch && matchesLanguage && matchesCategory
+  })
 }
 
 export function isValidProject(project: any): boolean {
   if (!project || !project.id || !project.github_full_name) {
-    return false;
+    return false
   }
 
-  const repoName = getRepoName(project.github_full_name);
+  const repoName = getRepoName(project.github_full_name)
 
   // Exclude special GitHub repositories
-  if (repoName === ".github") {
-    return false;
+  if (repoName === '.github') {
+    return false
   }
 
-  return true;
+  return true
 }


### PR DESCRIPTION
## Related Issues
Closes #454 

## Screenshot
<img width="708" height="591" alt="0" src="https://github.com/user-attachments/assets/678ffd66-0fda-4ab7-99a5-bf6800d429c7" />


## Summary
- `src/shared/utils/projectFilter.ts` previously had no combined-filter logic despite the ticket describing it as such; the real search+language+category filtering lived inline in `EcosystemDetailPage.tsx`.
- Extracted that inline predicate into a new exported `filterProjects()` in `projectFilter.ts`, and updated `EcosystemDetailPage.tsx` to use it.
- Added table-driven tests covering two-way and three-way combined filters, a zero-result combination, a full-result/no-op combination, and two filter-order-independence (commutativity) checks.

## Test plan
- [x] `npx vitest run src/shared/utils/projectFilter.test.ts` — 35 passed
- [x] `npx tsc --noEmit -p .` — no new type errors introduced
