### PR TITLE
fix: consolidate duplicated isLogoUrl helper into a shared module

### DIFF
--- a/src/features/leaderboard/components/ProjectsPodium.tsx
+++ b/src/features/leaderboard/components/ProjectsPodium.tsx
@@ -1,10 +1,7 @@
 import { Medal, Trophy, Crown, Sparkles } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { ProjectData } from '../types'
-
-function isLogoUrl(logo: string): boolean {
-  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
-}
+import { isLogoUrl } from '../../../shared/utils/isLogoUrl'
 
 interface ProjectsPodiumProps {
   topThree: ProjectData[]

--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { ProjectData, FilterType } from '../types'
 import { getAvatarGradient } from '../data/leaderboardData'
 import { LeaderboardTableState } from './LeaderboardTableState'
+import { isLogoUrl } from '../../../shared/utils/isLogoUrl'
 
 interface ProjectsTableProps {
   data: ProjectData[]
@@ -22,10 +23,6 @@ const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
   if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
   if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
   return <Minus className="w-4 h-4 text-[#7a6b5a]" />
-}
-
-function isLogoUrl(logo: string): boolean {
-  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
 }
 
 /**

--- a/src/shared/utils/isLogoUrl.test.ts
+++ b/src/shared/utils/isLogoUrl.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { isLogoUrl } from './isLogoUrl'
+
+describe('isLogoUrl', () => {
+  it('returns true for http URLs', () => {
+    expect(isLogoUrl('http://example.com/logo.png')).toBe(true)
+  })
+
+  it('returns true for https URLs', () => {
+    expect(isLogoUrl('https://example.com/logo.png')).toBe(true)
+  })
+
+  it('returns false for relative paths', () => {
+    expect(isLogoUrl('/images/logo.png')).toBe(false)
+  })
+
+  it('returns false for emoji strings', () => {
+    expect(isLogoUrl('🚀')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isLogoUrl('')).toBe(false)
+  })
+})

--- a/src/shared/utils/isLogoUrl.ts
+++ b/src/shared/utils/isLogoUrl.ts
@@ -1,0 +1,7 @@
+/**
+ * Checks whether a string is a valid HTTP/HTTPS URL (for use as a logo source).
+ * Returns `false` for emoji, initials, or any non-URL string.
+ */
+export function isLogoUrl(logo: string): boolean {
+  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
+}


### PR DESCRIPTION
### Description

Consolidates the duplicated `isLogoUrl` helper that existed identically in both `ProjectsPodium.tsx` and `ProjectsTable.tsx` into a single shared module.

### Changes

- Created `src/shared/utils/isLogoUrl.ts` with the shared helper
- Added unit tests in `src/shared/utils/isLogoUrl.test.ts`
- Updated `ProjectsPodium.tsx` to import from the shared module, removed local copy
- Updated `ProjectsTable.tsx` to import from the shared module, removed local copy

### Verification

- All 12 leaderboard test files pass (74 passed, 2 skipped — same as baseline)
- New `isLogoUrl` unit test covers http, https, relative paths, emoji, and empty string

Closes #790