### PR TITLE
test: cover TypeError, AbortError, and thrown plain object in errorHandler

### DIFF
--- a/src/shared/utils/errorHandler.test.ts
+++ b/src/shared/utils/errorHandler.test.ts
@@ -134,4 +134,31 @@ describe('getUserFriendlyError', () => {
       'Something went wrong. Please try again later.',
     );
   });
+
+  it('handles TypeError (network failure) with the appropriate network message', () => {
+    expect(getUserFriendlyError(new TypeError('Failed to fetch'))).toBe(
+      'Unable to connect to the server. Please check your internet connection and try again.',
+    );
+  });
+
+  it('handles AbortError gracefully with a generic fallback', () => {
+    const abortError = new DOMException('The operation was aborted', 'AbortError');
+    expect(getUserFriendlyError(abortError)).toBe(
+      'Something went wrong. Please try again later.',
+    );
+  });
+
+  it('handles a thrown plain object correctly', () => {
+    const plainObject = { message: 'Something broke', status: 500 };
+    expect(getUserFriendlyError(plainObject)).toBe(
+      'Something went wrong. Please try again later.',
+    );
+  });
+
+  it('does not leak the plain object string representation', () => {
+    const plainObject = { secret: 'abc123' };
+    const result = getUserFriendlyError(plainObject);
+    expect(result).not.toContain('secret');
+    expect(result).not.toContain('abc123');
+  });
 });


### PR DESCRIPTION
Closes #463

Adds normalization tests for edge-case inputs that were previously uncovered:

- **TypeError (network failure)** — verifies that `new TypeError('Failed to fetch')` maps to the correct network error message
- **AbortError** — verifies that a `DOMException` with name `'AbortError'` (from `AbortController`) falls back to the generic error message without leaking the raw details
- **Thrown plain object** — verifies that a non-Error object like `{ message: 'Something broke', status: 500 }` is handled without throwing and returns a generic message
- **Plain object information leak** — verifies that plain object properties (like `secret`) are not leaked into the user-facing message

All tests pass with `NODE_ENV=development vitest run`.