### PR TITLE
test: cover BlogWhyChoose card rendering in both themes

### DIFF
--- a/src/features/blog/components/BlogWhyChoose.test.tsx
+++ b/src/features/blog/components/BlogWhyChoose.test.tsx
@@ -1,0 +1,36 @@
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { BlogWhyChoose } from './BlogWhyChoose'
+
+const CARDS = [
+  {
+    title: 'Lightning Fast Matching',
+    description:
+      'Our AI-powered algorithm instantly connects you with the most relevant opportunities based on your profile and preferences.',
+  },
+  {
+    title: 'All Chains, One Platform',
+    description:
+      'Access projects from every major blockchain ecosystem without switching platforms or creating multiple accounts.',
+  },
+  {
+    title: 'Fair Compensation',
+    description:
+      'Transparent reward systems ensure contributors are fairly compensated for their work with competitive bounties and grants.',
+  },
+  {
+    title: 'Vibrant Community',
+    description:
+      'Join thousands of developers and projects building the future of Web3 together in a supportive ecosystem.',
+  },
+]
+
+describe.each(['light', 'dark'] as const)('BlogWhyChoose (%s theme)', (theme) => {
+  it('renders all four cards with correct title and description text', () => {
+    const { getByText } = renderWithTheme(<BlogWhyChoose />, { theme })
+
+    for (const card of CARDS) {
+      expect(getByText(card.title)).toBeInTheDocument()
+      expect(getByText(card.description)).toBeInTheDocument()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes #655

`BlogWhyChoose.tsx` had no dedicated test file — a regression that silently dropped a card or scrambled the mapping would go undetected.

## Changes

Adds `BlogWhyChoose.test.tsx`, parameterized over both theme values via `describe.each`, asserting all four card titles ("Lightning Fast Matching", "All Chains, One Platform", "Fair Compensation", "Vibrant Community") and their full description text render correctly, using `renderWithTheme` from `src/test/renderWithTheme.tsx`, consistent with sibling blog component tests.

## What's covered

- [x] All four cards render with correct title and description text, verified by test.
- [x] Component renders without error/mismatch under both light and dark theme, verified by test.

## Test plan

```
$ npx vitest run src/features/blog/components/BlogWhyChoose.test.tsx
Test Files  1 passed (1)
     Tests  2 passed (2)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.