### PR TITLE
fix: make IssueCardSkeleton respect light/dark theme like IssueCard

### DIFF
--- a/src/shared/components/IssueCardSkeleton.test.tsx
+++ b/src/shared/components/IssueCardSkeleton.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { IssueCardSkeleton } from './IssueCardSkeleton'
+import { useTheme } from '../contexts/ThemeContext'
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: vi.fn(),
+}))
+
+const mockUseTheme = vi.mocked(useTheme)
+
+describe('IssueCardSkeleton', () => {
+  it('renders light-mode classes when theme is light', () => {
+    mockUseTheme.mockReturnValue({ theme: 'light' } as ReturnType<typeof useTheme>)
+    const { container } = render(<IssueCardSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.15]')
+    expect(outer.className).toContain('border-white/25')
+    expect(outer.className).not.toContain('bg-white/[0.08]')
+  })
+
+  it('renders dark-mode classes when theme is dark', () => {
+    mockUseTheme.mockReturnValue({ theme: 'dark' } as ReturnType<typeof useTheme>)
+    const { container } = render(<IssueCardSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.08]')
+    expect(outer.className).toContain('border-white/10')
+    expect(outer.className).not.toContain('bg-white/[0.15]')
+  })
+})

--- a/src/shared/components/IssueCardSkeleton.tsx
+++ b/src/shared/components/IssueCardSkeleton.tsx
@@ -1,8 +1,15 @@
-import { SkeletonLoader } from './SkeletonLoader';
+import { SkeletonLoader } from './SkeletonLoader'
+import { useTheme } from '../contexts/ThemeContext'
 
 export function IssueCardSkeleton() {
+  const { theme } = useTheme()
+
   return (
-    <div className="backdrop-blur-[25px] rounded-[16px] border p-4 bg-white/[0.08] border-white/10">
+    <div
+      className={`backdrop-blur-[25px] rounded-[16px] border p-4 ${
+        theme === 'dark' ? 'bg-white/[0.08] border-white/10' : 'bg-white/[0.15] border-white/25'
+      }`}
+    >
       {/* Issue Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
@@ -26,7 +33,11 @@ export function IssueCardSkeleton() {
       </div>
 
       {/* Author and Time Skeleton */}
-      <div className="flex items-center gap-2 pt-3 border-t border-white/10">
+      <div
+        className={`flex items-center gap-2 pt-3 border-t ${
+          theme === 'dark' ? 'border-white/10' : 'border-white/20'
+        }`}
+      >
         {/* Avatar Skeleton */}
         <SkeletonLoader variant="circle" width="24px" height="24px" />
         {/* Name Skeleton */}
@@ -35,20 +46,5 @@ export function IssueCardSkeleton() {
         <SkeletonLoader variant="text" width="60px" height="12px" className="ml-auto" />
       </div>
     </div>
-  );
+  )
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

Closes #645

`IssueCardSkeleton` never called `useTheme()` and hardcoded `bg-white/[0.08] border-white/10` — which happens to match `IssueCard.tsx`'s **dark**-mode branch, meaning in light mode the skeleton rendered with dark-mode-tinted styling: a visible mismatch/flash right before the real, correctly light-styled card mounts.

## Changes

Wires `useTheme()` and mirrors `IssueCard.tsx`'s (`src/features/maintainers/components/issues/IssueCard.tsx`) two theme-conditional class pairs exactly:
- Outer container: `bg-white/[0.08] border-white/10` (dark) / `bg-white/[0.15] border-white/25` (light)
- Author/time section's top divider: `border-white/10` (dark) / `border-white/20` (light)

Adds `IssueCardSkeleton.test.tsx` asserting the container carries the correct theme-specific classes in both light and dark mode.

## What's covered

- [x] `IssueCardSkeleton` renders light-mode classes when `theme === 'light'`, verified by test.
- [x] `IssueCardSkeleton` renders dark-mode classes when `theme === 'dark'`, verified by test.
- [x] No visual mismatch between skeleton and loaded `IssueCard` in either theme — classes now match exactly.

## Test plan

```
$ npx vitest run src/shared/components/IssueCardSkeleton.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)

$ npx vitest run src/features/maintainers/components/issues src/features/dashboard/pages/IssueDetailPage.test.tsx
Test Files  1 failed | 5 passed (6)
     Tests  4 failed | 69 passed (73)
```

The 4 failures are pre-existing and unrelated (confirmed identical via `git stash` — a React reconcile crash in `IssueDetailPage.test.tsx`, same root cause as the repo-wide `lucide-react` issue affecting other test files).

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.