### PR TITLE
fix(security): actually strip sensitive fields before persisting billing profiles

### DIFF
--- a/src/features/settings/contexts/BillingProfilesContext.test.tsx
+++ b/src/features/settings/contexts/BillingProfilesContext.test.tsx
@@ -83,6 +83,35 @@ describe('BillingProfilesContext', () => {
     expect(result.current.profiles).toEqual([company]);
   });
 
+  it('strips sensitive fields before persisting to localStorage', () => {
+    const profileWithSensitiveData: BillingProfile = {
+      id: 3,
+      name: 'Sensitive',
+      type: 'individual',
+      status: 'verified',
+      taxId: '123-45-6789',
+      paymentMethods: [{ id: 1, ecosystem: 'stellar', cryptoType: 'usdc', walletAddress: 'GA...', isDefault: true, createdAt: '2026-01-01' }],
+      invoices: [{ id: 'inv-1', invoiceNumber: 'INV-001', date: '2026-01-01', amount: 100, currency: 'USD', status: 'paid', description: 'Test', billingPeriod: '2026-Q1' }],
+    };
+
+    const { result } = renderHook(() => useBillingProfiles(), { wrapper });
+
+    act(() => expect(result.current.addProfile(profileWithSensitiveData)).toBe(true));
+
+    // In-memory state retains the full data
+    expect(result.current.profiles[0].taxId).toBe('123-45-6789');
+    expect(result.current.profiles[0].paymentMethods).toHaveLength(1);
+    expect(result.current.profiles[0].invoices).toHaveLength(1);
+
+    // Persisted data has sensitive fields stripped
+    const stored = JSON.parse(localStorage.getItem('billing_profiles')!);
+    expect(stored[0].taxId).toBeUndefined();
+    expect(stored[0].paymentMethods).toBeUndefined();
+    expect(stored[0].invoices).toBeUndefined();
+    // Non-sensitive fields are still present
+    expect(stored[0].name).toBe('Sensitive');
+  });
+
   it('rolls back a create that cannot be persisted without logging sensitive data', () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
     const { result } = renderHook(() => useBillingProfiles(), { wrapper });

--- a/src/features/settings/contexts/BillingProfilesContext.tsx
+++ b/src/features/settings/contexts/BillingProfilesContext.tsx
@@ -30,6 +30,17 @@ function logStorageFailure(operation: 'load' | 'save') {
   logger.error(`Billing profile ${operation} failed`)
 }
 
+/**
+ * Returns a shallow copy of `profile` with sensitive fields (taxId,
+ * paymentMethods, invoices) excluded. The in-memory React state retains
+ * the full data for the current session; only the persisted copy is
+ * sanitised.
+ */
+function toPersistableProfile(profile: BillingProfile): Omit<BillingProfile, 'taxId' | 'paymentMethods' | 'invoices'> {
+  const { taxId, paymentMethods, invoices, ...safe } = profile
+  return safe
+}
+
 function loadProfilesFromStorage(): BillingProfile[] {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
@@ -42,7 +53,7 @@ function loadProfilesFromStorage(): BillingProfile[] {
 
 function saveProfilesToStorage(profiles: BillingProfile[]): boolean {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles.map(toPersistableProfile)))
     return true
   } catch {
     logStorageFailure('save')


### PR DESCRIPTION
## Description

Fixes #803

Implements the documented (but never actually implemented) privacy guarantee: sensitive fields (`taxId`, `paymentMethods`, `invoices`) are now stripped before every `localStorage` write.

### Changes

1. **`BillingProfilesContext.tsx`**: Added `toPersistableProfile()` helper that destructures and omits `taxId`, `paymentMethods`, and `invoices` from each profile object before serialization. Updated `saveProfilesToStorage` to map profiles through this helper.

2. **`BillingProfilesContext.test.tsx`**: Added test verifying that:
   - In-memory state retains the full profile data (including `taxId`, `paymentMethods`, `invoices`)
   - Persisted `localStorage` data has these fields stripped
   - Non-sensitive fields (e.g. `name`) are still present in the persisted copy

### Security

This closes a real gap between documented and actual behavior: tax identification numbers were being persisted in plaintext client-side storage despite explicit code comments claiming otherwise.