### PR TITLE
fix: remove dead Sidebar.tsx placeholder stub

### DIFF
--- a/src/features/dashboard/Sidebar.tsx
+++ b/src/features/dashboard/Sidebar.tsx
@@ -1,3 +1,0 @@
-export default function Sidebar() {
-  return <aside data-testid="real-sidebar">Sidebar</aside>
-}


### PR DESCRIPTION
## Summary

Closes #642

`src/features/dashboard/Sidebar.tsx` was a 3-line placeholder (`<aside data-testid="real-sidebar">Sidebar</aside>`) with zero importers anywhere in `src/` (confirmed via `grep -rn "dashboard/Sidebar" src` and `grep -rn "real-sidebar" src`). The real sidebar navigation — logo, nav links, collapse/expand state, mobile menu, admin-password gating — is implemented entirely inline inside `DashboardLayout.tsx`. A file named `Sidebar.tsx` sitting next to `DashboardLayout.tsx` was misleading for anyone navigating the codebase, and its `data-testid="real-sidebar"` attribute suggested an unfinished component swap that never happened.

## Approach

Took the minimal-fix option the issue explicitly allows: removal, rather than extracting the inline sidebar JSX/state out of `DashboardLayout.tsx` into a real props-driven `Sidebar.tsx`. That extraction would mean refactoring `DashboardLayout.tsx`'s navigation-state ownership (collapse state, active route, mobile menu, role-switching callbacks) — a much larger, separate change with real regression risk to live navigation behavior, out of scope for removing a confirmed-dead stub.

## What's covered

- [x] `src/features/dashboard/Sidebar.tsx` has been removed entirely.
- [x] No remaining `data-testid="real-sidebar"` orphaned stub in the codebase.
- [x] `DashboardLayout.tsx` navigation behavior is unchanged (untouched by this PR) — verified by the existing dashboard test suite still passing at the same rate.

## Test plan

```
$ npx vitest run
Test Files  17 failed | 98 passed | 1 skipped (116)
     Tests  96 failed | 1340 passed | 4 skipped (1440)
```

Identical to the unmodified baseline — zero new failures from this change.

`npm run build` fails on both this branch and unmodified `main` with the same pre-existing, unrelated error (`"Github" is not exported by lucide-react`) — not caused by this change.

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.