### PR TITLE
fix: make PRRowSkeleton respect light/dark theme like PRRow [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/shared/components/PRRowSkeleton.test.tsx
+++ b/src/shared/components/PRRowSkeleton.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { PRRowSkeleton } from './PRRowSkeleton';
+import { renderWithTheme } from '../../test/renderWithTheme';
+
+describe('PRRowSkeleton – theme support', () => {
+  it('renders light-mode classes when theme is light', () => {
+    const { container } = renderWithTheme(<PRRowSkeleton />, { theme: 'light' });
+    const tr = container.querySelector('tr') as HTMLElement;
+    expect(tr.className).toContain('bg-white/[0.15]');
+    expect(tr.className).toContain('border-white/25');
+  });
+
+  it('renders dark-mode classes when theme is dark', () => {
+    const { container } = renderWithTheme(<PRRowSkeleton />, { theme: 'dark' });
+    const tr = container.querySelector('tr') as HTMLElement;
+    expect(tr.className).toContain('bg-white/[0.08]');
+    expect(tr.className).toContain('border-white/15');
+  });
+
+  it('renders skeleton elements', () => {
+    const { container } = renderWithTheme(<PRRowSkeleton />);
+    // The skeleton should render structural elements
+    expect(container.querySelector('tr')).toBeTruthy();
+    // Should render skeleton cells
+    expect(screen.getByRole('row')).toBeInTheDocument();
+    // Should render the four cell columns
+    const cells = container.querySelectorAll('td[role="cell"]');
+    expect(cells.length).toBe(4);
+  });
+});

--- a/src/shared/components/PRRowSkeleton.tsx
+++ b/src/shared/components/PRRowSkeleton.tsx
@@ -1,8 +1,15 @@
 import { SkeletonLoader } from './SkeletonLoader';
+import { useTheme } from '../contexts/ThemeContext';
 
 export function PRRowSkeleton() {
+  const { theme } = useTheme();
+
   return (
-    <tr role="row" className="grid grid-cols-[2fr_1.5fr_1fr_0.5fr] gap-6 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border bg-white/[0.08] border-white/15">
+    <tr role="row" className={`grid grid-cols-[2fr_1.5fr_1fr_0.5fr] gap-6 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border ${
+      theme === 'dark'
+        ? 'bg-white/[0.08] border-white/15'
+        : 'bg-white/[0.15] border-white/25'
+    }`}>
       {/* Pull Request Info */}
       <td role="cell">
         <div className="flex items-start gap-3 mb-2">


### PR DESCRIPTION
## Description

Adds `useTheme()` to `PRRowSkeleton` so the loading placeholder respects the current theme, matching `PRRow.tsx`'s theme-conditional styling.

### Changes

**`src/shared/components/PRRowSkeleton.tsx`:**
- Added `useTheme()` import and call
- Container classes now branch on `theme === 'dark'`:
  - Dark mode: `bg-white/[0.08] border-white/15` (unchanged from before)
  - Light mode: `bg-white/[0.15] border-white/25` (matches theme pattern)

### Tests added (`PRRowSkeleton.test.tsx`)

- **Light mode**: verifies `bg-white/[0.15]` and `border-white/25` classes are applied
- **Dark mode**: verifies `bg-white/[0.08]` and `border-white/15` classes are applied
- **Renders skeleton elements**: verifies the component renders with 4 table cells

### Verification

All 3 tests pass (3/3, 0 failures).

### Acceptance Criteria

- [x] `PRRowSkeleton` renders light-mode classes when `theme === 'light'`
- [x] `PRRowSkeleton` renders dark-mode classes when `theme === 'dark'`
- [x] No visual mismatch between skeleton and loaded `PRRow` in either theme

Closes #646