### PR TITLE
test: cover useTranslation interpolation, locale, and anti-injection behavior

### DIFF
--- a/src/shared/i18n/useTranslation.test.tsx
+++ b/src/shared/i18n/useTranslation.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+import { render, renderHook, screen } from '@testing-library/react'
+import { I18nProvider } from './I18nProvider'
+import { useTranslation } from './useTranslation'
+import type { MessageId } from './messages'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>
+}
+
+function esWrapper({ children }: { children: ReactNode }) {
+  return <I18nProvider locale="es">{children}</I18nProvider>
+}
+
+describe('useTranslation', () => {
+  it('resolves an existing key to its English string', () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper })
+    expect(result.current.t('dashboardNav.discover')).toBe('Discover')
+  })
+
+  it('interpolates multiple placeholder values into a message', () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper })
+    const output = result.current.t('terms.status.acceptedVersion', {
+      version: 3,
+      date: '2026-01-01',
+    })
+    expect(output).toBe('✓ Accepted version 3 on 2026-01-01')
+  })
+
+  it('exposes the locale matching the active I18nProvider', () => {
+    const { result: enResult } = renderHook(() => useTranslation(), { wrapper })
+    expect(enResult.current.locale).toBe('en')
+
+    const { result: esResult } = renderHook(() => useTranslation(), { wrapper: esWrapper })
+    expect(esResult.current.locale).toBe('es')
+  })
+
+  it('does not throw when values contains null/undefined entries', () => {
+    const { result } = renderHook(() => useTranslation(), { wrapper })
+    expect(() =>
+      result.current.t('terms.status.acceptedVersion', {
+        version: null,
+        date: undefined,
+      })
+    ).not.toThrow()
+  })
+
+  it('reflects a locale prop change on the wrapping I18nProvider', () => {
+    function Probe() {
+      const { locale } = useTranslation()
+      return <span data-testid="locale">{locale}</span>
+    }
+
+    const { rerender } = render(
+      <I18nProvider locale="en">
+        <Probe />
+      </I18nProvider>
+    )
+    expect(screen.getByTestId('locale')).toHaveTextContent('en')
+
+    rerender(
+      <I18nProvider locale="es">
+        <Probe />
+      </I18nProvider>
+    )
+    expect(screen.getByTestId('locale')).toHaveTextContent('es')
+  })
+})
+
+describe('useTranslation — anti-injection', () => {
+  function Probe({ name }: { name: string }) {
+    const { t } = useTranslation()
+    return <div data-testid="out">{t('greeting.demo' as MessageId, { name })}</div>
+  }
+
+  it('renders markup-like interpolated values as literal text, never as an element', () => {
+    const evil = '<img src=x onerror="window.__pwned2 = true">'
+
+    const { container } = render(
+      <I18nProvider messages={{ 'greeting.demo': 'Hello, {name}!' }}>
+        <Probe name={evil} />
+      </I18nProvider>
+    )
+
+    expect(container.querySelector('img')).toBeNull()
+    expect((window as unknown as Record<string, unknown>).__pwned2).toBeUndefined()
+    expect(screen.getByTestId('out').textContent).toBe(`Hello, ${evil}!`)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #651

`useTranslation.ts` — the strongly-typed react-intl wrapper every feature calls to translate strings — had no dedicated test file. `i18n.test.tsx` covers a single bare `t(id)` call, but not multi-placeholder interpolation via `useTranslation` itself, locale reactivity, `null`/`undefined` values handling, or an anti-injection test that goes through `useTranslation` specifically (the existing anti-injection test in `i18n.test.tsx` exercises `<FormattedMessage>` directly, not this hook).

## Changes

Adds `useTranslation.test.tsx` covering:
- `t(id)` resolves an existing key to its English string.
- `t(id, values)` correctly interpolates multiple placeholders (`terms.status.acceptedVersion`'s `{version}`/`{date}`).
- `locale` matches the active `I18nProvider`'s locale, for both `en` and `es`.
- `values` containing `null`/`undefined` entries doesn't throw.
- `locale` updates when the wrapping `I18nProvider`'s `locale` prop changes.
- A `values` entry containing HTML-like text renders as literal text in a consuming component, never as markup/DOM — the anti-injection guarantee, verified through `useTranslation` itself rather than `<FormattedMessage>`.

## What's covered

- [x] `t(id, values)` returns correctly interpolated strings for a multi-placeholder message id, verified by test.
- [x] `locale` returned by the hook matches the active `I18nProvider` locale, verified by test.
- [x] A `values` entry containing markup-like text renders as literal text in the DOM, never as an element, verified by test.

## Test plan

```
$ npx vitest run src/shared/i18n/useTranslation.test.tsx
Test Files  1 passed (1)
     Tests  6 passed (6)

$ npx vitest run src/shared/i18n
Test Files  6 passed (6)
     Tests  63 passed (63)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.