### PR TITLE
test: cover BlogHowItWorks contributor and maintainer step lists [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/features/blog/components/BlogHowItWorks.test.tsx
+++ b/src/features/blog/components/BlogHowItWorks.test.tsx
@@ -1,0 +1,63 @@
+import { screen, within } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { BlogHowItWorks } from './BlogHowItWorks'
+
+// Mock the Github icon which doesn't exist in the installed lucide-react 1.23.0
+vi.mock('lucide-react', async () => {
+  const actual = await vi.importActual('lucide-react')
+  return {
+    ...(actual as Record<string, unknown>),
+    Github: () => React.createElement('svg'),
+  }
+})
+
+describe('BlogHowItWorks', () => {
+  it('renders the "How It Works" heading', () => {
+    renderWithTheme(<BlogHowItWorks />)
+
+    expect(screen.getByText('How It Works')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /how it works/i })).toBeInTheDocument()
+  })
+
+  it('renders all five contributor steps in order inside an <ol>', () => {
+    renderWithTheme(<BlogHowItWorks />)
+
+    const contributorHeading = screen.getByText('For Contributors')
+    expect(contributorHeading).toBeInTheDocument()
+
+    const contributorSection = contributorHeading.closest('div')!
+    const ol = within(contributorSection).getByRole('list')
+    expect(ol).toBeInTheDocument()
+    expect(ol.tagName).toBe('OL')
+
+    const items = within(ol).getAllByRole('listitem')
+    expect(items).toHaveLength(5)
+    expect(items[0]).toHaveTextContent('Connect your GitHub account')
+    expect(items[1]).toHaveTextContent('Browse projects that match your skills')
+    expect(items[2]).toHaveTextContent('Start contributing to issues and features')
+    expect(items[3]).toHaveTextContent('Earn rewards and build your reputation')
+    expect(items[4]).toHaveTextContent('Climb the leaderboard and unlock opportunities')
+  })
+
+  it('renders all five maintainer steps in order inside an <ol>', () => {
+    renderWithTheme(<BlogHowItWorks />)
+
+    const maintainerHeading = screen.getByText('For Project Maintainers')
+    expect(maintainerHeading).toBeInTheDocument()
+
+    const maintainerSection = maintainerHeading.closest('div')!
+    const ol = within(maintainerSection).getByRole('list')
+    expect(ol).toBeInTheDocument()
+    expect(ol.tagName).toBe('OL')
+
+    const items = within(ol).getAllByRole('listitem')
+    expect(items).toHaveLength(5)
+    expect(items[0]).toHaveTextContent('Submit your project to OnlyGrain')
+    expect(items[1]).toHaveTextContent('Set up bounties and contribution guidelines')
+    expect(items[2]).toHaveTextContent('Get matched with skilled developers')
+    expect(items[3]).toHaveTextContent('Review contributions and approve rewards')
+    expect(items[4]).toHaveTextContent('Scale your project with community support')
+  })
+})


### PR DESCRIPTION
## Description
Adds dedicated test coverage for `BlogHowItWorks.tsx` — the "How It Works" section on the blog page.

### Tests added
- **Heading**: verifies the "How It Works" heading renders
- **Contributor steps**: verifies all 5 contributor steps render in order inside an `<ol>` under "For Contributors"
- **Maintainer steps**: verifies all 5 maintainer steps render in order inside an `<ol>` under "For Project Maintainers"

### Notes
- The `Github` icon from `lucide-react` is mocked in the test because it doesn't exist in the installed version (1.23.0) — this is a pre-existing project issue, not related to this PR
- Uses `renderWithTheme` helper as recommended

### Testing
```
NODE_ENV=development npm test -- --run BlogHowItWorks
```
All 3 tests pass.

Closes #658