### PR TITLE
fix: use proper i18n interpolation for EcosystemsPage filtered-count message

### DIFF
--- a/src/features/dashboard/pages/EcosystemsPage.test.tsx
+++ b/src/features/dashboard/pages/EcosystemsPage.test.tsx
@@ -363,6 +363,15 @@ describe('EcosystemsPage — initial load', () => {
     expect(screen.getByText('No ecosystems found matching your search.')).toBeInTheDocument()
   })
 
+  it('shows filtered count when search filters out some ecosystems', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Ecosystem 0')).toBeInTheDocument())
+    await userEvent.type(screen.getByPlaceholderText('Search ecosystems...'), 'zzznomatch')
+    await waitFor(() => expect(screen.getByText(/Filtered from/)).toBeInTheDocument())
+    // With 2 ecosystems in the fixture, the plural form should be shown
+    expect(screen.getByText(/Filtered from 2 ecosystems/)).toBeInTheDocument()
+  })
+
   it('re-fetches ecosystems when "ecosystems-updated" event fires', async () => {
     renderPage()
     await waitFor(() => expect(mockGetEcosystems).toHaveBeenCalledTimes(1))

--- a/src/features/dashboard/pages/EcosystemsPage.tsx
+++ b/src/features/dashboard/pages/EcosystemsPage.tsx
@@ -403,7 +403,7 @@ export function EcosystemsPage({ onEcosystemClick }: EcosystemsPageProps) {
           </p>
           {!isLoading && ecosystems.length > 0 && (
             <div className="mt-2 text-[11px] md:text-xs opacity-70">
-              {t('ecosystems.filteredCount').replace('{count}', String(ecosystems.length))}
+              {t('ecosystems.filteredCount', { count: ecosystems.length })}
             </div>
           )}
         </div>

--- a/src/shared/i18n/messages.ts
+++ b/src/shared/i18n/messages.ts
@@ -175,7 +175,7 @@ export const en = {
   'ecosystems.searchPlaceholder': 'Search ecosystems...',
   'ecosystems.empty.noMatch': 'No ecosystems found matching your search.',
   'ecosystems.empty.none': 'No ecosystems available yet.',
-  'ecosystems.filteredCount': '(Filtered from {count} ecosystems)',
+  'ecosystems.filteredCount': '({count, plural, one {Filtered from # ecosystem} other {Filtered from # ecosystems}})',
   'ecosystems.card.projects': 'Projects',
   'ecosystems.card.contributors': 'Contributors',
   'ecosystems.card.visitWebsite': 'Visit Website',


### PR DESCRIPTION
## Description

Fixes #795

Replaces the `.replace()` post-processing in `EcosystemsPage.tsx` with the proper i18n `values` parameter, and updates the message catalog entry to use ICU plural syntax.

### Changes

1. **`src/shared/i18n/messages.ts`**: Updated `ecosystems.filteredCount` message to use ICU plural format (`{count, plural, one {...} other {...}}`)
2. **`src/features/dashboard/pages/EcosystemsPage.tsx`**: Replaced `t('ecosystems.filteredCount').replace('{count}', String(ecosystems.length))` with `t('ecosystems.filteredCount', { count: ecosystems.length })`
3. **`src/features/dashboard/pages/EcosystemsPage.test.tsx`**: Added test verifying the filtered count appears correctly when search filters out ecosystems

### Testing

- All 34 existing tests pass
- New test verifies the filtered count uses proper i18n interpolation