### PR TITLE
fix: make ContributorsTableSkeleton respect dark mode like ContributorsTable

### DIFF
--- a/src/features/leaderboard/components/ContributorsTableSkeleton.test.tsx
+++ b/src/features/leaderboard/components/ContributorsTableSkeleton.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { ContributorsTableSkeleton } from './ContributorsTableSkeleton'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+
+vi.mock('../../../shared/contexts/ThemeContext', () => ({
+  useTheme: vi.fn(),
+}))
+
+const mockUseTheme = vi.mocked(useTheme)
+
+describe('ContributorsTableSkeleton', () => {
+  it('renders light-mode container classes when theme is light', () => {
+    mockUseTheme.mockReturnValue({ theme: 'light' } as ReturnType<typeof useTheme>)
+    const { container } = render(<ContributorsTableSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.12]')
+    expect(outer.className).toContain('border-white/20')
+    expect(outer.className).not.toContain('bg-white/[0.10]')
+  })
+
+  it('renders dark-mode container classes when theme is dark', () => {
+    mockUseTheme.mockReturnValue({ theme: 'dark' } as ReturnType<typeof useTheme>)
+    const { container } = render(<ContributorsTableSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.10]')
+    expect(outer.className).toContain('border-white/[0.16]')
+    expect(outer.className).not.toContain('bg-white/[0.12]')
+  })
+})

--- a/src/features/leaderboard/components/ContributorsTableSkeleton.tsx
+++ b/src/features/leaderboard/components/ContributorsTableSkeleton.tsx
@@ -1,13 +1,23 @@
-import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
 
 export function ContributorsTableSkeleton() {
-  const { theme: _theme } = useTheme();
+  const { theme } = useTheme()
 
   return (
-    <div className={`backdrop-blur-[40px] bg-white/[0.12] rounded-[24px] border border-white/20 shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden`}>
+    <div
+      className={`backdrop-blur-[40px] rounded-[24px] border shadow-[0_8px_32px_rgba(0,0,0,0.08)] overflow-hidden ${
+        theme === 'dark' ? 'bg-white/[0.10] border-white/[0.16]' : 'bg-white/[0.12] border-white/20'
+      }`}
+    >
       {/* Table Header */}
-      <div className="grid grid-cols-12 gap-4 px-8 py-4 border-b border-white/10 backdrop-blur-[30px] bg-white/[0.08]">
+      <div
+        className={`grid grid-cols-12 gap-4 px-8 py-4 border-b backdrop-blur-[30px] ${
+          theme === 'dark'
+            ? 'bg-white/[0.06] border-white/[0.08]'
+            : 'bg-white/[0.08] border-white/10'
+        }`}
+      >
         <div className="col-span-1">
           <SkeletonLoader className="h-4 w-12" />
         </div>
@@ -57,6 +67,5 @@ export function ContributorsTableSkeleton() {
         ))}
       </div>
     </div>
-  );
+  )
 }
-


### PR DESCRIPTION
## Summary

Closes #644

`ContributorsTableSkeleton` destructured `theme` as `_theme` (the project's unused-variable escape hatch) and never used it, leaving every container class hardcoded.

## Investigation

`ContributorsTable.tsx` itself only branches **text** colors by theme (`theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'`, etc.) — its outer container and header row backgrounds/borders are fixed, identical in both themes. Skeleton placeholder bars (`SkeletonLoader`) already self-theme internally. So there's no direct container-level class pair in `ContributorsTable.tsx` to mirror 1:1 for the container background.

## Fix

Applied the same dark-mode alpha-reduction convention already established elsewhere on this same page (`FiltersSection.tsx` branches its background alpha by roughly -20% for dark mode, e.g. `bg-white/[0.1]` → `bg-white/[0.08]`) to the skeleton's outer container and header row, rather than inventing arbitrary values. Removed the `_theme` unused-variable escape hatch now that `theme` is genuinely used.

## What's covered

- [x] `ContributorsTableSkeleton` renders dark-mode-appropriate classes when `theme === 'dark'`, verified by test.
- [x] `ContributorsTableSkeleton` renders light-mode-appropriate classes when `theme === 'light'`, verified by test.
- [x] No unused-variable escape hatch (`_theme`) remains in the file.

## Test plan

```
$ npx vitest run src/features/leaderboard/components/ContributorsTableSkeleton.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)

$ npx vitest run src/features/leaderboard
Test Files  10 passed | 1 skipped (11)
     Tests  67 passed | 2 skipped (69)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.