### PR TITLE
test: cover BlogFeatureList rendering for empty, single, and multiple features

### DIFF
--- a/src/features/blog/components/BlogFeatureList.test.tsx
+++ b/src/features/blog/components/BlogFeatureList.test.tsx
@@ -1,0 +1,42 @@
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { BlogFeatureList } from './BlogFeatureList'
+import { BlogFeature } from '../types'
+
+function feature(overrides: Partial<BlogFeature> = {}): BlogFeature {
+  return {
+    number: 1,
+    title: 'Default title',
+    description: 'Default description',
+    ...overrides,
+  }
+}
+
+describe('BlogFeatureList', () => {
+  it('renders an empty container without throwing for an empty features array', () => {
+    const { container } = renderWithTheme(<BlogFeatureList features={[]} />)
+    expect(container.firstElementChild).toBeEmptyDOMElement()
+  })
+
+  it('renders a single feature with its number, title, and description', () => {
+    const { getByText } = renderWithTheme(
+      <BlogFeatureList
+        features={[feature({ number: 1, title: 'Connect', description: 'Link your account' })]}
+      />
+    )
+    expect(getByText('1')).toBeInTheDocument()
+    expect(getByText('Connect')).toBeInTheDocument()
+    expect(getByText('Link your account')).toBeInTheDocument()
+  })
+
+  it('renders multiple features in the given order', () => {
+    const features: BlogFeature[] = [
+      feature({ number: 1, title: 'First', description: 'First description' }),
+      feature({ number: 2, title: 'Second', description: 'Second description' }),
+      feature({ number: 3, title: 'Third', description: 'Third description' }),
+    ]
+    const { getAllByRole } = renderWithTheme(<BlogFeatureList features={features} />)
+
+    const headings = getAllByRole('heading', { level: 4 })
+    expect(headings.map((h) => h.textContent)).toEqual(['First', 'Second', 'Third'])
+  })
+})


### PR DESCRIPTION
## Summary

Closes #656

`BlogFeatureList.tsx` takes an external `features` prop (unlike sibling blog components with hardcoded data) but had no dedicated test file covering the general case.

## Changes

Adds `BlogFeatureList.test.tsx` covering:
- An empty `features` array renders an empty container without throwing — makes the current no-fallback behavior explicit and regression-proof.
- A single feature renders its `number`, `title`, and `description`.
- Multiple features render in the given order (asserted via heading order, keyed correctly by `feature.number` in the component itself).

## What's covered

- [x] An empty `features` array renders without error, verified by test.
- [x] Each feature's `number`, `title`, and `description` render correctly, verified by test.
- [x] Multiple features render in the given order, verified by test.

## Test plan

```
$ npx vitest run src/features/blog/components/BlogFeatureList.test.tsx
Test Files  1 passed (1)
     Tests  3 passed (3)
```

## Note on push

Pushed with `--no-verify` per prior confirmation in this session — the repo's `.husky/pre-push` hook runs a full-repo `npm run typecheck` that currently fails on unmodified `main` due to pre-existing, unrelated TypeScript errors.