### PR TITLE
fix: make ActivityItemSkeleton respect light/dark theme like ActivityItem

### DIFF
--- a/src/shared/components/ActivityItemSkeleton.test.tsx
+++ b/src/shared/components/ActivityItemSkeleton.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ActivityItemSkeleton } from './ActivityItemSkeleton';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+describe('ActivityItemSkeleton – theme support', () => {
+  it('renders light-mode classes when theme is light', () => {
+    const { container } = renderWithTheme(<ActivityItemSkeleton />, { theme: 'light' });
+    const outerDiv = container.firstChild as HTMLElement;
+    expect(outerDiv.className).toContain('bg-white/[0.15]');
+    expect(outerDiv.className).toContain('border-white/25');
+  });
+
+  it('renders dark-mode classes when theme is dark', () => {
+    const { container } = renderWithTheme(<ActivityItemSkeleton />, { theme: 'dark' });
+    const outerDiv = container.firstChild as HTMLElement;
+    expect(outerDiv.className).toContain('bg-white/[0.08]');
+    expect(outerDiv.className).toContain('border-white/10');
+  });
+
+  it('renders skeleton elements', () => {
+    const { container } = renderWithTheme(<ActivityItemSkeleton />);
+    // The skeleton should render structural elements
+    expect(container.querySelector('.flex')).toBeTruthy();
+  });
+});

--- a/src/shared/components/ActivityItemSkeleton.tsx
+++ b/src/shared/components/ActivityItemSkeleton.tsx
@@ -1,8 +1,15 @@
 import { SkeletonLoader } from './SkeletonLoader';
+import { useTheme } from '../contexts/ThemeContext';
 
 export function ActivityItemSkeleton() {
+  const { theme } = useTheme();
+
   return (
-    <div className="backdrop-blur-[25px] rounded-[14px] border p-4 bg-white/[0.08] border-white/10">
+    <div className={`backdrop-blur-[25px] rounded-[14px] border p-4 ${
+      theme === 'dark'
+        ? 'bg-white/[0.08] border-white/10'
+        : 'bg-white/[0.15] border-white/25'
+    }`}>
       <div className="flex items-start justify-between gap-4">
         {/* Left: Icon + Badge + Title */}
         <div className="flex items-start gap-3 flex-1 min-w-0">
@@ -31,18 +38,3 @@ export function ActivityItemSkeleton() {
     </div>
   );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description

Adds `useTheme()` to `ActivityItemSkeleton` so the loading placeholder respects the current theme, matching `ActivityItem.tsx`'s theme-conditional styling.

### Changes

**`src/shared/components/ActivityItemSkeleton.tsx`**:
- Added `useTheme()` import and call
- Container classes now branch on `theme === 'dark'`:
  - Dark mode: `bg-white/[0.08] border-white/10` (unchanged from before)
  - Light mode: `bg-white/[0.15] border-white/25` (matches `ActivityItem.tsx`)

### Tests added (`ActivityItemSkeleton.test.tsx`)

- **Light mode**: verifies `bg-white/[0.15]` and `border-white/25` classes are applied
- **Dark mode**: verifies `bg-white/[0.08]` and `border-white/10` classes are applied
- **Renders skeleton elements**: verifies the component renders structural elements

### Verification

All 3 tests pass (3/3, 0 failures).

### Acceptance Criteria

- [x] `ActivityItemSkeleton` renders light-mode classes when `theme === 'light'`
- [x] `ActivityItemSkeleton` renders dark-mode classes when `theme === 'dark'`
- [x] No visual mismatch between skeleton and loaded `ActivityItem` in either theme

Closes #647