### PR TITLE
test: add persistence and fallback tests for ThemeContext [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/shared/contexts/ThemeContext.test.tsx
+++ b/src/shared/contexts/ThemeContext.test.tsx
@@ -90,6 +90,18 @@ describe('ThemeProvider + useTheme', () => {
     await waitFor(() => expect(localStorage.getItem('theme')).toBe('light'))
   })
 
+  it('falls back to the default theme when localStorage has an invalid value', () => {
+    localStorage.setItem('theme', 'invalid-value')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('falls back to the default theme when localStorage has malformed JSON', () => {
+    localStorage.setItem('theme', '{{{broken')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('light')
+  })
+
   it('throws when useTheme is rendered without ThemeProvider', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const preventExpectedError = (event: ErrorEvent) => {

--- a/src/shared/contexts/ThemeContext.tsx
+++ b/src/shared/contexts/ThemeContext.tsx
@@ -12,8 +12,11 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
-    const savedTheme = localStorage.getItem('theme') as Theme;
-    return savedTheme || 'light';
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme;
+    }
+    return 'light';
   });
 
   useEffect(() => {


### PR DESCRIPTION
Closes #456

Adds persistence and fallback tests for ThemeContext, and fixes the initial state initialization to properly guard against invalid localStorage values.

**Changes:**

`src/shared/contexts/ThemeContext.tsx`:
- Fixed the initial state initializer to validate that the stored value is exactly `'light'` or `'dark'` before using it, rather than relying on the `|| 'light'` fallback which only catches falsy values (null/undefined/empty string) but not invalid strings like `'blue'` or `'invalid'`.

`src/shared/contexts/ThemeContext.test.tsx`:
- `falls back to the default theme when localStorage has an invalid value` — verifies that a stored value like `'invalid-value'` defaults to `'light'`
- `falls back to the default theme when localStorage has malformed JSON` — verifies that corrupted data like `{{{broken` defaults to `'light'`

All tests pass with `NODE_ENV=development vitest run`.