### PR TITLE
fix: wire up DiscoverPage favorite button to a real toggle state

### DIFF
--- a/src/features/dashboard/pages/DiscoverPage.test.tsx
+++ b/src/features/dashboard/pages/DiscoverPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
 import { renderWithTheme } from '../../../test/renderWithTheme'
 import { DiscoverPage, getDaysLeft } from './DiscoverPage'
@@ -783,5 +783,69 @@ describe('DiscoverPage Infinite Scroll and Load More', () => {
     // After all content is loaded, there should be no spinning loader
     const loader = screen.queryByTestId(/loader|spinner|loading/i)
     expect(loader).not.toBeInTheDocument()
+  })
+})
+
+describe('DiscoverPage - favorite button', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('toggles favorite state when the heart button is clicked', async () => {
+    const mockProjects = [
+      {
+        id: 'proj-1',
+        github_full_name: 'owner/repo-1',
+        stars_count: 100,
+        forks_count: 50,
+        open_issues_count: 5,
+        description: 'Repo 1 description',
+        tags: ['React', 'TypeScript'],
+        ecosystem_name: 'Stellar',
+      },
+    ]
+
+    const mockIssues = {
+      issues: [
+        {
+          github_issue_id: 101,
+          number: 1,
+          state: 'open',
+          title: 'Issue 1',
+          description: 'Issue 1 desc',
+          author_login: 'alice',
+          labels: [{ name: 'good first issue' }],
+          url: 'https://github.com/owner/repo-1/issues/1',
+          updated_at: '2026-06-26T12:00:00Z',
+          last_seen_at: '2026-06-26T12:00:00Z',
+          deadline: '2026-06-30T18:00:00Z',
+        },
+      ],
+    }
+
+    mockGetRecommendedProjects.mockResolvedValue({ projects: mockProjects })
+    mockGetPublicProjectIssues.mockResolvedValue(mockIssues)
+
+    renderWithTheme(<DiscoverPage />)
+
+    // Wait for projects to load
+    await waitFor(() => {
+      expect(screen.getByText('repo-1')).toBeInTheDocument()
+    })
+
+    // Find the favorite button — initially "Add to favorites"
+    const favButton = screen.getByRole('button', { name: /add to favorites/i })
+    expect(favButton).toBeInTheDocument()
+    expect(favButton).toHaveAttribute('aria-pressed', 'false')
+
+    // Click to favorite
+    fireEvent.click(favButton)
+    expect(favButton).toHaveAttribute('aria-label', 'Remove from favorites')
+    expect(favButton).toHaveAttribute('aria-pressed', 'true')
+
+    // Click again to unfavorite
+    fireEvent.click(favButton)
+    expect(favButton).toHaveAttribute('aria-label', 'Add to favorites')
+    expect(favButton).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/src/features/dashboard/pages/DiscoverPage.tsx
+++ b/src/features/dashboard/pages/DiscoverPage.tsx
@@ -204,6 +204,7 @@ export function DiscoverPage({ onGoToBilling, onGoToOpenSourceWeek }: DiscoverPa
     projectId?: string
   } | null>(null)
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
+  const [favoritedProjects, setFavoritedProjects] = useState<Set<string>>(new Set())
 
   // Use optimistic data hook for projects with 30-second cache
   const {
@@ -527,11 +528,26 @@ export function DiscoverPage({ onGoToBilling, onGoToOpenSourceWeek }: DiscoverPa
                     </div>
                   )}
                   <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setFavoritedProjects((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(project.id)) {
+                          next.delete(project.id)
+                        } else {
+                          next.add(project.id)
+                        }
+                        return next
+                      })
+                    }}
                     className="text-[#c9983a] hover:text-[#a67c2e] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#c9983a] rounded-lg"
-                    aria-label="Add to favorites"
-                    aria-pressed="false"
+                    aria-label={favoritedProjects.has(project.id) ? 'Remove from favorites' : 'Add to favorites'}
+                    aria-pressed={favoritedProjects.has(project.id)}
                   >
-                    <Heart className="w-5 h-5" aria-hidden="true" />
+                    <Heart
+                      className={`w-5 h-5 ${favoritedProjects.has(project.id) ? 'fill-[#c9983a]' : ''}`}
+                      aria-hidden="true"
+                    />
                   </button>
                 </div>
 


### PR DESCRIPTION
## Description

Fixes #759 — The "Add to favorites" heart button on project cards in DiscoverPage was a static placeholder with no toggle behavior.

### Changes

1. **Added `favoritedProjects` state** — A `Set<string>` keyed by project ID tracks which projects are favorited.

2. **Wired `onClick` handler** — Clicking the heart button toggles the project's favorited state. Uses `e.stopPropagation()` so the click doesn't trigger the parent card's navigation.

3. **Dynamic `aria-label` and `aria-pressed`** — `aria-label` switches between "Add to favorites" and "Remove from favorites". `aria-pressed` reflects the actual state (not a hardcoded `"false"`).

4. **Visual feedback** — The Heart icon fills with `fill-[#c9983a]` (gold) when favorited, empty outline when not.

5. **Test added** — Verifies the toggle works correctly: initial state → favorite → unfavorite, checking aria-label and aria-pressed at each step.

### Testing

- ✅ Favorite button toggles correctly when clicked
- ✅ aria-label switches between "Add to favorites" / "Remove from favorites"
- ✅ aria-pressed reflects the real state
- ✅ All existing tests still pass (4 pre-existing getDaysLeft timezone failures are unrelated)
