### PR TITLE
test: cover BlogCTA rendering in both themes

### DIFF
--- a/src/features/blog/components/BlogCTA.test.tsx
+++ b/src/features/blog/components/BlogCTA.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { BlogCTA } from './BlogCTA'
+
+// lucide-react 1.23.0 is missing the Github icon export
+vi.mock('lucide-react', async () => {
+  const actual = await vi.importActual('lucide-react')
+  return {
+    ...actual,
+    Github: () => null,
+  }
+})
+
+describe('BlogCTA', () => {
+  it('renders the "Ready to Get Started?" heading', () => {
+    renderWithTheme(<BlogCTA />)
+    expect(screen.getByText('Ready to Get Started?')).toBeInTheDocument()
+  })
+
+  it('renders the body copy text', () => {
+    renderWithTheme(<BlogCTA />)
+    expect(
+      screen.getByText(/Whether you're a developer looking for your next challenge/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders the "Join as Contributor" button', () => {
+    renderWithTheme(<BlogCTA />)
+    const btn = screen.getByText('Join as Contributor')
+    expect(btn).toBeInTheDocument()
+    expect(btn.tagName).toBe('BUTTON')
+  })
+
+  it('renders the "Submit Your Project" button', () => {
+    renderWithTheme(<BlogCTA />)
+    const btn = screen.getByText('Submit Your Project')
+    expect(btn).toBeInTheDocument()
+    expect(btn.tagName).toBe('BUTTON')
+  })
+
+  it('renders theme-consistent heading colour in dark mode', () => {
+    const { container } = renderWithTheme(<BlogCTA />, { theme: 'dark' })
+    const heading = container.querySelector('h3')
+    expect(heading).toBeInTheDocument()
+    expect(heading!.className).toContain('text-[#f5f5f5]')
+  })
+
+  it('renders theme-consistent heading colour in light mode', () => {
+    const { container } = renderWithTheme(<BlogCTA />, { theme: 'light' })
+    const heading = container.querySelector('h3')
+    expect(heading).toBeInTheDocument()
+    expect(heading!.className).toContain('text-[#2d2820]')
+  })
+
+  it('renders theme-consistent paragraph colour in dark mode', () => {
+    const { container } = renderWithTheme(<BlogCTA />, { theme: 'dark' })
+    const paragraph = container.querySelector('p')
+    expect(paragraph).toBeInTheDocument()
+    expect(paragraph!.className).toContain('text-[#d4d4d4]')
+  })
+
+  it('renders theme-consistent paragraph colour in light mode', () => {
+    const { container } = renderWithTheme(<BlogCTA />, { theme: 'light' })
+    const paragraph = container.querySelector('p')
+    expect(paragraph).toBeInTheDocument()
+    expect(paragraph!.className).toContain('text-[#6b5d4d]')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a dedicated test file for `BlogCTA.tsx` — the call-to-action block rendered at the end of the blog listing page.

## Changes

- Created `src/features/blog/components/BlogCTA.test.tsx`
- 8 test cases covering:
  - "Ready to Get Started?" heading renders
  - Body copy text renders
  - Both CTA buttons ("Join as Contributor" and "Submit Your Project") render with correct tag
  - Theme-consistent heading colours in dark and light mode
  - Theme-consistent paragraph colours in dark and light mode

## Testing

All 8 tests pass:
```
✓ src/features/blog/components/BlogCTA.test.tsx (8 tests) 86ms
```

Closes #657