### PR TITLE
fix: use a dedicated fallback for missing contributor names in ContributionsTab

### DIFF
--- a/src/features/dashboard/components/ContributionsTab.test.tsx
+++ b/src/features/dashboard/components/ContributionsTab.test.tsx
@@ -341,4 +341,27 @@ describe('ContributionsTab', () => {
     expect(await screen.findByText('<img src=x onerror=alert(1)>')).toBeInTheDocument()
     expect(document.querySelector('img[src="x"]')).toBeNull()
   })
+
+  it('uses a contributor-specific fallback when contributor_login and author_login are both empty', async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: 'no-contributor',
+          title: 'Contribution with no author',
+          status: 'assigned',
+          project_name: 'Test Project',
+        },
+      ],
+    })
+
+    renderContributionsTab()
+
+    await screen.findByText('Contribution with no author')
+
+    // Search for "Unknown contributor" — the search filter includes
+    // item.contributor, so this verifies the fallback is correct
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'Unknown contributor')
+
+    expect(screen.getByText('Contribution with no author')).toBeInTheDocument()
+  })
 })

--- a/src/features/dashboard/components/ContributionsTab.tsx
+++ b/src/features/dashboard/components/ContributionsTab.tsx
@@ -60,6 +60,7 @@ const contributionColumns: Array<{
 const rewardOptions: RewardFilter[] = ['Rewarded', 'Unrewarded']
 const fallbackTitle = 'Untitled contribution'
 const fallbackProject = 'Unknown project'
+const fallbackContributor = 'Unknown contributor'
 const fallbackTag = 'contribution'
 const fallbackTime = 'Recently'
 
@@ -177,7 +178,7 @@ function normalizeContribution(contribution: ProfileContribution): ContributionC
     ),
     contributor: normalizeText(
       contribution.contributor_login || contribution.author_login,
-      fallbackProject
+      fallbackContributor
     ),
     tag,
     tagType: getTagType(tag),


### PR DESCRIPTION
## Problem
`ContributionsTab.tsx` defines four purpose-specific fallback strings (`fallbackTitle`, `fallbackProject`, `fallbackTag`, `fallbackTime`), but `normalizeContribution`'s `contributor` field reuses `fallbackProject` ("Unknown project") instead of a contributor-specific fallback.

When a contribution genuinely has neither `contributor_login` nor `author_login` populated, the rendered contributor name displays the literal text "Unknown project" — nonsensical in a field meant to show a person's identity.

## Fix
1. Added `const fallbackContributor = 'Unknown contributor'` alongside the other fallback constants.
2. Updated the `contributor` field in `normalizeContribution` to use `fallbackContributor` instead of `fallbackProject`.
3. Added a test asserting that a contribution with no `contributor_login`/`author_login` is findable via the "Unknown contributor" fallback text in the search filter.

## Acceptance criteria
- [x] A contribution missing both `contributor_login` and `author_login` displays a contributor-specific fallback (not "Unknown project").
- [x] The `project` field's fallback behavior is unchanged.
- [x] A test covers the corrected fallback text.

Fixes #813