### PR TITLE
test: cover I18nProvider default locale, messages override, and error policy

### DIFF
--- a/src/shared/i18n/I18nProvider.test.tsx
+++ b/src/shared/i18n/I18nProvider.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import { I18nProvider } from './I18nProvider'
+import { useTranslation } from './useTranslation'
+import type { MessageId } from './messages'
+
+vi.mock('./errors', async () => {
+  const actual = await vi.importActual<typeof import('./errors')>('./errors')
+  return {
+    ...actual,
+    handleIntlError: vi.fn(actual.handleIntlError),
+  }
+})
+import { handleIntlError } from './errors'
+
+const mockHandleIntlError = vi.mocked(handleIntlError)
+
+function Probe({ id }: { id: MessageId }) {
+  const { t, locale } = useTranslation()
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="value">{t(id)}</span>
+    </div>
+  )
+}
+
+describe('I18nProvider', () => {
+  beforeEach(() => {
+    mockHandleIntlError.mockClear()
+  })
+
+  it('defaults to DEFAULT_LOCALE (en) when locale is omitted', () => {
+    render(
+      <I18nProvider>
+        <Probe id="dashboardNav.discover" />
+      </I18nProvider>
+    )
+    expect(screen.getByTestId('locale')).toHaveTextContent('en')
+    expect(screen.getByTestId('value')).toHaveTextContent('Discover')
+  })
+
+  it('resolves the layered catalog for a non-default locale prop', () => {
+    render(
+      <I18nProvider locale="es">
+        <Probe id="dashboardNav.discover" />
+      </I18nProvider>
+    )
+    expect(screen.getByTestId('locale')).toHaveTextContent('es')
+    expect(screen.getByTestId('value')).toHaveTextContent('Descubrir')
+  })
+
+  it('falls back to English for a key missing from the es catalog, even under locale="es"', () => {
+    render(
+      <I18nProvider locale="es">
+        <Probe id="terms.title" />
+      </I18nProvider>
+    )
+    // Not present in the `es` catalog — resolveMessages layers English in.
+    expect(screen.getByTestId('value')).toHaveTextContent('Terms and Conditions')
+  })
+
+  it('lets an explicit messages prop override resolveMessages entirely', () => {
+    render(
+      <I18nProvider locale="es" messages={{ 'dashboardNav.discover': 'Overridden' }}>
+        <Probe id="dashboardNav.discover" />
+      </I18nProvider>
+    )
+    // Not the real es catalog value ("Descubrir") — the override took precedence.
+    expect(screen.getByTestId('value')).toHaveTextContent('Overridden')
+  })
+
+  it('wires onError to handleIntlError instead of throwing or using react-intl defaults', () => {
+    render(
+      <I18nProvider messages={{}}>
+        <Probe id="dashboardNav.discover" />
+      </I18nProvider>
+    )
+    // messages={{}} means every lookup is a MISSING_TRANSLATION -
+    // handleIntlError must have been invoked to swallow it (render didn't throw).
+    expect(mockHandleIntlError).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #650

`I18nProvider.tsx` (the top-level react-intl wiring mounted above the router in `App.tsx`) had no dedicated test file. `i18n.test.tsx` covers `useTranslation` and `handleIntlError` in isolation, but nothing rendered `I18nProvider` itself to confirm the wiring is correct end-to-end.

## Changes

Adds `I18nProvider.test.tsx` covering:
- Omitting `locale` defaults to `DEFAULT_LOCALE` (`'en'`).
- A non-default `locale` prop (`'es'`) resolves the layered `es`-over-`en` catalog.
- A key missing from the `es` catalog still falls back to its English value under `locale="es"` (`resolveMessages`'s layering, exercised through the provider rather than called directly).
- An explicit `messages` prop overrides `resolveMessages(locale)` entirely, confirming the "intended for tests" escape hatch documented on the prop.
- `onError` is actually wired to `handleIntlError` end-to-end: mocks `./errors`, renders with an empty `messages` map (forcing every lookup to be a `MISSING_TRANSLATION`), and asserts the mock was invoked rather than the render throwing or falling through to react-intl's default policy.

## What's covered

- [x] Omitting `locale` renders using `DEFAULT_LOCALE`, verified by test.
- [x] An explicit `messages` prop overrides `resolveMessages(locale)`, verified by test.
- [x] `onError` is wired to `handleIntlError`, verified by test (spy assertion).

## Test plan

```
$ npx vitest run src/shared/i18n/I18nProvider.test.tsx
Test Files  1 passed (1)
     Tests  5 passed (5)

$ npx vitest run src/shared/i18n
Test Files  6 passed (6)
     Tests  62 passed (62)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.