### PR TITLE
fix: remove per-render debug log from EcosystemsPage ecosystem card map

### DIFF
--- a/src/features/dashboard/pages/EcosystemsPage.tsx
+++ b/src/features/dashboard/pages/EcosystemsPage.tsx
@@ -410,7 +410,6 @@ export function EcosystemsPage({ onEcosystemClick }: EcosystemsPageProps) {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-5">
           {filteredEcosystems.map((ecosystem) => {
-            logger.debug('Rendering ecosystem:', ecosystem)
             return (
               <div
                 key={ecosystem.id}


### PR DESCRIPTION
## Summary

Removes a `logger.debug('Rendering ecosystem:', ecosystem)` call that fires once per ecosystem card, per render, from inside the `filteredEcosystems.map()` render callback in `EcosystemsPage.tsx`.

## Problem

- The debug log fires once per ecosystem card, per render — including re-renders triggered by search/filter changes, theme toggles, or parent state updates
- This is unnecessary console noise in local/staging dev sessions
- Logging the full ecosystem object per row on every render is a code-hygiene concern

## Changes

- Removed the `logger.debug('Rendering ecosystem:', ecosystem)` call from line 413 of `EcosystemsPage.tsx`
- All other `logger.debug` calls in the same file (which live inside the data-fetch effect and only fire once per fetch) are unchanged

## Verification

- ✅ Existing EcosystemsPage tests pass (the 1 pre-existing failure in `shows no-match message when search finds nothing` is an i18n issue unrelated to this change)
- ✅ Ecosystem card rendering is otherwise unchanged

Closes #794