### PR TITLE
chore: resolve duplicate IssueCard naming collision (maintainers vs shared/ui)

### DIFF
--- a/src/features/maintainers/README.md
+++ b/src/features/maintainers/README.md
@@ -16,7 +16,7 @@ The Maintainers dashboard has been refactored into a clean, modular, feature-bas
 │   ├── issues/             # Tab 2: Issues components
 │   │   ├── ApplicationCard.tsx
 │   │   ├── EmptyIssueState.tsx
-│   │   ├── IssueCard.tsx
+│   │   ├── MaintainerIssueCard.tsx
 │   │   ├── IssueFilterDropdown.tsx
 │   │   ├── IssueListSidebar.tsx
 │   │   └── IssuesTab.tsx
@@ -42,7 +42,7 @@ The Maintainers dashboard has been refactored into a clean, modular, feature-bas
 - **DashboardTab** - Main dashboard container with all stats and activity
 
 ### ✅ Tab 2: Issues
-- **IssueCard** - Individual issue cards with tags, stats, and metadata
+- **MaintainerIssueCard** - Individual issue cards with tags, stats, and metadata
 - **IssueFilterDropdown** - Filter dropdown (All, Waiting for review, In progress, Stale)
 - **IssueListSidebar** - Left sidebar with filters, search, and scrollable issue list
 - **EmptyIssueState** - Beautiful empty state when no issue is selected

--- a/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.test.tsx
@@ -12,8 +12,8 @@ vi.mock('../../../../shared/contexts/ThemeContext', async (importOriginal) => {
   }
 })
 
-vi.mock('./IssueCard', () => ({
-  IssueCard: ({ issue }: any) => <div data-testid="issue-card">{issue.title}</div>,
+vi.mock('./MaintainerIssueCard', () => ({
+  MaintainerIssueCard: ({ issue }: any) => <div data-testid="issue-card">{issue.title}</div>,
 }))
 
 vi.mock('./IssueFilterDropdown', () => ({

--- a/src/features/maintainers/components/issues/IssueListSidebar.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../../shared/hooks/useDebouncedValue'
 import { Issue } from '../../types'
-import { IssueCard } from './IssueCard'
+import { MaintainerIssueCard } from './MaintainerIssueCard'
 import { IssueFilterDropdown } from './IssueFilterDropdown'
 
 interface IssueListSidebarProps {
@@ -172,7 +172,7 @@ export function IssueListSidebar({
           {!showNoIssuesFound &&
             !showNoMatches &&
             issues.map((issue, idx) => (
-              <IssueCard
+              <MaintainerIssueCard
                 key={issue.id}
                 issue={issue}
                 index={idx}

--- a/src/features/maintainers/components/issues/MaintainerIssueCard.tsx
+++ b/src/features/maintainers/components/issues/MaintainerIssueCard.tsx
@@ -2,13 +2,20 @@ import { Circle, FileText, User, Rocket, Users, User as UserIcon } from 'lucide-
 import { useTheme } from '../../../../shared/contexts/ThemeContext';
 import { Issue } from '../../types';
 
-interface IssueCardProps {
+interface MaintainerIssueCardProps {
   issue: Issue;
   index: number;
   onClick: () => void;
 }
 
-export function IssueCard({ issue, index, onClick }: IssueCardProps) {
+/**
+ * Maintainer-specific IssueCard — intentionally kept separate from the
+ * shared {@link import('../../../../shared/components/ui/IssueCard').IssueCard}
+ * because the two components have fundamentally different prop shapes and
+ * rendering logic. See the shared variant for the general-purpose, prop-driven
+ * version used in DiscoverPage and IssuesTab.
+ */
+export function MaintainerIssueCard({ issue, index, onClick }: MaintainerIssueCardProps) {
   const { theme } = useTheme();
   const getIcon = () => {
     const iconColor = theme === 'dark' ? '#b8a898' : '#7a6b5a';

--- a/src/shared/components/ui/IssueCard.tsx
+++ b/src/shared/components/ui/IssueCard.tsx
@@ -3,6 +3,15 @@ import { Users, Circle } from 'lucide-react'
 import { useTheme } from '../../contexts/ThemeContext'
 import { LanguageIcon } from '../LanguageIcon'
 
+/**
+ * General-purpose, prop-driven IssueCard used across DiscoverPage and
+ * IssuesTab.  There is a separate, intentionally independent
+ * {@link import('../../../features/maintainers/components/issues/MaintainerIssueCard').MaintainerIssueCard}
+ * that serves the maintainer issues sidebar with a different prop shape and
+ * rendering logic — the split is intentional to avoid a fragile unified
+ * interface.
+ */
+
 export interface IssueCardProps {
   id: string
   number?: string


### PR DESCRIPTION
## Summary

Audit and resolve the duplicate `IssueCard` naming collision. Two unrelated components in different directories shared the exact same name `IssueCard` with different prop shapes, different rendering logic, and no shared code:

- **`src/features/maintainers/components/issues/IssueCard.tsx`** — takes `{ issue: Issue, index, onClick }`, renders a card with icon mapping, DOM-manipulation avatar fallback, and animation delay
- **`src/shared/components/ui/IssueCard.tsx`** — general-purpose, prop-driven component with `variant='default' | 'recommended'`, `data-testid` attributes, `LanguageIcon` support

### Changes

1. **Renamed** `maintainers/components/issues/IssueCard.tsx` → `MaintainerIssueCard.tsx` with updated export name
2. **Updated** `IssueListSidebar.tsx` import to use `MaintainerIssueCard`
3. **Updated** `IssueListSidebar.test.tsx` mock to match the new name
4. **Added** cross-reference JSDoc comments in both `MaintainerIssueCard.tsx` and `shared/IssueCard.tsx` so future readers understand the split is intentional
5. **Updated** `README.md` file listing

### Verification

- `IssueListSidebar.test.tsx` — 7 tests passed
- `shared/IssueCard.test.tsx` — 6 tests passed
- All existing `MaintainerIssueCard` behavior preserved exactly (same rendering, props, styling)

Closes #659