### PR TITLE
test: cover LocaleProvider persistence and rehydration behavior

### DIFF
--- a/src/shared/i18n/LocaleProvider.test.tsx
+++ b/src/shared/i18n/LocaleProvider.test.tsx
@@ -1,0 +1,162 @@
+import type { ReactNode } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  LOCALE_STORAGE_KEY,
+  LocaleProvider,
+  readStoredLocale,
+  useLocale,
+} from './LocaleProvider'
+import { DEFAULT_LOCALE, type Locale } from './messages'
+
+describe('readStoredLocale', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns DEFAULT_LOCALE when no value is stored', () => {
+    expect(readStoredLocale()).toBe(DEFAULT_LOCALE)
+  })
+
+  it('returns a supported stored locale as-is', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es')
+
+    expect(readStoredLocale()).toBe('es')
+  })
+
+  it('falls back to DEFAULT_LOCALE for an unsupported stored value', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'fr')
+
+    expect(readStoredLocale()).toBe(DEFAULT_LOCALE)
+  })
+
+  it('falls back to DEFAULT_LOCALE when localStorage.getItem throws', () => {
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
+
+    expect(readStoredLocale()).toBe(DEFAULT_LOCALE)
+  })
+
+  it('falls back to DEFAULT_LOCALE when rendered without window', () => {
+    vi.stubGlobal('window', undefined)
+
+    try {
+      expect(readStoredLocale()).toBe(DEFAULT_LOCALE)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('LocaleProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    document.documentElement.lang = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createWrapper(initialLocale?: Locale) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider>
+    }
+  }
+
+  it('prefers initialLocale over a different persisted locale', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es')
+    const getItemSpy = vi.spyOn(window.localStorage, 'getItem')
+
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('en'),
+    })
+
+    expect(result.current.locale).toBe('en')
+    expect(getItemSpy).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('en')
+    expect(document.documentElement.lang).toBe('en')
+  })
+
+  it('persists a changed locale and updates document.documentElement.lang', () => {
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('en'),
+    })
+
+    act(() => {
+      result.current.setLocale('es')
+    })
+
+    expect(result.current.locale).toBe('es')
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es')
+    expect(document.documentElement.lang).toBe('es')
+  })
+
+  it('falls back to DEFAULT_LOCALE for an unsupported runtime locale', () => {
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('es'),
+    })
+
+    act(() => {
+      result.current.setLocale('fr' as unknown as Locale)
+    })
+
+    expect(result.current.locale).toBe(DEFAULT_LOCALE)
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe(DEFAULT_LOCALE)
+    expect(document.documentElement.lang).toBe(DEFAULT_LOCALE)
+  })
+
+  it('keeps the in-memory locale when localStorage.setItem throws', () => {
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
+
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('en'),
+    })
+
+    act(() => {
+      result.current.setLocale('es')
+    })
+
+    expect(result.current.locale).toBe('es')
+    expect(document.documentElement.lang).toBe('es')
+    expect(setItemSpy).toHaveBeenLastCalledWith(LOCALE_STORAGE_KEY, 'es')
+  })
+
+  it('persists the latest locale after consecutive changes', () => {
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('en'),
+    })
+
+    act(() => {
+      result.current.setLocale('es')
+    })
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es')
+
+    act(() => {
+      result.current.setLocale('en')
+    })
+
+    expect(result.current.locale).toBe('en')
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('en')
+    expect(document.documentElement.lang).toBe('en')
+  })
+
+  it('throws a clear error when useLocale is called outside LocaleProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() => renderHook(() => useLocale())).toThrow(
+      'useLocale must be used within a LocaleProvider'
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/shared/i18n/LocaleProvider.test.tsx
+++ b/src/shared/i18n/LocaleProvider.test.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react'
-import { act, renderHook } from '@testing-library/react'
+import { Component, type ReactNode } from 'react'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -9,6 +9,30 @@ import {
   useLocale,
 } from './LocaleProvider'
 import { DEFAULT_LOCALE, type Locale } from './messages'
+
+class TestErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  render() {
+    if (this.state.error) {
+      return <span>{this.state.error.message}</span>
+    }
+
+    return this.props.children
+  }
+}
+
+function LocaleConsumer() {
+  useLocale()
+  return null
+}
 
 describe('readStoredLocale', () => {
   beforeEach(() => {
@@ -114,9 +138,11 @@ describe('LocaleProvider', () => {
   })
 
   it('keeps the in-memory locale when localStorage.setItem throws', () => {
-    const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
-      throw new Error('storage unavailable')
-    })
+    const setItemSpy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('storage unavailable')
+      })
 
     const { result } = renderHook(() => useLocale(), {
       wrapper: createWrapper('en'),
@@ -153,10 +179,13 @@ describe('LocaleProvider', () => {
   it('throws a clear error when useLocale is called outside LocaleProvider', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    expect(() => renderHook(() => useLocale())).toThrow(
-      'useLocale must be used within a LocaleProvider'
+    render(
+      <TestErrorBoundary>
+        <LocaleConsumer />
+      </TestErrorBoundary>
     )
 
+    expect(screen.getByText('useLocale must be used within a LocaleProvider')).toBeInTheDocument()
     consoleError.mockRestore()
   })
 })

--- a/src/shared/i18n/LocaleProvider.test.tsx
+++ b/src/shared/i18n/LocaleProvider.test.tsx
@@ -2,18 +2,10 @@ import { Component, type ReactNode } from 'react'
 import { act, render, renderHook, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  LOCALE_STORAGE_KEY,
-  LocaleProvider,
-  readStoredLocale,
-  useLocale,
-} from './LocaleProvider'
+import { LOCALE_STORAGE_KEY, LocaleProvider, readStoredLocale, useLocale } from './LocaleProvider'
 import { DEFAULT_LOCALE, type Locale } from './messages'
 
-class TestErrorBoundary extends Component<
-  { children: ReactNode },
-  { error: Error | null }
-> {
+class TestErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state: { error: Error | null } = { error: null }
 
   static getDerivedStateFromError(error: Error) {
@@ -87,6 +79,7 @@ describe('LocaleProvider', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   function createWrapper(initialLocale?: Locale) {
@@ -94,6 +87,18 @@ describe('LocaleProvider', () => {
       return <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider>
     }
   }
+
+  it('rehydrates a valid stored locale when initialLocale is omitted', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es')
+
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.locale).toBe('es')
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es')
+    expect(document.documentElement.lang).toBe('es')
+  })
 
   it('prefers initialLocale over a different persisted locale', () => {
     window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es')
@@ -123,6 +128,25 @@ describe('LocaleProvider', () => {
     expect(document.documentElement.lang).toBe('es')
   })
 
+  it('persists a changed locale when document is unavailable', () => {
+    const { result } = renderHook(() => useLocale(), {
+      wrapper: createWrapper('en'),
+    })
+
+    vi.stubGlobal('document', undefined)
+
+    try {
+      act(() => {
+        result.current.setLocale('es')
+      })
+
+      expect(result.current.locale).toBe('es')
+      expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('falls back to DEFAULT_LOCALE for an unsupported runtime locale', () => {
     const { result } = renderHook(() => useLocale(), {
       wrapper: createWrapper('es'),
@@ -138,11 +162,9 @@ describe('LocaleProvider', () => {
   })
 
   it('keeps the in-memory locale when localStorage.setItem throws', () => {
-    const setItemSpy = vi
-      .spyOn(window.localStorage, 'setItem')
-      .mockImplementation(() => {
-        throw new Error('storage unavailable')
-      })
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
 
     const { result } = renderHook(() => useLocale(), {
       wrapper: createWrapper('en'),
@@ -178,14 +200,20 @@ describe('LocaleProvider', () => {
 
   it('throws a clear error when useLocale is called outside LocaleProvider', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const preventDefault = (event: ErrorEvent) => event.preventDefault()
+    window.addEventListener('error', preventDefault)
 
-    render(
-      <TestErrorBoundary>
-        <LocaleConsumer />
-      </TestErrorBoundary>
-    )
+    try {
+      render(
+        <TestErrorBoundary>
+          <LocaleConsumer />
+        </TestErrorBoundary>
+      )
 
-    expect(screen.getByText('useLocale must be used within a LocaleProvider')).toBeInTheDocument()
-    consoleError.mockRestore()
+      expect(screen.getByText('useLocale must be used within a LocaleProvider')).toBeInTheDocument()
+    } finally {
+      window.removeEventListener('error', preventDefault)
+      consoleError.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary

- add dedicated coverage for `readStoredLocale()` fallback and validation behavior
- verify `LocaleProvider` rehydration, `initialLocale` precedence, persistence, runtime locale guarding, and document language updates
- cover storage read/write failures, SSR/no-window behavior, no-document behavior, consecutive locale changes, and `useLocale()` outside its provider

## Validation

- `npm test -- src/shared/i18n/LocaleProvider.test.tsx` — 13 tests passed
- `npx --no-install vitest run src/shared/i18n/LocaleProvider.test.tsx --coverage --coverage.include=src/shared/i18n/LocaleProvider.tsx` — 100% statements, branches, functions, and lines
- `npx prettier --check src/shared/i18n/LocaleProvider.test.tsx`
- `npx eslint src/shared/i18n/LocaleProvider.test.tsx`
- `git diff --check`

## Notes

The repository's committed `package-lock.json` is currently out of sync with `package.json`, so validation used `npm install --package-lock=false` without modifying either manifest.

Repository-wide formatting, type-check, lint, and build failures are pre-existing and unrelated to this test-only change.

Closes #581