### PR TITLE
fix: remove nested interactive elements in ActivityItem

### DIFF
--- a/src/features/maintainers/components/dashboard/ActivityItem.test.tsx
+++ b/src/features/maintainers/components/dashboard/ActivityItem.test.tsx
@@ -43,4 +43,15 @@ describe('ActivityItem', () => {
     fireEvent.keyDown(row, { key: ' ' });
     expect(handler).toHaveBeenCalledTimes(2);
   });
+
+  it('renders Review as a non-interactive badge instead of a nested button', () => {
+    const { container } = render(<ActivityItem activity={baseActivity as any} index={0} onClick={vi.fn()} />);
+    // The row itself is the interactive element (role="button")
+    const row = container.firstChild as HTMLElement;
+    expect(row).toHaveAttribute('role', 'button');
+
+    // "Review" should be rendered as text, not a <button> — no nested interactive elements
+    expect(row.textContent).toContain('Review');
+    expect(row.querySelector('button')).toBeNull();
+  });
 });

--- a/src/features/maintainers/components/dashboard/ActivityItem.tsx
+++ b/src/features/maintainers/components/dashboard/ActivityItem.tsx
@@ -110,11 +110,11 @@ export function ActivityItem({ activity, index, onClick }: ActivityItemProps) {
           </div>
         </div>
 
-        {/* Right: Review Button */}
+        {/* Right: Review Badge */}
         {isClickable && (
-          <button className="px-4 py-2 rounded-[10px] backdrop-blur-[25px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/20 border border-[#c9983a]/40 text-[13px] font-semibold text-[#c9983a] hover:from-[#c9983a]/35 hover:to-[#d4af37]/30 hover:scale-105 transition-all duration-200 whitespace-nowrap flex-shrink-0">
+          <span className="px-4 py-2 rounded-[10px] backdrop-blur-[25px] bg-gradient-to-br from-[#c9983a]/25 to-[#d4af37]/20 border border-[#c9983a]/40 text-[13px] font-semibold text-[#c9983a] whitespace-nowrap flex-shrink-0">
             Review
-          </button>
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Problem
`ActivityItem.tsx` renders a `<button>` element inside a `div[role="button"]` row when `isClickable` is true. This creates a nested-interactive-element pattern that violates ARIA guidelines and causes inconsistent behavior across browsers/assistive tech.

The inner "Review" `<button>` has no `onClick` of its own — clicking it does nothing different from clicking the row background, making it functionally redundant.

## Fix
- Replaced the nested `<button>` with a `<span>` that keeps the same visual styling but is non-interactive.
- The row's existing `role="button"` + `tabIndex` + `onClick` remains the sole interactive element.
- Updated the test to assert no `<button>` exists inside a clickable row.

## Acceptance criteria
- [x] A clickable `ActivityItem` row contains exactly one interactive element, not a button nested inside a `role="button"` container.
- [x] The "Review" label is preserved as a visual badge.
- [x] A test verifies there's no nested-interactive-element structure.

Fixes #810