### PR TITLE
fix: wire up the unused onRefresh prop in PullRequestsTab

### DIFF
--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
@@ -129,3 +129,22 @@ describe('PullRequestsTab accessibility', () => {
     expect(headers[3]).toHaveAttribute('scope', 'col')
   })
 })
+
+describe('PullRequestsTab onRefresh', () => {
+  beforeEach(() => {
+    mockGetProjectPRs.mockReset()
+  })
+
+  it('calls onRefresh when the repositories-refreshed event is dispatched', () => {
+    const onRefresh = vi.fn()
+    mockGetProjectPRs.mockResolvedValue({ prs: [] })
+
+    renderWithTheme(<PullRequestsTab selectedProjects={PROJECTS} onRefresh={onRefresh} />)
+
+    expect(onRefresh).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('repositories-refreshed'))
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
@@ -89,7 +89,7 @@ function getEmptyStateKind({
  * @param props - The component props.
  * @returns The Pull Requests tab component.
  */
-export function PullRequestsTab({ selectedProjects }: PullRequestsTabProps) {
+export function PullRequestsTab({ selectedProjects, onRefresh }: PullRequestsTabProps) {
   const { theme } = useTheme()
   const { userRole } = useAuth()
   const isAuthorized = userRole === 'maintainer' || userRole === 'admin'
@@ -175,6 +175,7 @@ export function PullRequestsTab({ selectedProjects }: PullRequestsTabProps) {
     const handleRepositoriesRefreshed = () => {
       // Refresh PRs when repositories are added or updated.
       loadPRs()
+      onRefresh?.()
     }
 
     document.addEventListener('visibilitychange', handleVisibilityChange)


### PR DESCRIPTION
## Description

This PR wires up the `onRefresh` prop that was declared in `PullRequestsTabProps` but never destructured or called by the component. The parent `MaintainersPage` passes a real `refreshAll` handler that was silently dropped.

### Changes

**PullRequestsTab.tsx:**
- Destructure `onRefresh` in the function signature
- Call `onRefresh?.()` after the `repositories-refreshed` event triggers `loadPRs()`

**PullRequestsTab.test.tsx:**
- Add a test verifying `onRefresh` is invoked when the `repositories-refreshed` event is dispatched

### Related

- `IssuesTab.tsx` (the sibling tab) correctly wires `onRefresh` and calls `onRefresh?.()` after relevant actions, making `PullRequestsTab` the outlier where a documented, intentionally-passed refresh callback was a no-op.

Closes #788