### PR TITLE
fix: replace leftover OnlyGrain branding with Grainlify in blog content

### DIFF
--- a/src/features/blog/components/BlogArticle.tsx
+++ b/src/features/blog/components/BlogArticle.tsx
@@ -20,13 +20,13 @@ export function BlogArticle({ content }: BlogArticleProps) {
       number: 1,
       title: 'Connect Developers with Projects',
       description:
-        "We provide an intelligent matching system that connects developers with projects that align with their skills, interests, and experience level. Whether you're a seasoned blockchain architect or just starting your Web3 journey, there's a place for you on OnlyGrain.",
+        "We provide an intelligent matching system that connects developers with projects that align with their skills, interests, and experience level. Whether you're a seasoned blockchain architect or just starting your Web3 journey, there's a place for you on Grainlify.",
     },
     {
       number: 2,
       title: 'Multi-Chain Support',
       description:
-        'From Ethereum to Solana, Polkadot to Cosmos, and everything in between—OnlyGrain supports projects across all major blockchain ecosystems. We believe in a multi-chain future and our platform reflects that vision.',
+        'From Ethereum to Solana, Polkadot to Cosmos, and everything in between—Grainlify supports projects across all major blockchain ecosystems. We believe in a multi-chain future and our platform reflects that vision.',
     },
     {
       number: 3,
@@ -44,7 +44,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
       number: 5,
       title: 'Community-Driven Development',
       description:
-        'At OnlyGrain, we believe in the power of community. Our platform facilitates collaboration, knowledge sharing, and networking among developers, project maintainers, and ecosystem stakeholders.',
+        'At Grainlify, we believe in the power of community. Our platform facilitates collaboration, knowledge sharing, and networking among developers, project maintainers, and ecosystem stakeholders.',
     },
   ]
 
@@ -58,7 +58,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
               theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
             }`}
           >
-            Welcome to OnlyGrain: The Future of Open Source Collaboration
+            Welcome to Grainlify: The Future of Open Source Collaboration
           </h2>
           <div
             className={`flex items-center justify-center gap-4 text-[14px] transition-colors ${
@@ -91,14 +91,14 @@ export function BlogArticle({ content }: BlogArticleProps) {
                   }`}
                 >
                   <Sparkles className="w-7 h-7 text-[#c9983a]" />
-                  What is OnlyGrain?
+                  What is Grainlify?
                 </h3>
                 <p
                   className={`text-[16px] leading-relaxed mb-4 transition-colors ${
                     theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
                   }`}
                 >
-                  OnlyGrain is a revolutionary platform that bridges the gap between talented
+                  Grainlify is a revolutionary platform that bridges the gap between talented
                   open-source developers and innovative Web3 projects across all blockchain
                   ecosystems. We're not just another development platform—we're building the future
                   of decentralized collaboration.
@@ -110,7 +110,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
                 >
                   In the rapidly evolving world of blockchain and Web3, finding the right talent for
                   your project or discovering meaningful contribution opportunities can be
-                  challenging. OnlyGrain solves this by creating a unified ecosystem where
+                  challenging. Grainlify solves this by creating a unified ecosystem where
                   developers and projects connect, collaborate, and thrive together.
                 </p>
               </div>
@@ -155,7 +155,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
               {/* How It Works */}
               <BlogHowItWorks />
 
-              {/* Why Choose OnlyGrain */}
+              {/* Why Choose Grainlify */}
               <div className="mb-8">
                 <h3
                   className={`text-[28px] font-bold mb-4 flex items-center gap-3 transition-colors ${
@@ -163,7 +163,7 @@ export function BlogArticle({ content }: BlogArticleProps) {
                   }`}
                 >
                   <Coins className="w-7 h-7 text-[#c9983a]" />
-                  Why Choose OnlyGrain?
+                  Why Choose Grainlify?
                 </h3>
                 <BlogWhyChoose />
               </div>

--- a/src/features/blog/components/BlogCTA.tsx
+++ b/src/features/blog/components/BlogCTA.tsx
@@ -1,31 +1,40 @@
-import { ArrowRight, Github } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { ArrowRight, Github } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
 
 export function BlogCTA() {
-  const { theme } = useTheme();
+  const { theme } = useTheme()
 
   return (
     <div className="text-center p-8 backdrop-blur-[30px] bg-gradient-to-br from-[#c9983a]/15 to-[#d4af37]/10 rounded-[20px] border-2 border-[#c9983a]/30">
-      <h3 className={`text-[28px] font-bold mb-3 transition-colors ${
-        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-      }`}>Ready to Get Started?</h3>
-      <p className={`text-[16px] mb-6 max-w-2xl mx-auto transition-colors ${
-        theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
-      }`}>
-        Whether you're a developer looking for your next challenge or a project seeking talented contributors, OnlyGrain is your gateway to the future of open-source collaboration.
+      <h3
+        className={`text-[28px] font-bold mb-3 transition-colors ${
+          theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+        }`}
+      >
+        Ready to Get Started?
+      </h3>
+      <p
+        className={`text-[16px] mb-6 max-w-2xl mx-auto transition-colors ${
+          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
+        }`}
+      >
+        Whether you're a developer looking for your next challenge or a project seeking talented
+        contributors, Grainlify is your gateway to the future of open-source collaboration.
       </p>
       <div className="flex items-center justify-center gap-4">
         <button className="px-8 py-4 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[16px] font-bold text-[16px] shadow-[0_6px_24px_rgba(162,121,44,0.4)] hover:shadow-[0_8px_28px_rgba(162,121,44,0.5)] transition-all flex items-center gap-2 border border-white/10">
           Join as Contributor
           <ArrowRight className="w-5 h-5" />
         </button>
-        <button className={`px-8 py-4 backdrop-blur-[30px] bg-white/[0.25] border-2 border-[#c9983a] rounded-[16px] font-bold text-[16px] hover:bg-white/[0.35] transition-all flex items-center gap-2 ${
-          theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-        }`}>
+        <button
+          className={`px-8 py-4 backdrop-blur-[30px] bg-white/[0.25] border-2 border-[#c9983a] rounded-[16px] font-bold text-[16px] hover:bg-white/[0.35] transition-all flex items-center gap-2 ${
+            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+          }`}
+        >
           Submit Your Project
           <Github className="w-5 h-5" />
         </button>
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/blog/components/BlogHero.tsx
+++ b/src/features/blog/components/BlogHero.tsx
@@ -1,15 +1,18 @@
-import { BookOpen, Sparkles } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { BookOpen, Sparkles } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
 
 export function BlogHero() {
-  const { theme } = useTheme();
+  const { theme } = useTheme()
 
   return (
     <div className="relative backdrop-blur-[40px] bg-gradient-to-br from-white/[0.18] to-white/[0.12] rounded-[28px] border border-white/25 shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden">
       {/* Animated Background Elements */}
       <div className="absolute inset-0 opacity-20">
         <div className="absolute top-10 right-10 w-40 h-40 bg-[#c9983a]/30 rounded-full blur-[80px] animate-pulse" />
-        <div className="absolute bottom-10 left-10 w-48 h-48 bg-[#d4af37]/25 rounded-full blur-[90px] animate-pulse" style={{ animationDelay: '1s' }} />
+        <div
+          className="absolute bottom-10 left-10 w-48 h-48 bg-[#d4af37]/25 rounded-full blur-[90px] animate-pulse"
+          style={{ animationDelay: '1s' }}
+        />
       </div>
 
       <div className="relative z-10 p-12">
@@ -20,12 +23,20 @@ export function BlogHero() {
                 <BookOpen className="w-7 h-7 text-white" />
               </div>
               <div>
-                <h1 className={`text-[38px] font-bold transition-colors ${
-                  theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>OnlyGrain Blog</h1>
-                <p className={`text-[15px] transition-colors ${
-                  theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                }`}>Insights, updates, and stories from the OnlyGrain ecosystem</p>
+                <h1
+                  className={`text-[38px] font-bold transition-colors ${
+                    theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  Grainlify Blog
+                </h1>
+                <p
+                  className={`text-[15px] transition-colors ${
+                    theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                  }`}
+                >
+                  Insights, updates, and stories from the Grainlify ecosystem
+                </p>
               </div>
             </div>
           </div>
@@ -35,5 +46,5 @@ export function BlogHero() {
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/blog/components/BlogHowItWorks.tsx
+++ b/src/features/blog/components/BlogHowItWorks.tsx
@@ -1,8 +1,8 @@
-import { Github } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { Github } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
 
 export function BlogHowItWorks() {
-  const { theme } = useTheme();
+  const { theme } = useTheme()
 
   const contributorSteps = [
     'Connect your GitHub account',
@@ -10,33 +10,41 @@ export function BlogHowItWorks() {
     'Start contributing to issues and features',
     'Earn rewards and build your reputation',
     'Climb the leaderboard and unlock opportunities',
-  ];
+  ]
 
   const maintainerSteps = [
-    'Submit your project to OnlyGrain',
+    'Submit your project to Grainlify',
     'Set up bounties and contribution guidelines',
     'Get matched with skilled developers',
     'Review contributions and approve rewards',
     'Scale your project with community support',
-  ];
+  ]
 
   return (
     <div className="mb-8 p-6 backdrop-blur-[30px] bg-gradient-to-br from-[#c9983a]/10 to-[#d4af37]/5 rounded-[20px] border-2 border-[#c9983a]/30">
-      <h3 className={`text-[28px] font-bold mb-4 flex items-center gap-3 transition-colors ${
-        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-      }`}>
+      <h3
+        className={`text-[28px] font-bold mb-4 flex items-center gap-3 transition-colors ${
+          theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+        }`}
+      >
         <Github className="w-7 h-7 text-[#c9983a]" />
         How It Works
       </h3>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Contributors */}
         <div className="backdrop-blur-[20px] bg-white/[0.25] rounded-[16px] border border-white/30 p-5">
-          <h4 className={`text-[18px] font-bold mb-3 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>For Contributors</h4>
-          <ol className={`space-y-2 text-[14px] transition-colors ${
-            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
-          }`}>
+          <h4
+            className={`text-[18px] font-bold mb-3 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            For Contributors
+          </h4>
+          <ol
+            className={`space-y-2 text-[14px] transition-colors ${
+              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
+            }`}
+          >
             {contributorSteps.map((step, index) => (
               <li key={index} className="flex gap-2">
                 <span className="font-bold text-[#c9983a]">{index + 1}.</span>
@@ -48,12 +56,18 @@ export function BlogHowItWorks() {
 
         {/* Maintainers */}
         <div className="backdrop-blur-[20px] bg-white/[0.25] rounded-[16px] border border-white/30 p-5">
-          <h4 className={`text-[18px] font-bold mb-3 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>For Project Maintainers</h4>
-          <ol className={`space-y-2 text-[14px] transition-colors ${
-            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
-          }`}>
+          <h4
+            className={`text-[18px] font-bold mb-3 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            For Project Maintainers
+          </h4>
+          <ol
+            className={`space-y-2 text-[14px] transition-colors ${
+              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#6b5d4d]'
+            }`}
+          >
             {maintainerSteps.map((step, index) => (
               <li key={index} className="flex gap-2">
                 <span className="font-bold text-[#c9983a]">{index + 1}.</span>
@@ -64,5 +78,5 @@ export function BlogHowItWorks() {
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/blog/data/blogPosts.ts
+++ b/src/features/blog/data/blogPosts.ts
@@ -1,61 +1,62 @@
-import { BlogPost } from '../types';
+import { BlogPost } from '../types'
 
 export const featuredPost: BlogPost = {
   id: 0,
-  slug: "bridging-the-gap-onlygrain-open-source",
-  title: "Bridging the Gap: How OnlyGrain is Revolutionizing Open Source Contribution",
-  excerpt: "Discover how OnlyGrain connects talented developers with groundbreaking Web3 projects across all blockchain ecosystems, creating a seamless bridge between innovation and execution.",
+  slug: 'bridging-the-gap-onlygrain-open-source',
+  title: 'Bridging the Gap: How Grainlify is Revolutionizing Open Source Contribution',
+  excerpt:
+    'Discover how Grainlify connects talented developers with groundbreaking Web3 projects across all blockchain ecosystems, creating a seamless bridge between innovation and execution.',
   content:
-    "OnlyGrain connects talented open-source developers with innovative Web3 " +
-    "projects across every major blockchain ecosystem. By matching contributors " +
-    "to work that fits their skills and rewarding quality contributions " +
-    "transparently, we make meaningful collaboration accessible to everyone — " +
-    "from seasoned protocol engineers to first-time Web3 contributors.",
-  date: "December 27, 2024",
-  readTime: "8 min read",
-  author: "OnlyGrain Team",
-  image: "🌐",
+    'Grainlify connects talented open-source developers with innovative Web3 ' +
+    'projects across every major blockchain ecosystem. By matching contributors ' +
+    'to work that fits their skills and rewarding quality contributions ' +
+    'transparently, we make meaningful collaboration accessible to everyone — ' +
+    'from seasoned protocol engineers to first-time Web3 contributors.',
+  date: 'December 27, 2024',
+  readTime: '8 min read',
+  author: 'Grainlify Team',
+  image: '🌐',
   isFeatured: true,
-};
+}
 
 export const recentPosts: BlogPost[] = [
   {
     id: 1,
-    slug: "future-of-decentralized-development",
-    title: "The Future of Decentralized Development",
-    excerpt: "Exploring how blockchain technology is transforming the way developers collaborate on open-source projects.",
-    date: "December 20, 2024",
-    readTime: "6 min read",
-    category: "Innovation",
-    icon: "🚀"
+    slug: 'future-of-decentralized-development',
+    title: 'The Future of Decentralized Development',
+    excerpt:
+      'Exploring how blockchain technology is transforming the way developers collaborate on open-source projects.',
+    date: 'December 20, 2024',
+    readTime: '6 min read',
+    category: 'Innovation',
+    icon: '🚀',
   },
   {
     id: 2,
-    slug: "cross-chain-collaboration",
-    title: "Cross-Chain Collaboration: Breaking Down Barriers",
-    excerpt: "How OnlyGrain enables developers to contribute to projects across multiple blockchain ecosystems seamlessly.",
-    date: "December 15, 2024",
-    readTime: "7 min read",
-    category: "Technology",
-    icon: "🔗"
+    slug: 'cross-chain-collaboration',
+    title: 'Cross-Chain Collaboration: Breaking Down Barriers',
+    excerpt:
+      'How Grainlify enables developers to contribute to projects across multiple blockchain ecosystems seamlessly.',
+    date: 'December 15, 2024',
+    readTime: '7 min read',
+    category: 'Technology',
+    icon: '🔗',
   },
   {
     id: 3,
-    slug: "incentivizing-quality-contributions",
-    title: "Incentivizing Quality Contributions",
-    excerpt: "Learn about our reward system that recognizes and compensates exceptional open-source contributions.",
-    date: "December 10, 2024",
-    readTime: "5 min read",
-    category: "Community",
-    icon: "💎"
-  }
-];
+    slug: 'incentivizing-quality-contributions',
+    title: 'Incentivizing Quality Contributions',
+    excerpt:
+      'Learn about our reward system that recognizes and compensates exceptional open-source contributions.',
+    date: 'December 10, 2024',
+    readTime: '5 min read',
+    category: 'Community',
+    icon: '💎',
+  },
+]
 
 // Easy to add more blog posts here in the future
-export const allBlogPosts: BlogPost[] = [
-  featuredPost,
-  ...recentPosts,
-];
+export const allBlogPosts: BlogPost[] = [featuredPost, ...recentPosts]
 
 /**
  * Resolves a post from the *known* post set by its slug.
@@ -69,5 +70,5 @@ export const allBlogPosts: BlogPost[] = [
  * @returns The matching post, or `undefined` when no post owns that slug.
  */
 export function getPostBySlug(slug: string): BlogPost | undefined {
-  return allBlogPosts.find((post) => post.slug === slug);
+  return allBlogPosts.find((post) => post.slug === slug)
 }


### PR DESCRIPTION
## Summary

Closes #643

Several blog components and blog mock data still referenced the retired product name "OnlyGrain" instead of "Grainlify" — user-facing copy rendered directly on the public `/blog` route and blog article detail pages, a visible branding inconsistency.

## Changes

Replaced every occurrence of "OnlyGrain" with "Grainlify" across:
- `BlogHero.tsx` (page heading, subtitle)
- `BlogCTA.tsx` (call-to-action copy)
- `BlogHowItWorks.tsx` (step description)
- `BlogArticle.tsx` (9 mentions: section headings, body copy)
- `blogPosts.ts` (title, excerpt, author, body text)

No possessive forms ("OnlyGrain's") were present anywhere, so a plain string replacement was safe throughout — double-checked each diff reads naturally. No third product name was introduced.

## What's covered

- [x] `grep -rn "OnlyGrain" src` returns zero matches.
- [x] No test file asserted on the literal "OnlyGrain" string (confirmed via `grep --include="*.test.tsx" --include="*.test.ts"`), so no test updates were needed.
- [x] All blog-related tests pass at the same rate as before this change.

## Test plan

```
$ npx vitest run src/features/blog
Test Files  1 failed | 6 passed (7)
     Tests  3 failed | 60 passed (63)
```

Identical failure count before and after this change (verified via `git stash`) — the 3 failures are pre-existing and unrelated (a React reconcile crash in `BlogPage.test.tsx`, same root cause as the repo-wide `lucide-react` issue affecting other test files).

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.