### PR TITLE
fix: use React state for IssueCard avatar fallback instead of DOM mutation

### DIFF
--- a/src/features/maintainers/components/issues/IssueCard.test.tsx
+++ b/src/features/maintainers/components/issues/IssueCard.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { IssueCard } from './IssueCard';
+import { renderWithTheme } from '../../../../test/renderWithTheme';
+import type { Issue } from '../../types';
+
+const baseIssue: Issue = {
+  id: '1',
+  title: 'Test Issue',
+  repo: 'test/repo',
+  comments: 5,
+  applicants: 2,
+  tags: ['bug', 'frontend'],
+  user: 'testuser',
+  timeAgo: '2 days ago',
+  applicationStatus: 'none',
+};
+
+describe('IssueCard – avatar fallback', () => {
+  it('renders the avatar image when loaded successfully', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    const img = screen.getByAltText('testuser') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toContain('github.com/testuser.png');
+  });
+
+  it('shows initials fallback when image fails to load', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    const img = screen.getByAltText('testuser') as HTMLImageElement;
+    fireEvent.error(img);
+    // After the error, the initials should be visible
+    const initials = screen.getByText('TE');
+    expect(initials).toBeInTheDocument();
+  });
+
+  it('resets to image when issue.user changes after a prior failure', () => {
+    const { rerender } = renderWithTheme(
+      <IssueCard issue={baseIssue} index={0} onClick={() => {}} />,
+    );
+    // Trigger image failure
+    const img = screen.getByAltText('testuser') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(screen.getByText('TE')).toBeInTheDocument();
+
+    // Change user
+    const updatedIssue = { ...baseIssue, user: 'newuser' };
+    rerender(<IssueCard issue={updatedIssue} index={0} onClick={() => {}} />);
+    // After user change, should show the image again (reset state)
+    const newImg = screen.getByAltText('newuser') as HTMLImageElement;
+    expect(newImg).toBeInTheDocument();
+    expect(newImg.src).toContain('github.com/newuser.png');
+  });
+
+  it('renders correct initials for different usernames', () => {
+    const issues = [
+      { ...baseIssue, user: 'alice' },
+      { ...baseIssue, user: 'bob' },
+      { ...baseIssue, user: 'charlie' },
+    ];
+    issues.forEach((issue) => {
+      const { unmount } = renderWithTheme(
+        <IssueCard issue={issue} index={0} onClick={() => {}} />,
+      );
+      const img = screen.getByAltText(issue.user) as HTMLImageElement;
+      fireEvent.error(img);
+      expect(screen.getByText(issue.user.substring(0, 2).toUpperCase())).toBeInTheDocument();
+      unmount();
+    });
+  });
+});
+
+describe('IssueCard – basic rendering', () => {
+  it('renders issue title and repo', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('Test Issue')).toBeInTheDocument();
+    expect(screen.getByText('test/repo')).toBeInTheDocument();
+  });
+
+  it('renders comment count', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders applicant count with correct pluralization', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('2 applicants')).toBeInTheDocument();
+
+    const singleIssue = { ...baseIssue, applicants: 1 };
+    const { unmount } = renderWithTheme(
+      <IssueCard issue={singleIssue} index={0} onClick={() => {}} />,
+    );
+    expect(screen.getByText('1 applicant')).toBeInTheDocument();
+    unmount();
+  });
+
+  it('renders the username and timeAgo', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+    expect(screen.getByText('2 days ago')).toBeInTheDocument();
+  });
+
+  it('renders tags', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('bug')).toBeInTheDocument();
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+  });
+
+  it('renders issue number', () => {
+    renderWithTheme(<IssueCard issue={baseIssue} index={0} onClick={() => {}} />);
+    expect(screen.getByText('#1')).toBeInTheDocument();
+  });
+
+  it('handles empty tags gracefully', () => {
+    const noTags = { ...baseIssue, tags: [] };
+    const { container } = renderWithTheme(
+      <IssueCard issue={noTags} index={0} onClick={() => {}} />,
+    );
+    const tagContainers = container.querySelectorAll('.flex.flex-wrap');
+    // Should not render a tag section
+    expect(tagContainers.length).toBe(0);
+  });
+});

--- a/src/features/maintainers/components/issues/IssueCard.tsx
+++ b/src/features/maintainers/components/issues/IssueCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Circle, FileText, User, Rocket, Users, User as UserIcon } from 'lucide-react';
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
 import { Issue } from '../../types';
@@ -10,6 +11,11 @@ interface IssueCardProps {
 
 export function IssueCard({ issue, index, onClick }: IssueCardProps) {
   const { theme } = useTheme();
+  const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => setImageFailed(false), [issue.user]);
+
+  const initials = issue.user.substring(0, 2).toUpperCase();
   const getIcon = () => {
     const iconColor = theme === 'dark' ? '#b8a898' : '#7a6b5a';
     switch (issue.icon) {
@@ -102,26 +108,18 @@ export function IssueCard({ issue, index, onClick }: IssueCardProps) {
       <div className={`flex items-center gap-2 pt-3 border-t transition-colors ${
         theme === 'dark' ? 'border-white/10' : 'border-white/20'
       }`}>
-        <img
-          src={`https://github.com/${issue.user}.png?size=24`}
-          alt={issue.user}
-          className="w-6 h-6 rounded-full border border-[#c9983a]/40"
-          onError={(e) => {
-            // Fallback to initials if image fails to load
-            const target = e.target as HTMLImageElement;
-            target.style.display = 'none';
-            const parent = target.parentElement;
-            if (parent) {
-              const fallback = document.createElement('div');
-              fallback.className = 'w-6 h-6 rounded-full bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border border-[#c9983a]/40 flex items-center justify-center';
-              const span = document.createElement('span');
-              span.className = 'text-[10px] font-bold text-[#c9983a]';
-              span.textContent = issue.user.substring(0, 2).toUpperCase();
-              fallback.appendChild(span);
-              parent.insertBefore(fallback, target);
-            }
-          }}
-        />
+        {imageFailed ? (
+          <div className="w-6 h-6 rounded-full bg-gradient-to-br from-[#c9983a]/30 to-[#d4af37]/20 border border-[#c9983a]/40 flex items-center justify-center flex-shrink-0">
+            <span className="text-[10px] font-bold text-[#c9983a]">{initials}</span>
+          </div>
+        ) : (
+          <img
+            src={`https://github.com/${issue.user}.png?size=24`}
+            alt={issue.user}
+            className="w-6 h-6 rounded-full border border-[#c9983a]/40"
+            onError={() => setImageFailed(true)}
+          />
+        )}
         <span className={`text-[11px] font-semibold transition-colors ${
           theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
         }`}>{issue.user}</span>


### PR DESCRIPTION
## Description

Replaces imperative DOM manipulation in IssueCard's avatar `onError` handler with React state-based conditional rendering, matching the pattern already established in `UserAvatar.tsx`.

### Changes

**`src/features/maintainers/components/issues/IssueCard.tsx`**:
- Added `useState<boolean>(false)` for `imageFailed` state
- Added `useEffect(() => setImageFailed(false), [issue.user])` to reset failure state when user changes
- Replaced `document.createElement`/`insertBefore` DOM mutation with conditional JSX rendering
- Added `flex-shrink-0` to the fallback `<div>` for consistent layout

### Tests added (`IssueCard.test.tsx`)

- **Image loads successfully**: verifies `<img>` renders with correct `src`
- **Image fails to load**: verifies initials fallback ("TE" for "testuser") is shown after `fireEvent.error`
- **User changes after prior failure**: verifies new avatar image is retried (not stuck on stale initials)
- **Different usernames**: verifies correct initials for alice→"AL", bob→"BO", charlie→"CH"
- **Basic rendering**: title, repo, comment count, applicant count (pluralization), username, timeAgo, tags, issue number, empty tags

### Verification

All 11 tests pass (11/11, 0 failures).

### Acceptance Criteria

- [x] No `document.createElement`/`insertBefore`/`target.style.display` in the component
- [x] Changing `issue.user` after a prior image failure re-attempts loading the new avatar
- [x] Visual output (fallback classes, initials text) is unchanged

Closes #648