### PR TITLE
fix: type nav/search-result icons as LucideIcon instead of any

### DIFF
--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -16,6 +16,7 @@ import {
   Shield,
   X,
   Menu,
+  type LucideIcon,
 } from 'lucide-react'
 import { useModeAnimation } from 'react-theme-switch-animation'
 import { useAuth } from '../../shared/contexts/AuthContext'
@@ -161,8 +162,15 @@ export function DashboardLayout() {
     }
   }
 
+  interface NavItem {
+    id: string
+    icon: LucideIcon
+    label: string
+    path: string
+  }
+
   // Role-based navigation items
-  const navItems = [
+  const navItems: NavItem[] = [
     {
       id: 'discover',
       icon: Compass,
@@ -303,7 +311,7 @@ export function DashboardLayout() {
             <nav className={`space-y-2 mb-auto ${isSidebarCollapsed ? 'px-[8px]' : 'px-2'}`}>
               {navItems.map((item) => {
                 const isActive = currentPage === item.id
-                const Icon = item.icon as any
+                const Icon = item.icon
                 return (
                   <Link
                     key={item.id}

--- a/src/features/dashboard/pages/SearchPage.tsx
+++ b/src/features/dashboard/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Search, ArrowRight, X, FileText, FolderGit2, User, ChevronLeft } from 'lucide-react'
+import { Search, ArrowRight, X, FileText, FolderGit2, User, ChevronLeft, type LucideIcon } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue'
 
@@ -31,7 +31,7 @@ interface SearchResult {
   type: 'issue' | 'project' | 'contributor'
   title: string
   subtitle?: string
-  icon: any
+  icon: LucideIcon
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaced `any` type casts in `DashboardLayout.tsx` and `SearchPage.tsx` with the proper `LucideIcon` type from `lucide-react`, improving type safety in two actively-used components.

## Changes

- **`DashboardLayout.tsx`**: Defined a `NavItem` interface with `icon: LucideIcon`, typed the `navItems` array with it, and removed the `as any` cast from the render loop
- **`SearchPage.tsx`**: Changed `SearchResult.icon` from `any` to `LucideIcon`

## Verification

- ✅ `tsc --noEmit` passes with no errors
- ✅ All existing tests pass (pre-existing failures unchanged)

Closes #783