### PR TITLE
fix: consolidate duplicated getPrefersReducedMotion logic into a shared hook

### DIFF
--- a/src/features/leaderboard/components/FallingPetals.tsx
+++ b/src/features/leaderboard/components/FallingPetals.tsx
@@ -1,27 +1,12 @@
-import { useState, useEffect } from 'react'
 import { Petal } from '../types'
+import { usePrefersReducedMotion } from '../../../shared/hooks/usePrefersReducedMotion'
 
 interface FallingPetalsProps {
   petals: Petal[]
 }
 
-function getPrefersReducedMotion() {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false
-  }
-
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
 export function FallingPetals({ petals }: FallingPetalsProps) {
-  const [reducedMotion, setReducedMotion] = useState(getPrefersReducedMotion)
-
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
-    mql.addEventListener('change', handler)
-    return () => mql.removeEventListener('change', handler)
-  }, [])
+  const reducedMotion = usePrefersReducedMotion()
 
   if (reducedMotion) return null
 

--- a/src/features/leaderboard/components/LeaderboardHero.tsx
+++ b/src/features/leaderboard/components/LeaderboardHero.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
 import { Crown, Trophy, Star } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { usePrefersReducedMotion } from '../../../shared/hooks/usePrefersReducedMotion'
 import { LeaderboardType } from '../types'
 
 interface LeaderboardHeroProps {
@@ -9,23 +9,9 @@ interface LeaderboardHeroProps {
   children: React.ReactNode
 }
 
-function getPrefersReducedMotion() {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false
-  }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
 export function LeaderboardHero({ leaderboardType, isLoaded, children }: LeaderboardHeroProps) {
   const { theme } = useTheme()
-  const [reducedMotion, setReducedMotion] = useState(getPrefersReducedMotion)
-
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
-    mql.addEventListener('change', handler)
-    return () => mql.removeEventListener('change', handler)
-  }, [])
+  const reducedMotion = usePrefersReducedMotion()
 
   return (
     <div

--- a/src/shared/hooks/usePrefersReducedMotion.ts
+++ b/src/shared/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Returns whether the user prefers reduced motion, based on the
+ * `(prefers-reduced-motion: reduce)` media query.
+ *
+ * Automatically listens for changes and updates the returned value.
+ * Returns `false` during SSR (no `window` / no `matchMedia`).
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false
+    }
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  })
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return reducedMotion
+}


### PR DESCRIPTION
## Summary

Consolidates the duplicated `getPrefersReducedMotion()` function and its accompanying `useState`/`matchMedia`-listener effect — which existed identically in both `FallingPetals.tsx` and `LeaderboardHero.tsx` — into a single shared `usePrefersReducedMotion()` hook at `src/shared/hooks/usePrefersReducedMotion.ts`.

## Changes

- **`src/shared/hooks/usePrefersReducedMotion.ts`** (new): Shared hook encapsulating the `prefers-reduced-motion` detection function, `useState` initializer, and `useEffect` matchMedia-change listener pattern.
- **`FallingPetals.tsx`**: Removed local `getPrefersReducedMotion` function and `useState`/`useEffect` logic. Now calls `usePrefersReducedMotion()`.
- **`LeaderboardHero.tsx`**: Removed local `getPrefersReducedMotion` function and `useState`/`useEffect` logic. Now calls `usePrefersReducedMotion()`.

## Acceptance Criteria

- [x] A single shared `usePrefersReducedMotion` hook exists
- [x] Both `FallingPetals.tsx` and `LeaderboardHero.tsx` use it instead of local duplicate implementations
- [x] All existing tests pass (69 passed, 2 skipped)

Closes #792