### PR TITLE
fix: wire up the unused onRefresh prop in DashboardTab

### DIFF
--- a/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.test.tsx
@@ -442,3 +442,23 @@ describe('DashboardTab', () => {
     expect(screen.queryByText('Show less')).not.toBeInTheDocument()
   })
 })
+
+describe('DashboardTab onRefresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls onRefresh when the repositories-refreshed event is dispatched', () => {
+    const onRefresh = vi.fn()
+    vi.mocked(getProjectIssues).mockResolvedValue({ issues: [] } as any)
+    vi.mocked(getProjectPRs).mockResolvedValue({ prs: [] } as any)
+
+    render(<DashboardTab selectedProjects={[{ id: 'proj-1', github_full_name: 'test/repo', status: 'active' }]} isLoadingProjects={false} onRefresh={onRefresh} />)
+
+    expect(onRefresh).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('repositories-refreshed'))
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/maintainers/components/dashboard/DashboardTab.tsx
+++ b/src/features/maintainers/components/dashboard/DashboardTab.tsx
@@ -56,6 +56,7 @@ function safeStatValue(v: number): number {
 export function DashboardTab({
   selectedProjects,
   isLoadingProjects = false,
+  onRefresh,
   onNavigateToIssue,
   onNavigateToPR,
 }: DashboardTabProps) {
@@ -198,6 +199,7 @@ export function DashboardTab({
       if (selectedProjects.length > 0) {
         loadData()
       }
+      onRefresh?.()
     }
 
     document.addEventListener('visibilitychange', handleVisibilityChange)


### PR DESCRIPTION
## Description

This PR wires up the `onRefresh` prop that was declared in `DashboardTabProps` but never destructured or called by the component. The parent `MaintainersPage` passes a real `refreshAll` handler that was silently dropped.

### Changes

**DashboardTab.tsx:**
- Destructure `onRefresh` in the function signature
- Call `onRefresh?.()` after the `repositories-refreshed` event triggers `loadData()`

**DashboardTab.test.tsx:**
- Add a test verifying `onRefresh` is invoked when the `repositories-refreshed` event is dispatched

### Related

- `IssuesTab.tsx` (the sibling tab) correctly wires `onRefresh` and calls `onRefresh?.()` after relevant actions, making `DashboardTab` the outlier where a documented, intentionally-passed refresh callback was a no-op.
- `PullRequestsTab` had the same bug and was fixed in PR #814.

Closes #787