### PR TITLE
chore: remove unused Material-UI and Emotion dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@emotion/react": "11.14.0",
-    "@emotion/styled": "11.14.1",
     "@hookform/resolvers": "^5.5.7",
-    "@mui/icons-material": "7.3.5",
-    "@mui/material": "7.3.5",
     "@popperjs/core": "2.11.8",
     "@radix-ui/react-accordion": "1.2.20",
     "@radix-ui/react-alert-dialog": "1.1.23",


### PR DESCRIPTION
### Summary

Removes four unused Material-UI and Emotion dependencies from `package.json`:

- `@mui/material`
- `@mui/icons-material`
- `@emotion/react`
- `@emotion/styled`

### Why

These packages are listed as direct dependencies but are never imported anywhere in `src/`. The entire app uses Tailwind CSS plus Radix-based components — no Material Design surfaces exist. Carrying these large unused packages adds install time, `node_modules` size, and dependency-audit surface for zero benefit.

### Verification

- `grep -rn '@mui/\|@emotion/' src/` returns zero matches
- The four packages have been removed from `package.json` dependencies
- Build failure is a **pre-existing project issue** (`lucide-react` 1.23.0 missing `Github` export) — confirmed by running `npm run build` on the base branch before making changes, which produces the same error

Closes #806