### PR TITLE
fix: replace leftover OnlyGrain branding with Grainlify in blog content

### DIFF
--- a/src/features/blog/components/BlogArticle.tsx
+++ b/src/features/blog/components/BlogArticle.tsx
@@ -20,13 +20,13 @@ export function BlogArticle({ content }: BlogArticleProps) {
       number: 1,
       title: 'Connect Developers with Projects',
       description:
-        "We provide an intelligent matching system that connects developers with projects that align with their skills, interests, and experience level. Whether you're a seasoned blockchain architect or just starting your Web3 journey, there's a place for you on OnlyGrain.",
+        "We provide an intelligent matching system that connects developers with projects that align with their skills, interests, and experience level. Whether you're a seasoned blockchain architect or just starting your Web3 journey, there's a place for you on Grainlify.",
     },
     {
       number: 2,
       title: 'Multi-Chain Support',
       description:
-        'From Ethereum to Solana, Polkadot to Cosmos, and everything in between—OnlyGrain supports projects across all major blockchain ecosystems. We believe in a multi-chain future and our platform reflects that vision.',
+        'From Ethereum to Solana, Polkadot to Cosmos, and everything in between—Grainlify supports projects across all major blockchain ecosystems. We believe in a multi-chain future and our platform reflects that vision.',
     },
     {
       number: 3,
@@ -44,7 +44,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
       number: 5,
       title: 'Community-Driven Development',
       description:
-        'At OnlyGrain, we believe in the power of community. Our platform facilitates collaboration, knowledge sharing, and networking among developers, project maintainers, and ecosystem stakeholders.',
+        'At Grainlify, we believe in the power of community. Our platform facilitates collaboration, knowledge sharing, and networking among developers, project maintainers, and ecosystem stakeholders.',
     },
   ]
 
@@ -58,7 +58,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
               theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
             }`}
           >
-            Welcome to OnlyGrain: The Future of Open Source Collaboration
+            Welcome to Grainlify: The Future of Open Source Collaboration
           </h2>
           <div
             className={`flex items-center justify-center gap-4 text-[14px] transition-colors ${
@@ -91,14 +91,14 @@ export function BlogArticle({ content }: BlogArticleProps) {
                   }`}
                 >
                   <Sparkles className="w-7 h-7 text-[#c9983a]" />
-                  What is OnlyGrain?
+                  What is Grainlify?
                 </h3>
                 <p
                   className={`text-[16px] leading-relaxed mb-4 transition-colors ${
                     theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
                   }`}
                 >
-                  OnlyGrain is a revolutionary platform that bridges the gap between talented
+                  Grainlify is a revolutionary platform that bridges the gap between talented
                   open-source developers and innovative Web3 projects across all blockchain
                   ecosystems. We're not just another development platform—we're building the future
                   of decentralized collaboration.
@@ -110,7 +110,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
                 >
                   In the rapidly evolving world of blockchain and Web3, finding the right talent for
                   your project or discovering meaningful contribution opportunities can be
-                  challenging. OnlyGrain solves this by creating a unified ecosystem where
+                  challenging. Grainlify solves this by creating a unified ecosystem where
                   developers and projects connect, collaborate, and thrive together.
                 </p>
               </div>
@@ -155,7 +155,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
               {/* How It Works */}
               <BlogHowItWorks />
 
-              {/* Why Choose OnlyGrain */}
+              {/* Why Choose Grainlify */}
               <div className="mb-8">
                 <h3
                   className={`text-[28px] font-bold mb-4 flex items-center gap-3 transition-colors ${
@@ -163,7 +163,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
                   }`}
                 >
                   <Coins className="w-7 h-7 text-[#c9983a]" />
-                  Why Choose OnlyGrain?
+                  Why Choose Grainlify?
                 </h3>
                 <BlogWhyChoose />
               </div>

--- a/src/features/blog/components/BlogCTA.tsx
+++ b/src/features/blog/components/BlogCTA.tsx
@@ -12,7 +12,7 @@ export function BlogCTA() {
       <p className={`text-[16px] mb-6 max-w-2xl mx-auto transition-colors ${
         theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
       }`}>
-        Whether you're a developer looking for your next challenge or a project seeking talented contributors, OnlyGrain is your gateway to the future of open-source collaboration.
+        Whether you're a developer looking for your next challenge or a project seeking talented contributors, Grainlify is your gateway to the future of open-source collaboration.
       </p>
       <div className="flex items-center justify-center gap-4">
         <button className="px-8 py-4 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[16px] font-bold text-[16px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all flex items-center gap-2 border border-white/10">

--- a/src/features/blog/components/BlogHero.tsx
+++ b/src/features/blog/components/BlogHero.tsx
@@ -22,10 +22,10 @@ export function BlogHero() {
               <div>
                 <h1 className={`text-[38px] font-bold transition-colors ${
                   theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>OnlyGrain Blog</h1>
+                }`}>Grainlify Blog</h1>
                 <p className={`text-[15px] transition-colors ${
                   theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                }`}>Insights, updates, and stories from the OnlyGrain ecosystem</p>
+                }`}>Insights, updates, and stories from the Grainlify ecosystem</p>
               </div>
             </div>
           </div>

--- a/src/features/blog/components/BlogHowItWorks.tsx
+++ b/src/features/blog/components/BlogHowItWorks.tsx
@@ -13,7 +13,7 @@ export function BlogHowItWorks() {
   ];
 
   const maintainerSteps = [
-    'Submit your project to OnlyGrain',
+    'Submit your project to Grainlify',
     'Set up bounties and contribution guidelines',
     'Get matched with skilled developers',
     'Review contributions and approve rewards',

--- a/src/features/blog/data/blogPosts.ts
+++ b/src/features/blog/data/blogPosts.ts
@@ -3,17 +3,17 @@ import { BlogPost } from '../types';
 export const featuredPost: BlogPost = {
   id: 0,
   slug: "bridging-the-gap-onlygrain-open-source",
-  title: "Bridging the Gap: How OnlyGrain is Revolutionizing Open Source Contribution",
-  excerpt: "Discover how OnlyGrain connects talented developers with groundbreaking Web3 projects across all blockchain ecosystems, creating a seamless bridge between innovation and execution.",
+  title: "Bridging the Gap: How Grainlify is Revolutionizing Open Source Contribution",
+  excerpt: "Discover how Grainlify connects talented developers with groundbreaking Web3 projects across all blockchain ecosystems, creating a seamless bridge between innovation and execution.",
   content:
-    "OnlyGrain connects talented open-source developers with innovative Web3 " +
+    "Grainlify connects talented open-source developers with innovative Web3 " +
     "projects across every major blockchain ecosystem. By matching contributors " +
     "to work that fits their skills and rewarding quality contributions " +
     "transparently, we make meaningful collaboration accessible to everyone — " +
     "from seasoned protocol engineers to first-time Web3 contributors.",
   date: "December 27, 2024",
   readTime: "8 min read",
-  author: "OnlyGrain Team",
+  author: "Grainlify Team",
   image: "🌐",
   isFeatured: true,
 };
@@ -33,7 +33,7 @@ export const recentPosts: BlogPost[] = [
     id: 2,
     slug: "cross-chain-collaboration",
     title: "Cross-Chain Collaboration: Breaking Down Barriers",
-    excerpt: "How OnlyGrain enables developers to contribute to projects across multiple blockchain ecosystems seamlessly.",
+    excerpt: "How Grainlify enables developers to contribute to projects across multiple blockchain ecosystems seamlessly.",
     date: "December 15, 2024",
     readTime: "7 min read",
     category: "Technology",


### PR DESCRIPTION
## Description

Replaces leftover "OnlyGrain" product name with "Grainlify" across blog content components and mock data.

### Changes

- **`src/features/blog/components/BlogArticle.tsx`**: Updated all 9 "OnlyGrain" mentions (section headings, paragraphs, welcome text)
- **`src/features/blog/components/BlogHero.tsx`**: Updated heading and subtitle text
- **`src/features/blog/components/BlogHowItWorks.tsx`**: Updated step description text
- **`src/features/blog/components/BlogCTA.tsx`**: Updated call-to-action body text
- **`src/features/blog/data/blogPosts.ts`**: Updated post titles, excerpts, and author name

### Verification

- `grep -rn "OnlyGrain" src/` returns zero matches
- All blog-related tests pass (6/7 test files pass, 60/63 tests pass — the 1 failing file `BlogPage.test.tsx` with 3 failures is pre-existing and unrelated to this change)

### Acceptance Criteria

- [x] `grep -rn "OnlyGrain" src` returns zero matches
- [x] Blog tests pass (no regressions)
- [x] No other product name introduced by mistake

Closes #643
