### PR TITLE
fix: wrap dashboard routed content in an error boundary to contain per-page crashes

### DIFF
--- a/src/features/dashboard/DashboardLayout.test.tsx
+++ b/src/features/dashboard/DashboardLayout.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { I18nProvider } from '../../shared/i18n'
 
 // ─── mock dependencies ──────────────────────────────────────────────────────
@@ -366,5 +366,98 @@ describe('DashboardLayout icon-only controls accessibility', () => {
       // Focus should be returned to the open button (sensible focus restoration)
       expect(document.activeElement).toBe(openBtn)
     })
+  })
+})
+
+describe('DashboardLayout route-level error boundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  function ThrowingChild() {
+    throw new Error('Dashboard route boom')
+  }
+
+  function SafeChild() {
+    return <p>Safe route content</p>
+  }
+
+  beforeAll(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    window.addEventListener('error', (e: Event) => e.preventDefault())
+  })
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('shows the error boundary fallback when a child route throws, while sidebar remains intact', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/browse']}>
+        <I18nProvider>
+          <Routes>
+            <Route path="/dashboard" element={<DashboardLayout />}>
+              <Route path="browse" element={<ThrowingChild />} />
+            </Route>
+          </Routes>
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    // The error fallback is shown
+    expect(screen.getByRole('alert', { name: 'Something went wrong' })).toBeInTheDocument()
+
+    // The sidebar navigation items remain intact
+    expect(screen.getByRole('link', { name: 'Discover' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Browse' })).toBeInTheDocument()
+  })
+
+  it('recovers when navigating to a different route after a crash', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard/browse']}>
+        <I18nProvider>
+          <Routes>
+            <Route path="/dashboard" element={<DashboardLayout />}>
+              <Route path="browse" element={<ThrowingChild />} />
+              <Route path="discover" element={<SafeChild />} />
+            </Route>
+          </Routes>
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    // The error fallback is shown
+    expect(screen.getByRole('alert', { name: 'Something went wrong' })).toBeInTheDocument()
+
+    // Navigate to a different route via sidebar link
+    await user.click(screen.getByRole('link', { name: 'Discover' }))
+
+    // The safe route content is now rendered
+    expect(screen.getByText('Safe route content')).toBeInTheDocument()
+  })
+
+  it('does not interfere with non-erroring child routes', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/discover']}>
+        <I18nProvider>
+          <Routes>
+            <Route path="/dashboard" element={<DashboardLayout />}>
+              <Route path="discover" element={<SafeChild />} />
+            </Route>
+          </Routes>
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    // The safe route content renders normally
+    expect(screen.getByText('Safe route content')).toBeInTheDocument()
+
+    // Sidebar navigation is still present
+    expect(screen.getByRole('link', { name: 'Discover' })).toBeInTheDocument()
   })
 })

--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, type ReactNode } from 'react'
 import { Link, useNavigate, useLocation, Outlet } from 'react-router-dom'
+import { ErrorBoundary } from '../../shared/components/ErrorBoundary'
 import {
   Search,
   Compass,
@@ -533,7 +534,9 @@ export function DashboardLayout() {
 
           {/* Page Content - Outlet for nested routes */}
           <div className="pt-[68px]">
-            <Outlet />
+            <ErrorBoundary key={location.pathname}>
+              <Outlet />
+            </ErrorBoundary>
           </div>
         </div>
       </main>


### PR DESCRIPTION
Closes #503

**Problem:** An uncaught error in any single dashboard sub-page would blank the entire dashboard shell (sidebar + header), making the whole area unusable.

**Fix:** Wrapped the `<Outlet />` in `DashboardLayout.tsx` with the existing `ErrorBoundary` component, keyed by `location.pathname`. This ensures:

- **Per-page crash isolation** — An error in one sub-page shows the ErrorBoundary fallback while the sidebar and header remain fully functional
- **Route-based recovery** — Navigating to a different route unmounts the old ErrorBoundary via the `key={location.pathname}` prop, so the new route renders cleanly without a full page reload
- **No regression** — Non-erroring sub-pages are entirely unaffected

**Test coverage:**
- `shows the error boundary fallback when a child route throws, while sidebar remains intact` — verifies the fallback UI appears and sidebar nav items are still accessible
- `recovers when navigating to a different route after a crash` — verifies navigating to a different route recovers cleanly without a full page reload
- `does not interfere with non-erroring child routes` — verifies safe routes render normally with the boundary in place

All tests pass with `NODE_ENV=development vitest run`.