### PR TITLE
perf: use a stable trend-icon lookup in ProjectsTable, matching ContributorsTable

### DIFF
--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -18,11 +18,16 @@ interface ProjectsTableProps {
   onRetry?: () => void
 }
 
-const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
-  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
-  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
-  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
-}
+// ---------------------------------------------------------------------------
+// Stable icon map - avoids creating new JSX nodes on every getTrendIcon call.
+// ---------------------------------------------------------------------------
+const TREND_ICONS = {
+  up: <TrendingUp className="w-4 h-4 text-green-600" />,
+  down: <TrendingDown className="w-4 h-4 text-red-600" />,
+  same: <Minus className="w-4 h-4 text-[#7a6b5a]" />,
+} as const
+
+const getTrendIcon = (trend: 'up' | 'down' | 'same') => TREND_ICONS[trend]
 
 function isLogoUrl(logo: string): boolean {
   return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))


### PR DESCRIPTION
## Summary

Applies the same `TREND_ICONS` stable lookup pattern from `ContributorsTable.tsx` to `ProjectsTable.tsx`, avoiding the creation of new JSX elements on every `getTrendIcon` call.

## Problem

`ProjectsTable.tsx`'s `getTrendIcon` created a fresh JSX element on every call:
```tsx
const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
}
```

This is called once per row, per render — unnecessary allocations that the sibling `ContributorsTable.tsx` already documents as intentional to avoid.

## Changes

- Added a module-level `TREND_ICONS` const with the same icons as `ContributorsTable.tsx`'s
- Changed `getTrendIcon` to use the stable lookup: `TREND_ICONS[trend]`
- Added the same explanatory comment matching `ContributorsTable.tsx`

## Verification

- ✅ Rendered trend icons are identical (same icons, same classes)
- ✅ Pattern now matches the sibling `ContributorsTable.tsx` exactly

Closes #791