### PR TITLE
fix: remove hardcoded 2025 from DataPage chart tooltip

### DIFF
--- a/src/features/dashboard/pages/DataPage.test.tsx
+++ b/src/features/dashboard/pages/DataPage.test.tsx
@@ -252,4 +252,22 @@ describe('DataPage', () => {
       expect(apiClient.getProjectActivity).toHaveBeenCalledWith('Weekly interval')
     })
   })
+
+  // ------------- Tooltip year ------------------------------------------------
+
+  describe('chart tooltip', () => {
+    it('does not hardcode a literal year string', async () => {
+      renderPage()
+      await waitFor(() => expect(apiClient.getProjectActivity).toHaveBeenCalled())
+
+      // The tooltip renders the CustomTooltip component. The mock Tooltip
+      // passes its content prop through, so <p> elements inside the tooltip
+      // should not contain the old hardcoded "2025" literal.
+      const tooltips = screen.getAllByTestId('tooltip')
+      expect(tooltips.length).toBeGreaterThanOrEqual(1)
+      for (const tooltip of tooltips) {
+        expect(tooltip.textContent).not.toContain('2025')
+      }
+    })
+  })
 })

--- a/src/features/dashboard/pages/DataPage.tsx
+++ b/src/features/dashboard/pages/DataPage.tsx
@@ -165,7 +165,7 @@ export function DataPage() {
       const data = payload[0].payload
       return (
         <div className="backdrop-blur-[30px] bg-[#1a1410]/95 border-2 border-white/20 rounded-[12px] px-5 py-4 min-w-[200px]">
-          <p className="text-[13px] font-bold text-white mb-3">{data.month} 2025</p>
+          <p className="text-[13px] font-bold text-white mb-3">{data.month} {new Date().getFullYear()}</p>
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Description

This PR fixes the DataPage growth chart tooltip that hardcoded the year "2025", which is now displaying the wrong year.

### Changes

**DataPage.tsx:**
- Replaced `{data.month} 2025` with `{data.month} {new Date().getFullYear()}` — dynamically derives the current year instead of using a hardcoded literal
- The chart data doesn't carry a year field, so deriving it from the current date is the correct approach for this single-year chart

**Test added:**
- Asserts that no tooltip on the page contains the old hardcoded "2025" string, guarding against regression

### Acceptance Criteria
- [x] The chart tooltip no longer hardcodes `2025`
- [x] The displayed year is correct for the current date
- [x] A test guards against a hardcoded year literal reappearing

Closes #761