### PR TITLE
fix: add aria-label to AdminPage icon-only Edit/Delete buttons

### DIFF
--- a/src/features/admin/pages/AdminPage.test.tsx
+++ b/src/features/admin/pages/AdminPage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+
+const mockGetAdminEcosystems = vi.fn()
+const mockGetAdminOpenSourceWeekEvents = vi.fn()
+
+vi.mock('../../../shared/api/client', () => ({
+  getAdminEcosystems: (...a: unknown[]) => mockGetAdminEcosystems(...a),
+  getAdminOpenSourceWeekEvents: (...a: unknown[]) => mockGetAdminOpenSourceWeekEvents(...a),
+  createEcosystem: vi.fn(),
+  getAdminEcosystem: vi.fn(),
+  deleteEcosystem: vi.fn(),
+  updateEcosystem: vi.fn(),
+  createOpenSourceWeekEvent: vi.fn(),
+  deleteOpenSourceWeekEvent: vi.fn(),
+}))
+
+vi.mock('react-intl', () => ({
+  IntlProvider: ({ children }: { children: React.ReactNode }) => children,
+  useIntl: () => ({ formatMessage: ({ id }: { id: string }) => id }),
+  FormattedMessage: ({ id }: { id: string }) => id,
+  defineMessages: (msgs: Record<string, unknown>) => msgs,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+beforeEach(() => {
+  mockGetAdminEcosystems.mockReset()
+  mockGetAdminOpenSourceWeekEvents.mockReset()
+})
+
+describe('AdminPage — icon-only button aria-labels', () => {
+  it('renders ecosystem edit/delete buttons with aria-label', async () => {
+    mockGetAdminEcosystems.mockResolvedValue({
+      ecosystems: [
+        {
+          id: 'eco-1',
+          slug: 'test-eco',
+          name: 'Test Ecosystem',
+          description: 'A test ecosystem',
+          logo_url: null,
+          website_url: null,
+          status: 'active',
+          project_count: 0,
+          user_count: 0,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+    mockGetAdminOpenSourceWeekEvents.mockResolvedValue({ events: [] })
+
+    const { AdminPage } = await import('./AdminPage')
+
+    render(
+      <ThemeProvider>
+        <AdminPage />
+      </ThemeProvider>
+    )
+
+    // Wait for the ecosystem to render and check aria-labels
+    const editButton = await screen.findByRole('button', { name: 'Edit ecosystem' })
+    expect(editButton).toBeInTheDocument()
+    expect(editButton).toHaveAttribute('aria-label', 'Edit ecosystem')
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete ecosystem' })
+    expect(deleteButton).toBeInTheDocument()
+    expect(deleteButton).toHaveAttribute('aria-label', 'Delete ecosystem')
+  })
+
+  it('renders event delete button with aria-label', async () => {
+    mockGetAdminEcosystems.mockResolvedValue({ ecosystems: [] })
+    mockGetAdminOpenSourceWeekEvents.mockResolvedValue({
+      events: [
+        {
+          id: 'evt-1',
+          title: 'Test Event',
+          description: null,
+          location: null,
+          status: 'upcoming',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-07T00:00:00Z',
+        },
+      ],
+    })
+
+    const { AdminPage } = await import('./AdminPage')
+
+    render(
+      <ThemeProvider>
+        <AdminPage />
+      </ThemeProvider>
+    )
+
+    // Wait for the event to render and check aria-label
+    const deleteEventButton = await screen.findByRole('button', { name: 'Delete event' })
+    expect(deleteEventButton).toBeInTheDocument()
+    expect(deleteEventButton).toHaveAttribute('aria-label', 'Delete event')
+  })
+})

--- a/src/features/admin/pages/AdminPage.tsx
+++ b/src/features/admin/pages/AdminPage.tsx
@@ -770,6 +770,7 @@ export function AdminPage() {
                             : 'hover:bg-amber-500/30 text-amber-600'
                             }`}
                           title="Edit ecosystem"
+                          aria-label="Edit ecosystem"
                         >
                           <Pencil className="w-4 h-4" />
                         </button>
@@ -783,6 +784,7 @@ export function AdminPage() {
                               : 'hover:bg-red-500/30 text-red-600'
                             }`}
                           title="Delete ecosystem"
+                          aria-label="Delete ecosystem"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
@@ -927,6 +929,7 @@ export function AdminPage() {
                     className={`p-2 rounded-[10px] transition-all ${theme === 'dark' ? 'hover:bg-red-500/20 text-red-400' : 'hover:bg-red-500/30 text-red-600'
                       }`}
                     title="Delete event"
+                    aria-label="Delete event"
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
## Description

**Issue**: #770

`AdminPage.tsx`'s ecosystem Edit/Delete buttons and Open Source Week event Delete button used the `title` HTML attribute as their only accessible-name mechanism. The `title` attribute is not a reliable accessible-name source — it's not announced consistently across screen reader/browser combinations, and it's undiscoverable without a mouse hover.

## Changes

1. **`src/features/admin/pages/AdminPage.tsx`**: Added `aria-label="Edit ecosystem"`, `aria-label="Delete ecosystem"`, and `aria-label="Delete event"` to the three icon-only action buttons, while keeping the existing `title` attributes as supplementary hover tooltips.

2. **`src/features/admin/pages/AdminPage.test.tsx`**: Added tests verifying each icon-only button has the correct `aria-label` attribute.

## Verification

- ✅ New test: "renders ecosystem edit/delete buttons with aria-label" — passes
- ✅ New test: "renders event delete button with aria-label" — passes
- ✅ All existing tests continue to pass