### PR TITLE
fix: use shared useIntlFormatters in ContributionsTab instead of hardcoded en-US

### DIFF
--- a/src/features/dashboard/components/ContributionsTab.test.tsx
+++ b/src/features/dashboard/components/ContributionsTab.test.tsx
@@ -18,6 +18,13 @@ vi.mock('../../../shared/contexts/ThemeContext', () => ({
   }),
 }))
 
+vi.mock('../../../shared/i18n', () => ({
+  useIntlFormatters: () => ({
+    formatDate: (date: Date, options?: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat('en-US', options).format(date),
+  }),
+}))
+
 import { ContributionsTab } from './ContributionsTab'
 
 function renderContributionsTab() {

--- a/src/features/dashboard/components/ContributionsTab.tsx
+++ b/src/features/dashboard/components/ContributionsTab.tsx
@@ -15,6 +15,7 @@ import {
 import { getProfileContributions, type ProfileContribution } from '../../../shared/api/client'
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { useIntlFormatters, type UseIntlFormatters } from '../../../shared/i18n'
 
 type ContributionStatus = 'applied' | 'assigned' | 'pending' | 'complete'
 type RewardFilter = 'Rewarded' | 'Unrewarded'
@@ -133,7 +134,10 @@ const getRewardFilter = (contribution: ProfileContribution): RewardFilter => {
   return 'Unrewarded'
 }
 
-const formatContributionTime = (contribution: ProfileContribution) => {
+const formatContributionTime = (
+  contribution: ProfileContribution,
+  formatDate: UseIntlFormatters['formatDate']
+) => {
   const value =
     contribution.updated_at ||
     contribution.submitted_at ||
@@ -144,11 +148,11 @@ const formatContributionTime = (contribution: ProfileContribution) => {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return normalizeText(value, fallbackTime)
 
-  return new Intl.DateTimeFormat('en-US', {
+  return formatDate(date, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-  }).format(date)
+  })
 }
 
 /**
@@ -159,7 +163,7 @@ const formatContributionTime = (contribution: ProfileContribution) => {
  * supplied strings such as issue titles are escaped by default rather than
  * interpreted as HTML.
  */
-function normalizeContribution(contribution: ProfileContribution): ContributionCardData {
+function normalizeContribution(contribution: ProfileContribution, formatDate: UseIntlFormatters['formatDate']): ContributionCardData {
   const tag = normalizeText(getFirstLabel(contribution), fallbackTag)
 
   return {
@@ -167,7 +171,7 @@ function normalizeContribution(contribution: ProfileContribution): ContributionC
     title: normalizeText(contribution.title, fallbackTitle),
     status: normalizeStatus(contribution.status),
     badge: getBadge(contribution),
-    time: formatContributionTime(contribution),
+    time: formatContributionTime(contribution, formatDate),
     project: normalizeText(
       contribution.project_name ||
         contribution.project ||
@@ -429,6 +433,7 @@ function ContributionColumn({
 
 export function ContributionsTab() {
   const { theme } = useTheme()
+  const { formatDate } = useIntlFormatters()
   const [isFilterOpen, setIsFilterOpen] = useState(false)
   const [selectedProject, setSelectedProject] = useState('')
   const [projectSearchQuery, setProjectSearchQuery] = useState('')
@@ -444,7 +449,7 @@ export function ContributionsTab() {
       .then((response) => {
         setState({
           status: 'ok',
-          contributions: (response.contributions || []).map(normalizeContribution),
+          contributions: (response.contributions || []).map((c) => normalizeContribution(c, formatDate)),
         })
       })
       .catch(() => setState({ status: 'error' }))


### PR DESCRIPTION
## Summary

Replaces the hardcoded `Intl.DateTimeFormat('en-US', ...)` in `ContributionsTab.tsx` with the shared `useIntlFormatters()` hook, so contribution dates are formatted using the app's active locale instead of being locked to `en-US`.

## Changes

- **`ContributionsTab.tsx`**: Added import for `useIntlFormatters` and `UseIntlFormatters` type. Added `formatDate` parameter to `formatContributionTime` and `normalizeContribution` functions. Called `useIntlFormatters()` hook in the `ContributionsTab` component to get the locale-aware `formatDate` function. Replaced `new Intl.DateTimeFormat('en-US', ...).format(date)` with `formatDate(date, { ... })`.
- **`ContributionsTab.test.tsx`**: Added mock for `useIntlFormatters` to keep existing tests passing (all 10 previously-passing tests continue to pass).

## Acceptance Criteria

- [x] `ContributionsTab.tsx` no longer hardcodes `'en-US'` in its date formatting
- [x] Contribution dates are formatted via the shared `useIntlFormatters` hook
- [x] Existing default-locale rendered output is unchanged (all 10 existing tests pass)

Closes #797