### PR TITLE
fix: make PRRowSkeleton respect light/dark theme like PRRow

### DIFF
--- a/src/shared/components/PRRowSkeleton.test.tsx
+++ b/src/shared/components/PRRowSkeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import { PRRowSkeleton } from './PRRowSkeleton'
+import { useTheme } from '../contexts/ThemeContext'
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: vi.fn(),
+}))
+
+const mockUseTheme = vi.mocked(useTheme)
+
+function renderSkeleton() {
+  return render(
+    <table>
+      <tbody>
+        <PRRowSkeleton />
+      </tbody>
+    </table>
+  )
+}
+
+describe('PRRowSkeleton', () => {
+  it('renders light-mode classes when theme is light', () => {
+    mockUseTheme.mockReturnValue({ theme: 'light' } as ReturnType<typeof useTheme>)
+    const { getByRole } = renderSkeleton()
+    const row = getByRole('row')
+    expect(row.className).toContain('bg-white/[0.08]')
+    expect(row.className).toContain('border-white/15')
+    expect(row.className).not.toContain('bg-white/[0.06]')
+  })
+
+  it('renders dark-mode classes when theme is dark', () => {
+    mockUseTheme.mockReturnValue({ theme: 'dark' } as ReturnType<typeof useTheme>)
+    const { getByRole } = renderSkeleton()
+    const row = getByRole('row')
+    expect(row.className).toContain('bg-white/[0.06]')
+    expect(row.className).toContain('border-white/[0.12]')
+    expect(row.className).not.toContain('bg-white/[0.08]')
+  })
+})

--- a/src/shared/components/PRRowSkeleton.tsx
+++ b/src/shared/components/PRRowSkeleton.tsx
@@ -1,8 +1,16 @@
-import { SkeletonLoader } from './SkeletonLoader';
+import { SkeletonLoader } from './SkeletonLoader'
+import { useTheme } from '../contexts/ThemeContext'
 
 export function PRRowSkeleton() {
+  const { theme } = useTheme()
+
   return (
-    <tr role="row" className="grid grid-cols-[2fr_1.5fr_1fr_0.5fr] gap-6 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border bg-white/[0.08] border-white/15">
+    <tr
+      role="row"
+      className={`grid grid-cols-[2fr_1.5fr_1fr_0.5fr] gap-6 px-6 py-5 rounded-[16px] backdrop-blur-[25px] border ${
+        theme === 'dark' ? 'bg-white/[0.06] border-white/[0.12]' : 'bg-white/[0.08] border-white/15'
+      }`}
+    >
       {/* Pull Request Info */}
       <td role="cell">
         <div className="flex items-start gap-3 mb-2">
@@ -50,5 +58,5 @@ export function PRRowSkeleton() {
         <SkeletonLoader variant="circle" width="28px" height="28px" />
       </td>
     </tr>
-  );
+  )
 }


### PR DESCRIPTION
## Summary

Closes #646

`PRRowSkeleton` never called `useTheme()` and hardcoded a single container style regardless of the active theme.

## Investigation

`PRRow.tsx`'s row container base classes (`bg-white/[0.08] border-white/15`) are actually identical in both themes — only the **hover** state's border alpha differs (`hover:border-[#c9983a]/30` dark vs `/20` light), which doesn't apply to a non-interactive skeleton. So there's no exact base-state class pair to mirror 1:1 the way #645's `IssueCard` fix could.

## Fix

Applied the same dark-mode alpha-reduction convention already used in #644's `ContributorsTableSkeleton` fix (and originally established by `FiltersSection.tsx` elsewhere in the codebase) to the row container, wired via a real `useTheme()` call rather than leaving it fixed.

## What's covered

- [x] `PRRowSkeleton` renders light-mode classes when `theme === 'light'`, verified by test.
- [x] `PRRowSkeleton` renders dark-mode classes when `theme === 'dark'`, verified by test.

## Test plan

```
$ npx vitest run src/shared/components/PRRowSkeleton.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)

$ npx vitest run src/features/maintainers/components/pull-requests
Test Files  3 passed (3)
     Tests  27 passed (27)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.