### PR TITLE
fix: link LeaderboardTypeToggle tabs to real tabpanel elements

### DIFF
--- a/src/features/leaderboard/components/LeaderboardTypeToggle.test.tsx
+++ b/src/features/leaderboard/components/LeaderboardTypeToggle.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LeaderboardTypeToggle } from './LeaderboardTypeToggle'
+
+describe('LeaderboardTypeToggle', () => {
+  it('gives each tab an id matching its own aria-controls target', () => {
+    render(<LeaderboardTypeToggle leaderboardType="contributors" onToggle={() => {}} isLoaded />)
+
+    const contributorsTab = screen.getByRole('tab', { name: /contributors/i })
+    const projectsTab = screen.getByRole('tab', { name: /projects/i })
+
+    expect(contributorsTab).toHaveAttribute('id', 'leaderboard-tab-contributors')
+    expect(contributorsTab).toHaveAttribute('aria-controls', 'leaderboard-panel-contributors')
+    expect(projectsTab).toHaveAttribute('id', 'leaderboard-tab-projects')
+    expect(projectsTab).toHaveAttribute('aria-controls', 'leaderboard-panel-projects')
+  })
+
+  it('calls onToggle when a tab is clicked', () => {
+    const onToggle = vi.fn()
+    render(<LeaderboardTypeToggle leaderboardType="contributors" onToggle={onToggle} isLoaded />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /projects/i }))
+    expect(onToggle).toHaveBeenCalledWith('projects')
+  })
+
+  it('preserves ArrowLeft/ArrowRight keyboard navigation between the two tabs', () => {
+    const onToggle = vi.fn()
+    render(<LeaderboardTypeToggle leaderboardType="contributors" onToggle={onToggle} isLoaded />)
+
+    const contributorsTab = screen.getByRole('tab', { name: /contributors/i })
+    fireEvent.keyDown(contributorsTab, { key: 'ArrowRight' })
+    expect(onToggle).toHaveBeenCalledWith('projects')
+
+    onToggle.mockClear()
+    fireEvent.keyDown(contributorsTab, { key: 'ArrowLeft' })
+    expect(onToggle).toHaveBeenCalledWith('projects')
+  })
+})

--- a/src/features/leaderboard/components/LeaderboardTypeToggle.tsx
+++ b/src/features/leaderboard/components/LeaderboardTypeToggle.tsx
@@ -1,46 +1,56 @@
-import { useCallback } from 'react';
-import { Users, FolderGit2 } from 'lucide-react';
-import { LeaderboardType } from '../types';
+import { useCallback } from 'react'
+import { Users, FolderGit2 } from 'lucide-react'
+import { LeaderboardType } from '../types'
 
 interface LeaderboardTypeToggleProps {
-  leaderboardType: LeaderboardType;
-  onToggle: (type: LeaderboardType) => void;
-  isLoaded: boolean;
+  leaderboardType: LeaderboardType
+  onToggle: (type: LeaderboardType) => void
+  isLoaded: boolean
 }
 
 const TYPES: { key: LeaderboardType; icon: typeof Users; label: string }[] = [
   { key: 'contributors', icon: Users, label: 'Contributors' },
   { key: 'projects', icon: FolderGit2, label: 'Projects' },
-];
+]
 
-export function LeaderboardTypeToggle({ leaderboardType, onToggle, isLoaded }: LeaderboardTypeToggleProps) {
-  const onKeyDown = useCallback((e: React.KeyboardEvent, current: LeaderboardType) => {
-    let next: LeaderboardType | null = null;
-    if (e.key === 'ArrowLeft') {
-      next = current === 'contributors' ? 'projects' : 'contributors';
-    } else if (e.key === 'ArrowRight') {
-      next = current === 'projects' ? 'contributors' : 'projects';
-    }
-    if (next) {
-      e.preventDefault();
-      onToggle(next);
-    }
-  }, [onToggle]);
+export function LeaderboardTypeToggle({
+  leaderboardType,
+  onToggle,
+  isLoaded,
+}: LeaderboardTypeToggleProps) {
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent, current: LeaderboardType) => {
+      let next: LeaderboardType | null = null
+      if (e.key === 'ArrowLeft') {
+        next = current === 'contributors' ? 'projects' : 'contributors'
+      } else if (e.key === 'ArrowRight') {
+        next = current === 'projects' ? 'contributors' : 'projects'
+      }
+      if (next) {
+        e.preventDefault()
+        onToggle(next)
+      }
+    },
+    [onToggle]
+  )
 
   return (
-    <div className={`sticky top-6 z-[200] flex justify-center transition-all duration-1000 ${
-      isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'
-    }`}>
+    <div
+      className={`sticky top-6 z-[200] flex justify-center transition-all duration-1000 ${
+        isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'
+      }`}
+    >
       <div
         role="tablist"
         aria-label="Leaderboard type"
         className="backdrop-blur-[40px] bg-gradient-to-br from-white/[0.25] to-white/[0.15] rounded-[20px] border-2 border-white/30 shadow-[0_12px_48px_rgba(0,0,0,0.15)] p-2 flex gap-2"
       >
         {TYPES.map(({ key, icon: Icon, label }) => {
-          const isActive = leaderboardType === key;
+          const isActive = leaderboardType === key
           return (
             <button
               key={key}
+              id={`leaderboard-tab-${key}`}
               role="tab"
               aria-selected={isActive}
               aria-controls={`leaderboard-panel-${key}`}
@@ -56,9 +66,9 @@ export function LeaderboardTypeToggle({ leaderboardType, onToggle, isLoaded }: L
               <Icon className="w-5 h-5" />
               {label}
             </button>
-          );
+          )
         })}
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/leaderboard/pages/LeaderboardPage.test.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.test.tsx
@@ -3,10 +3,42 @@ import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
 import { MemoryRouter } from 'react-router-dom'
 import { LeaderboardPage } from './LeaderboardPage'
 
+vi.mock('../../../shared/api/client', () => ({
+  getLeaderboard: vi.fn().mockResolvedValue([]),
+  getRecommendedProjects: vi.fn().mockResolvedValue({ projects: [] }),
+}))
+
 const mockData = [
   { id: 1, dimension: 'blockchain' },
   { id: 2, dimension: 'web' },
 ]
+
+// Issue #639: aria-controls on the leaderboard tabs must resolve to real
+// tabpanel elements, each cross-linked back to its tab via aria-labelledby.
+test('leaderboard tabs are correctly wired to their tabpanel elements', async () => {
+  renderPage()
+
+  const contributorsTab = await screen.findByRole('tab', { name: /contributors/i })
+  const projectsTab = screen.getByRole('tab', { name: /projects/i })
+
+  // Every aria-controls value must resolve to an existing element id.
+  const contributorsPanelId = contributorsTab.getAttribute('aria-controls')
+  const projectsPanelId = projectsTab.getAttribute('aria-controls')
+  expect(contributorsPanelId).toBeTruthy()
+  expect(projectsPanelId).toBeTruthy()
+  expect(document.getElementById(contributorsPanelId!)).not.toBeNull()
+  // The projects panel only renders once its tab is selected.
+  fireEvent.click(projectsTab)
+  expect(document.getElementById(projectsPanelId!)).not.toBeNull()
+
+  // Each panel points back to its own tab via aria-labelledby.
+  const projectsPanel = document.getElementById(projectsPanelId!)!
+  expect(projectsPanel.getAttribute('aria-labelledby')).toBe(projectsTab.id)
+
+  fireEvent.click(contributorsTab)
+  const contributorsPanel = document.getElementById(contributorsPanelId!)!
+  expect(contributorsPanel.getAttribute('aria-labelledby')).toBe(contributorsTab.id)
+})
 
 // ContributorsTable/ProjectsTable call useTheme(), which requires a ThemeProvider.
 const renderPage = () =>

--- a/src/features/leaderboard/pages/LeaderboardPage.tsx
+++ b/src/features/leaderboard/pages/LeaderboardPage.tsx
@@ -1,27 +1,25 @@
-import { logger } from '../../../shared/utils/logger';
-import { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { LeaderboardType, FilterType, Petal, LeaderData, ProjectData } from '../types';
-import { getLeaderboard, getRecommendedProjects } from '../../../shared/api/client';
-import { clampLimit, clampOffset, hasMoreByPageSize } from '../../../shared/utils/pagination';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { FallingPetals } from '../components/FallingPetals';
-import { LeaderboardTypeToggle } from '../components/LeaderboardTypeToggle';
-import { LeaderboardHero } from '../components/LeaderboardHero';
-import { ContributorsPodium } from '../components/ContributorsPodium';
-import { ProjectsPodium } from '../components/ProjectsPodium';
-import { FiltersSection } from '../components/FiltersSection';
-import { ContributorsTable } from '../components/ContributorsTable';
-import { ContributorsTableSkeleton } from '../components/ContributorsTableSkeleton';
-import { ProjectsTable } from '../components/ProjectsTable';
+import { logger } from '../../../shared/utils/logger'
+import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { LeaderboardType, FilterType, Petal, LeaderData, ProjectData } from '../types'
+import { getLeaderboard, getRecommendedProjects } from '../../../shared/api/client'
+import { clampLimit, clampOffset, hasMoreByPageSize } from '../../../shared/utils/pagination'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { FallingPetals } from '../components/FallingPetals'
+import { LeaderboardTypeToggle } from '../components/LeaderboardTypeToggle'
+import { LeaderboardHero } from '../components/LeaderboardHero'
+import { ContributorsPodium } from '../components/ContributorsPodium'
+import { ProjectsPodium } from '../components/ProjectsPodium'
+import { FiltersSection } from '../components/FiltersSection'
+import { ContributorsTable } from '../components/ContributorsTable'
+import { ContributorsTableSkeleton } from '../components/ContributorsTableSkeleton'
+import { ProjectsTable } from '../components/ProjectsTable'
 
 /** Number of contributors fetched per page. */
-const LEADERBOARD_PAGE_SIZE = 20;
+const LEADERBOARD_PAGE_SIZE = 20
 
 /** Transform a raw leaderboard API row into the UI {@link LeaderData} shape. */
-function transformLeader(
-  item: Awaited<ReturnType<typeof getLeaderboard>>[number],
-): LeaderData {
+function transformLeader(item: Awaited<ReturnType<typeof getLeaderboard>>[number]): LeaderData {
   return {
     rank: item.rank,
     rank_tier: item.rank_tier,
@@ -34,92 +32,98 @@ function transformLeader(
     trendValue: item.trendValue,
     contributions: item.contributions,
     ecosystems: item.ecosystems || [],
-  };
+  }
 }
 
 export function LeaderboardPage() {
-  const { theme } = useTheme();
-  const navigate = useNavigate();
-  const [activeFilter, setActiveFilter] = useState<FilterType>('overall');
-  const [leaderboardType, setLeaderboardType] = useState<LeaderboardType>('contributors');
-  const [showEcosystemDropdown, setShowEcosystemDropdown] = useState(false);
+  const { theme } = useTheme()
+  const navigate = useNavigate()
+  const [activeFilter, setActiveFilter] = useState<FilterType>('overall')
+  const [leaderboardType, setLeaderboardType] = useState<LeaderboardType>('contributors')
+  const [showEcosystemDropdown, setShowEcosystemDropdown] = useState(false)
   const [selectedEcosystem, setSelectedEcosystem] = useState({
     label: 'All Ecosystems',
     value: 'all',
-  });
-  const [petals, setPetals] = useState<Petal[]>([]);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [leaderboardData, setLeaderboardData] = useState<LeaderData[]>([]);
-  const [projectsData, setProjectsData] = useState<ProjectData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingProjects, setIsLoadingProjects] = useState(true);
+  })
+  const [petals, setPetals] = useState<Petal[]>([])
+  const [isLoaded, setIsLoaded] = useState(false)
+  const [leaderboardData, setLeaderboardData] = useState<LeaderData[]>([])
+  const [projectsData, setProjectsData] = useState<ProjectData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true)
   /** Offset (start index) of the last loaded contributors page. */
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState(0)
   /** Whether the API may still have more contributors to load. */
-  const [hasMore, setHasMore] = useState(true);
+  const [hasMore, setHasMore] = useState(true)
   /** True while an additional ("load more") page is being fetched. */
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   // Synchronous guard so a rapid double-click of "Load more" cannot start two
   // concurrent requests before `isLoadingMore` state has flushed.
-  const loadingMoreRef = useRef(false);
+  const loadingMoreRef = useRef(false)
 
   const getProjectIcon = (githubFullName: string) => {
-    const [owner] = githubFullName.split('/');
+    const [owner] = githubFullName.split('/')
     // Use higher-resolution owner avatar so leaderboard projects look crisp
-    return `https://github.com/${owner}.png?size=200`;
-  };
+    return `https://github.com/${owner}.png?size=200`
+  }
 
   // Fetch leaderboard data
   useEffect(() => {
     const fetchLeaderboard = async () => {
       if (leaderboardType === 'contributors') {
-        setIsLoading(true);
+        setIsLoading(true)
         // Changing leaderboard type / filter / ecosystem resets pagination.
-        setOffset(0);
-        setHasMore(true);
-        const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
+        setOffset(0)
+        setHasMore(true)
+        const limit = clampLimit(LEADERBOARD_PAGE_SIZE)
         try {
           const data = await getLeaderboard(
             limit,
             0,
-            selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined,
-          );
-          setLeaderboardData(data.map(transformLeader));
+            selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined
+          )
+          setLeaderboardData(data.map(transformLeader))
           // A full first page implies more may exist; a short page is the end.
-          setHasMore(hasMoreByPageSize(data.length, limit));
-          setIsLoading(false);
+          setHasMore(hasMoreByPageSize(data.length, limit))
+          setIsLoading(false)
         } catch (err) {
-          logger.error('Failed to fetch leaderboard:', err);
-          setLeaderboardData([]);
-          setHasMore(false);
-          setIsLoading(false);
+          logger.error('Failed to fetch leaderboard:', err)
+          setLeaderboardData([])
+          setHasMore(false)
+          setIsLoading(false)
         }
       } else {
-        setIsLoading(false);
+        setIsLoading(false)
       }
-    };
+    }
 
-    fetchLeaderboard();
-  }, [leaderboardType, activeFilter, selectedEcosystem.value]);
+    fetchLeaderboard()
+  }, [leaderboardType, activeFilter, selectedEcosystem.value])
 
   // Fetch projects leaderboard (top projects by contributors count)
   useEffect(() => {
-    if (leaderboardType !== 'projects') return;
-    let cancelled = false;
+    if (leaderboardType !== 'projects') return
+    let cancelled = false
     const fetchProjects = async () => {
-      setIsLoadingProjects(true);
+      setIsLoadingProjects(true)
       try {
-        const res = await getRecommendedProjects(50);
-        const projects = res?.projects ?? [];
-        if (cancelled) return;
+        const res = await getRecommendedProjects(50)
+        const projects = res?.projects ?? []
+        if (cancelled) return
         const mapped: ProjectData[] = projects
           .filter((p) => (p.github_full_name.split('/')[1] || '') !== '.github')
           .map((p, idx) => {
-            const repoName = p.github_full_name.split('/')[1] || p.github_full_name;
-            const contributors = p.contributors_count ?? 0;
-            const openIssues = p.open_issues_count ?? 0;
+            const repoName = p.github_full_name.split('/')[1] || p.github_full_name
+            const contributors = p.contributors_count ?? 0
+            const openIssues = p.open_issues_count ?? 0
             const activity =
-              openIssues > 10 ? 'Very High' : openIssues > 5 ? 'High' : openIssues > 2 ? 'Medium' : 'Low';
+              openIssues > 10
+                ? 'Very High'
+                : openIssues > 5
+                  ? 'High'
+                  : openIssues > 2
+                    ? 'Medium'
+                    : 'Low'
             return {
               rank: idx + 1,
               name: repoName,
@@ -130,20 +134,20 @@ export function LeaderboardPage() {
               contributors,
               ecosystems: p.ecosystem_name ? [p.ecosystem_name] : [],
               activity,
-            };
-          });
-        setProjectsData(mapped);
+            }
+          })
+        setProjectsData(mapped)
       } catch (err) {
-        if (!cancelled) setProjectsData([]);
+        if (!cancelled) setProjectsData([])
       } finally {
-        if (!cancelled) setIsLoadingProjects(false);
+        if (!cancelled) setIsLoadingProjects(false)
       }
-    };
-    fetchProjects();
+    }
+    fetchProjects()
     return () => {
-      cancelled = true;
-    };
-  }, [leaderboardType]);
+      cancelled = true
+    }
+  }, [leaderboardType])
 
   /**
    * Append the next page of contributors to the leaderboard.
@@ -154,38 +158,38 @@ export function LeaderboardPage() {
    * being sent to the API.
    */
   const loadMore = async () => {
-    if (loadingMoreRef.current || isLoadingMore || !hasMore) return;
+    if (loadingMoreRef.current || isLoadingMore || !hasMore) return
 
-    loadingMoreRef.current = true;
-    setIsLoadingMore(true);
-    const limit = clampLimit(LEADERBOARD_PAGE_SIZE);
-    const nextOffset = clampOffset(offset + limit);
+    loadingMoreRef.current = true
+    setIsLoadingMore(true)
+    const limit = clampLimit(LEADERBOARD_PAGE_SIZE)
+    const nextOffset = clampOffset(offset + limit)
     try {
       const data = await getLeaderboard(
         limit,
         nextOffset,
-        selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined,
-      );
+        selectedEcosystem.value !== 'all' ? selectedEcosystem.value : undefined
+      )
 
       if (data.length > 0) {
-        setLeaderboardData((prev) => [...prev, ...data.map(transformLeader)]);
-        setOffset(nextOffset);
+        setLeaderboardData((prev) => [...prev, ...data.map(transformLeader)])
+        setOffset(nextOffset)
       }
       // Disable "Load more" once a short/empty page signals the end of list.
-      setHasMore(hasMoreByPageSize(data.length, limit));
+      setHasMore(hasMoreByPageSize(data.length, limit))
     } catch (err) {
-      logger.error('Failed to load more leaderboard:', err);
-      setHasMore(false);
+      logger.error('Failed to load more leaderboard:', err)
+      setHasMore(false)
     } finally {
-      loadingMoreRef.current = false;
-      setIsLoadingMore(false);
+      loadingMoreRef.current = false
+      setIsLoadingMore(false)
     }
-  };
+  }
 
   // Generate falling petals on mount
   useEffect(() => {
     const generatePetals = () => {
-      const newPetals: Petal[] = [];
+      const newPetals: Petal[] = []
       for (let i = 0; i < 30; i++) {
         newPetals.push({
           id: i,
@@ -194,21 +198,21 @@ export function LeaderboardPage() {
           duration: 8 + Math.random() * 6,
           rotation: Math.random() * 360,
           size: 0.6 + Math.random() * 0.8,
-        });
+        })
       }
-      setPetals(newPetals);
-    };
+      setPetals(newPetals)
+    }
 
-    generatePetals();
-    const loadTimer = window.setTimeout(() => setIsLoaded(true), 100);
+    generatePetals()
+    const loadTimer = window.setTimeout(() => setIsLoaded(true), 100)
 
     // Regenerate petals every 15 seconds for continuous effect
-    const interval = window.setInterval(generatePetals, 15000);
+    const interval = window.setInterval(generatePetals, 15000)
     return () => {
-      clearTimeout(loadTimer);
-      clearInterval(interval);
-    };
-  }, []);
+      clearTimeout(loadTimer)
+      clearInterval(interval)
+    }
+  }, [])
 
   // Ensure we have at least 3 items for the podium (pad with empty data if needed)
   const contributorTopThree: LeaderData[] = [
@@ -225,7 +229,7 @@ export function LeaderboardPage() {
         contributions: 0,
         ecosystems: [],
       })),
-  ].slice(0, 3) as LeaderData[];
+  ].slice(0, 3) as LeaderData[]
 
   const projectTopThree: ProjectData[] = [
     ...projectsData.slice(0, 3),
@@ -242,7 +246,7 @@ export function LeaderboardPage() {
         ecosystems: [] as string[],
         activity: 'Low',
       })),
-  ].slice(0, 3) as ProjectData[];
+  ].slice(0, 3) as ProjectData[]
 
   return (
     <div
@@ -288,7 +292,11 @@ export function LeaderboardPage() {
 
         {/* Contributors table */}
         {leaderboardType === 'contributors' && (
-          <>
+          <div
+            role="tabpanel"
+            id="leaderboard-panel-contributors"
+            aria-labelledby="leaderboard-tab-contributors"
+          >
             {isLoading ? (
               <ContributorsTableSkeleton />
             ) : (
@@ -298,8 +306,8 @@ export function LeaderboardPage() {
                   activeFilter={activeFilter}
                   isLoaded={isLoaded}
                   onUserClick={(username, userId) => {
-                    const identifier = userId || username;
-                    navigate(`/dashboard?tab=profile&user=${identifier}`);
+                    const identifier = userId || username
+                    navigate(`/dashboard?tab=profile&user=${identifier}`)
                   }}
                 />
                 <div className="flex justify-center mt-6">
@@ -332,24 +340,24 @@ export function LeaderboardPage() {
                 </div>
               </>
             )}
-          </>
+          </div>
         )}
 
         {/* Projects table */}
         {leaderboardType === 'projects' && (
-          <>
+          <div
+            role="tabpanel"
+            id="leaderboard-panel-projects"
+            aria-labelledby="leaderboard-tab-projects"
+          >
             {isLoadingProjects ? (
               <ContributorsTableSkeleton />
             ) : (
-              <ProjectsTable
-                data={projectsData}
-                activeFilter={activeFilter}
-                isLoaded={isLoaded}
-              />
+              <ProjectsTable data={projectsData} activeFilter={activeFilter} isLoaded={isLoaded} />
             )}
-          </>
+          </div>
         )}
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary

Closes #639

`LeaderboardTypeToggle.tsx`'s tab buttons set `aria-controls` to `leaderboard-panel-{contributors,projects}`, but `LeaderboardPage.tsx` never rendered an element with either id, and no `role="tabpanel"` existed at all. Screen readers pointed to nothing, and axe-core/Lighthouse would flag this as a broken ARIA reference.

## Changes

- `LeaderboardTypeToggle.tsx`: each tab now has `id={`leaderboard-tab-${key}`}` alongside its existing `aria-controls`.
- `LeaderboardPage.tsx`: the contributors and projects table blocks are each wrapped in a `role="tabpanel"` div with the matching `id="leaderboard-panel-{contributors,projects}"` and `aria-labelledby="leaderboard-tab-{contributors,projects}"`, completing the ARIA tabs pattern. No layout/visual changes — the wrapping div replaces an existing React fragment 1:1.
- Adds `LeaderboardTypeToggle.test.tsx`: asserts tab id/aria-controls values, click behavior, and that ArrowLeft/ArrowRight keyboard navigation between the two tabs still works.
- Adds a new (non-skipped) test to `LeaderboardPage.test.tsx`, mocking the leaderboard/projects API calls, asserting every `aria-controls` value resolves to a real element in the rendered DOM and that each panel's `aria-labelledby` correctly points back to its own tab's id.

## What's covered

- [x] Every `aria-controls` value on the leaderboard toggle tabs resolves to an existing element id in the rendered DOM, verified by test.
- [x] Each panel has a matching `aria-labelledby` pointing to its tab, verified by test.
- [x] No regression to existing keyboard arrow-key navigation.

## Test plan

```
$ npx vitest run src/features/leaderboard
Test Files  11 passed (11)
     Tests  69 passed | 2 skipped (71)
```

Full-suite `npx vitest run`: 96 tests fail both before and after this change (identical count via `git stash` comparison) — all pre-existing, unrelated to leaderboard code. This change adds 4 new passing tests with zero new failures.

`npx eslint` on the touched files: clean except one pre-existing warning (`'err' is defined but never used`) at `LeaderboardPage.tsx:136`, in an untouched catch block unrelated to this change.

## Note on push

This repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck`, which currently fails with ~45 pre-existing TypeScript errors across unrelated files (`lucide-react` missing exports, jest/vitest namespace conflicts, `recharts` typing issues in `chart.tsx`, etc.) — confirmed via diff that these are identical on unmodified `main` and this branch, so this isn't something introduced here. Pushed with `--no-verify` after user confirmation, since no branch can currently pass this repo-wide gate.