### PR TITLE
fix: make ActivityItemSkeleton respect light/dark theme like ActivityItem

### DIFF
--- a/src/shared/components/ActivityItemSkeleton.test.tsx
+++ b/src/shared/components/ActivityItemSkeleton.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { ActivityItemSkeleton } from './ActivityItemSkeleton'
+import { useTheme } from '../contexts/ThemeContext'
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: vi.fn(),
+}))
+
+const mockUseTheme = vi.mocked(useTheme)
+
+describe('ActivityItemSkeleton', () => {
+  it('renders light-mode classes when theme is light', () => {
+    mockUseTheme.mockReturnValue({ theme: 'light' } as ReturnType<typeof useTheme>)
+    const { container } = render(<ActivityItemSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.15]')
+    expect(outer.className).toContain('border-white/25')
+    expect(outer.className).not.toContain('bg-white/[0.08]')
+  })
+
+  it('renders dark-mode classes when theme is dark', () => {
+    mockUseTheme.mockReturnValue({ theme: 'dark' } as ReturnType<typeof useTheme>)
+    const { container } = render(<ActivityItemSkeleton />)
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.className).toContain('bg-white/[0.08]')
+    expect(outer.className).toContain('border-white/10')
+    expect(outer.className).not.toContain('bg-white/[0.15]')
+  })
+})

--- a/src/shared/components/ActivityItemSkeleton.tsx
+++ b/src/shared/components/ActivityItemSkeleton.tsx
@@ -1,22 +1,29 @@
-import { SkeletonLoader } from './SkeletonLoader';
+import { SkeletonLoader } from './SkeletonLoader'
+import { useTheme } from '../contexts/ThemeContext'
 
 export function ActivityItemSkeleton() {
+  const { theme } = useTheme()
+
   return (
-    <div className="backdrop-blur-[25px] rounded-[14px] border p-4 bg-white/[0.08] border-white/10">
+    <div
+      className={`backdrop-blur-[25px] rounded-[14px] border p-4 ${
+        theme === 'dark' ? 'bg-white/[0.08] border-white/10' : 'bg-white/[0.15] border-white/25'
+      }`}
+    >
       <div className="flex items-start justify-between gap-4">
         {/* Left: Icon + Badge + Title */}
         <div className="flex items-start gap-3 flex-1 min-w-0">
           {/* Icon Skeleton */}
           <SkeletonLoader variant="circle" width="32px" height="32px" />
-          
+
           {/* Badge Skeleton */}
           <SkeletonLoader variant="text" width="50px" height="24px" />
-          
+
           {/* Title and Label */}
           <div className="flex-1 min-w-0 pt-0.5 space-y-2">
             {/* Title Skeleton */}
             <SkeletonLoader variant="text" width="80%" height="16px" />
-            
+
             {/* Label and Time Skeleton */}
             <div className="flex items-center gap-3">
               <SkeletonLoader variant="text" width="60px" height="20px" />
@@ -29,20 +36,5 @@ export function ActivityItemSkeleton() {
         <SkeletonLoader variant="default" width="80px" height="36px" />
       </div>
     </div>
-  );
+  )
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

Closes #647

`ActivityItemSkeleton` never called `useTheme()` and hardcoded `bg-white/[0.08] border-white/10`, matching `ActivityItem.tsx`'s **dark**-mode branch only — the same class of bug already fixed in `ContributorsTableSkeleton` (#644), `IssueCardSkeleton` (#645), and `PRRowSkeleton` (#646), causing a visible flash in light mode right before the real (correctly light-styled) activity row mounts.

## Changes

Wires `useTheme()` and mirrors `ActivityItem.tsx`'s (`src/features/maintainers/components/dashboard/ActivityItem.tsx`) container class pair exactly: `bg-white/[0.08] border-white/10` (dark) / `bg-white/[0.15] border-white/25` (light).

Adds `ActivityItemSkeleton.test.tsx` asserting the container carries the correct theme-specific classes in both light and dark mode.

## What's covered

- [x] `ActivityItemSkeleton` renders light-mode classes when `theme === 'light'`, verified by test.
- [x] `ActivityItemSkeleton` renders dark-mode classes when `theme === 'dark'`, verified by test.
- [x] No visual mismatch between skeleton and loaded `ActivityItem` in either theme — classes now match exactly.

## Test plan

```
$ npx vitest run src/shared/components/ActivityItemSkeleton.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)

$ npx vitest run src/features/maintainers/components/dashboard
Test Files  4 passed (4)
     Tests  42 passed (42)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.