### PR TITLE
fix: type BillingTab's KYC extracted-data mapping instead of any

### DIFF
--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -239,7 +239,20 @@ export function BillingTab() {
     }
   }
 
-  const updateProfileWithKYCData = (extracted: any) => {
+  interface KycExtractedData {
+    first_name?: string
+    last_name?: string
+    full_name?: string
+    address?: string
+    city?: string
+    postal_code?: string
+    postalCode?: string
+    country?: string
+    document_number?: string
+    tax_id?: string
+  }
+
+  const updateProfileWithKYCData = (extracted: KycExtractedData) => {
     if (!selectedProfile) return
 
     // Preserve the original profile name


### PR DESCRIPTION
## Summary

Replaced the `any` type on `updateProfileWithKYCData`'s `extracted` parameter with a properly defined `KycExtractedData` interface. This ensures the compiler validates field access against the known KYC provider response shape, preventing silent empty-string population if the provider's response shape changes.

## Changes

- Defined a `KycExtractedData` interface covering all fields accessed by the function (`first_name`, `last_name`, `full_name`, `address`, `city`, `postal_code`, `postalCode`, `country`, `document_number`, `tax_id`)
- Changed `extracted: any` → `extracted: KycExtractedData`

## Verification

- ✅ `tsc --noEmit` passes with no errors
- ✅ All existing tests pass (pre-existing failures unchanged)
- ✅ Existing KYC-verification behavior is unchanged

Closes #805