### PR TITLE
fix: use shared useIntlFormatters in ProfilePage instead of hardcoded en-US

### DIFF
--- a/src/features/dashboard/pages/ProfilePage.test.tsx
+++ b/src/features/dashboard/pages/ProfilePage.test.tsx
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { I18nProvider } from '../../../shared/i18n/I18nProvider'
 
 // ---------------------------------------------------------------------------
 // Mock API client — declared BEFORE vi.mock() factory so they are in scope
@@ -109,9 +110,11 @@ function makeContributedProjects() {
 
 function renderPage(props: Partial<React.ComponentProps<typeof ProfilePage>> = {}) {
   return render(
-    <ThemeProvider>
-      <ProfilePage {...props} />
-    </ThemeProvider>
+    <I18nProvider>
+      <ThemeProvider>
+        <ProfilePage {...props} />
+      </ThemeProvider>
+    </I18nProvider>
   )
 }
 

--- a/src/features/dashboard/pages/ProfilePage.tsx
+++ b/src/features/dashboard/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { Search, Award, GitPullRequest, FolderGit2, Trophy, Github, Code, Globe,
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { useAuth } from '../../../shared/contexts/AuthContext';
+import { useIntlFormatters } from '../../../shared/i18n/useIntlFormatters';
 import { getUserProfile, getProjectsContributed, getProjectsLed, getProfileCalendar, getProfileActivity, getPublicProfile } from '../../../shared/api/client';
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
 import { LanguageIcon } from '../../../shared/components/LanguageIcon';
@@ -103,6 +104,7 @@ interface ProfilePageProps {
 export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProjectClick, onIssueClick }: ProfilePageProps) {
   const { theme } = useTheme();
   const { user } = useAuth();
+  const { formatDate } = useIntlFormatters();
   const [profileData, setProfileData] = useState<ProfileData | null>(null);
   const [viewingUser, setViewingUser] = useState<{ login: string; avatar_url?: string } | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -401,7 +403,7 @@ export function ProfilePage({ viewingUserId, viewingUserLogin, onBack, onProject
       title: activity.title,
       project: activity.project_name,
       project_id: activity.project_id,
-      date: new Date(activity.date).toLocaleDateString('en-US', { day: 'numeric', month: 'short' }),
+      date: formatDate(activity.date, { day: 'numeric', month: 'short' }),
       url: activity.url,
     });
   });


### PR DESCRIPTION
## Problem
`ProfilePage.tsx` hardcodes `'en-US'` in its activity date formatting:
```ts
new Date(activity.date).toLocaleDateString('en-US', { day: 'numeric', month: 'short' })
```

This is the third file found with this pattern — the project already has a shared `useIntlFormatters` hook in `src/shared/i18n/useIntlFormatters.ts` whose purpose is to centralize locale-aware date formatting.

## Fix
- Imported `useIntlFormatters` from `src/shared/i18n/useIntlFormatters.ts`
- Called `const { formatDate } = useIntlFormatters()` in the component body
- Replaced the hardcoded `toLocaleDateString('en-US', ...)` call with `formatDate(activity.date, { day: 'numeric', month: 'short' })`
- Wrapped the test render in `I18nProvider` to provide the required i18n context

## Acceptance criteria
- [x] `ProfilePage.tsx` no longer hardcodes `'en-US'` in its activity date formatting.
- [x] The activity date is formatted via the shared `useIntlFormatters` hook.
- [x] Existing default-locale rendered output is unchanged (formatDate with 'en-US' default locale produces identical output).

Fixes #798