### PR TITLE
feat: add pagination utils for page ranges and clamping

### DIFF
--- a/src/shared/utils/pagination.test.ts
+++ b/src/shared/utils/pagination.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from 'vitest'
 import {
   DEFAULT_PAGE_LIMIT,
   MAX_PAGE_LIMIT,
@@ -7,103 +7,150 @@ import {
   clampOffset,
   hasMoreByTotal,
   hasMoreByPageSize,
-} from "./pagination";
+  computePageRanges,
+  clampCurrentPage,
+} from './pagination'
 
-describe("clampLimit", () => {
-  it("returns the requested limit when within bounds", () => {
-    expect(clampLimit(25)).toBe(25);
-    expect(clampLimit(1)).toBe(1);
-    expect(clampLimit(MAX_PAGE_LIMIT)).toBe(MAX_PAGE_LIMIT);
-  });
+describe('clampLimit', () => {
+  it('returns the requested limit when within bounds', () => {
+    expect(clampLimit(25)).toBe(25)
+    expect(clampLimit(1)).toBe(1)
+    expect(clampLimit(MAX_PAGE_LIMIT)).toBe(MAX_PAGE_LIMIT)
+  })
 
-  it("caps oversized limits at MAX_PAGE_LIMIT (anti-abuse)", () => {
-    expect(clampLimit(MAX_PAGE_LIMIT + 1)).toBe(MAX_PAGE_LIMIT);
-    expect(clampLimit(1_000_000)).toBe(MAX_PAGE_LIMIT);
-    expect(clampLimit(Number.MAX_SAFE_INTEGER)).toBe(MAX_PAGE_LIMIT);
-  });
+  it('caps oversized limits at MAX_PAGE_LIMIT (anti-abuse)', () => {
+    expect(clampLimit(MAX_PAGE_LIMIT + 1)).toBe(MAX_PAGE_LIMIT)
+    expect(clampLimit(1_000_000)).toBe(MAX_PAGE_LIMIT)
+    expect(clampLimit(Number.MAX_SAFE_INTEGER)).toBe(MAX_PAGE_LIMIT)
+  })
 
-  it("falls back for missing / non-positive / non-finite input", () => {
-    expect(clampLimit(undefined)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(null)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(0)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(-5)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(NaN)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(Infinity)).toBe(DEFAULT_PAGE_LIMIT);
-  });
+  it('falls back for missing / non-positive / non-finite input', () => {
+    expect(clampLimit(undefined)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(null)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(0)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(-5)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(NaN)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(Infinity)).toBe(DEFAULT_PAGE_LIMIT)
+  })
 
-  it("floors fractional values", () => {
-    expect(clampLimit(10.9)).toBe(10);
-  });
+  it('floors fractional values', () => {
+    expect(clampLimit(10.9)).toBe(10)
+  })
 
-  it("honours a custom fallback but still clamps it to bounds", () => {
-    expect(clampLimit(undefined, 5)).toBe(5);
-    expect(clampLimit(0, 20)).toBe(20);
-    expect(clampLimit(undefined, 0)).toBe(DEFAULT_PAGE_LIMIT);
-    expect(clampLimit(undefined, MAX_PAGE_LIMIT + 50)).toBe(MAX_PAGE_LIMIT);
-  });
-});
+  it('honours a custom fallback but still clamps it to bounds', () => {
+    expect(clampLimit(undefined, 5)).toBe(5)
+    expect(clampLimit(0, 20)).toBe(20)
+    expect(clampLimit(undefined, 0)).toBe(DEFAULT_PAGE_LIMIT)
+    expect(clampLimit(undefined, MAX_PAGE_LIMIT + 50)).toBe(MAX_PAGE_LIMIT)
+  })
+})
 
-describe("clampOffset", () => {
-  it("returns the requested offset when within bounds", () => {
-    expect(clampOffset(0)).toBe(0);
-    expect(clampOffset(120)).toBe(120);
-    expect(clampOffset(MAX_OFFSET)).toBe(MAX_OFFSET);
-  });
+describe('clampOffset', () => {
+  it('returns the requested offset when within bounds', () => {
+    expect(clampOffset(0)).toBe(0)
+    expect(clampOffset(120)).toBe(120)
+    expect(clampOffset(MAX_OFFSET)).toBe(MAX_OFFSET)
+  })
 
-  it("caps oversized offsets at MAX_OFFSET (anti-abuse)", () => {
-    expect(clampOffset(MAX_OFFSET + 1)).toBe(MAX_OFFSET);
-    expect(clampOffset(999_999_999)).toBe(MAX_OFFSET);
-  });
+  it('caps oversized offsets at MAX_OFFSET (anti-abuse)', () => {
+    expect(clampOffset(MAX_OFFSET + 1)).toBe(MAX_OFFSET)
+    expect(clampOffset(999_999_999)).toBe(MAX_OFFSET)
+  })
 
-  it("coerces negative / non-finite / missing input to 0", () => {
-    expect(clampOffset(-1)).toBe(0);
-    expect(clampOffset(-1000)).toBe(0);
-    expect(clampOffset(NaN)).toBe(0);
-    expect(clampOffset(Infinity)).toBe(0);
-    expect(clampOffset(undefined)).toBe(0);
-    expect(clampOffset(null)).toBe(0);
-  });
+  it('coerces negative / non-finite / missing input to 0', () => {
+    expect(clampOffset(-1)).toBe(0)
+    expect(clampOffset(-1000)).toBe(0)
+    expect(clampOffset(NaN)).toBe(0)
+    expect(clampOffset(Infinity)).toBe(0)
+    expect(clampOffset(undefined)).toBe(0)
+    expect(clampOffset(null)).toBe(0)
+  })
 
-  it("floors fractional values", () => {
-    expect(clampOffset(10.7)).toBe(10);
-  });
-});
+  it('floors fractional values', () => {
+    expect(clampOffset(10.7)).toBe(10)
+  })
+})
 
-describe("hasMoreByTotal", () => {
-  it("reports more while loaded is below total", () => {
-    expect(hasMoreByTotal(10, 50)).toBe(true);
-  });
+describe('hasMoreByTotal', () => {
+  it('reports more while loaded is below total', () => {
+    expect(hasMoreByTotal(10, 50)).toBe(true)
+  })
 
-  it("stops at and beyond the total (offset + loaded >= total)", () => {
-    expect(hasMoreByTotal(50, 50)).toBe(false);
-    expect(hasMoreByTotal(60, 50)).toBe(false);
-  });
+  it('stops at and beyond the total (offset + loaded >= total)', () => {
+    expect(hasMoreByTotal(50, 50)).toBe(false)
+    expect(hasMoreByTotal(60, 50)).toBe(false)
+  })
 
-  it("returns false for empty / invalid totals", () => {
-    expect(hasMoreByTotal(0, 0)).toBe(false);
-    expect(hasMoreByTotal(0, -1)).toBe(false);
-    expect(hasMoreByTotal(NaN, 10)).toBe(false);
-    expect(hasMoreByTotal(5, NaN)).toBe(false);
-  });
-});
+  it('returns false for empty / invalid totals', () => {
+    expect(hasMoreByTotal(0, 0)).toBe(false)
+    expect(hasMoreByTotal(0, -1)).toBe(false)
+    expect(hasMoreByTotal(NaN, 10)).toBe(false)
+    expect(hasMoreByTotal(5, NaN)).toBe(false)
+  })
+})
 
-describe("hasMoreByPageSize", () => {
-  it("reports more when the last page was full", () => {
-    expect(hasMoreByPageSize(10, 10)).toBe(true);
-  });
+describe('hasMoreByPageSize', () => {
+  it('reports more when the last page was full', () => {
+    expect(hasMoreByPageSize(10, 10)).toBe(true)
+  })
 
-  it("reports no more on a short or empty page (end of list)", () => {
-    expect(hasMoreByPageSize(4, 10)).toBe(false);
-    expect(hasMoreByPageSize(0, 10)).toBe(false);
-  });
+  it('reports no more on a short or empty page (end of list)', () => {
+    expect(hasMoreByPageSize(4, 10)).toBe(false)
+    expect(hasMoreByPageSize(0, 10)).toBe(false)
+  })
 
-  it("uses the clamped limit when comparing", () => {
+  it('uses the clamped limit when comparing', () => {
     // An absurd limit is clamped to MAX_PAGE_LIMIT before comparison.
-    expect(hasMoreByPageSize(MAX_PAGE_LIMIT, 1_000_000)).toBe(true);
-  });
+    expect(hasMoreByPageSize(MAX_PAGE_LIMIT, 1_000_000)).toBe(true)
+  })
 
-  it("returns false for invalid received counts", () => {
-    expect(hasMoreByPageSize(NaN, 10)).toBe(false);
-    expect(hasMoreByPageSize(-3, 10)).toBe(false);
-  });
-});
+  it('returns false for invalid received counts', () => {
+    expect(hasMoreByPageSize(NaN, 10)).toBe(false)
+    expect(hasMoreByPageSize(-3, 10)).toBe(false)
+  })
+})
+
+describe('computePageRanges', () => {
+  it('covers zero items by returning a single page', () => {
+    expect(computePageRanges(1, 0, 10)).toEqual([1])
+  })
+
+  it('covers exactly one page', () => {
+    expect(computePageRanges(1, 10, 10)).toEqual([1])
+  })
+
+  it('covers exactly-divisible item counts', () => {
+    expect(computePageRanges(1, 20, 10)).toEqual([1, 2])
+  })
+
+  it('covers a partially-filled last page', () => {
+    expect(computePageRanges(1, 25, 10)).toEqual([1, 2, 3])
+  })
+
+  it('asserts page-number label generation (ellipsis truncation) is correct for many pages', () => {
+    // Current page is near the start
+    expect(computePageRanges(1, 100, 10)).toEqual([1, 2, 3, 4, 5, 'ellipsis', 10])
+    // Current page is in the middle
+    expect(computePageRanges(5, 100, 10)).toEqual([1, 'ellipsis', 4, 5, 6, 'ellipsis', 10])
+    // Current page is near the end
+    expect(computePageRanges(9, 100, 10)).toEqual([1, 'ellipsis', 6, 7, 8, 9, 10])
+  })
+})
+
+describe('clampCurrentPage', () => {
+  it('asserts current-page clamping when the requested page exceeds the total', () => {
+    expect(clampCurrentPage(5, 20, 10)).toBe(2)
+  })
+
+  it('clamps to 1 when zero items are available', () => {
+    expect(clampCurrentPage(5, 0, 10)).toBe(1)
+  })
+
+  it('clamps to 1 when requested page is negative', () => {
+    expect(clampCurrentPage(-5, 20, 10)).toBe(1)
+  })
+
+  it('returns requested page when within bounds', () => {
+    expect(clampCurrentPage(2, 50, 10)).toBe(2)
+  })
+})

--- a/src/shared/utils/pagination.ts
+++ b/src/shared/utils/pagination.ts
@@ -10,19 +10,19 @@
  */
 
 /** Default number of items requested per page. */
-export const DEFAULT_PAGE_LIMIT = 12;
+export const DEFAULT_PAGE_LIMIT = 12
 
 /**
  * Hard upper bound on a single page size. Requesting more than this is treated
  * as abuse / a bug and is clamped down to protect the API.
  */
-export const MAX_PAGE_LIMIT = 100;
+export const MAX_PAGE_LIMIT = 100
 
 /**
  * Hard upper bound on `offset`. Prevents pathological deep-paging requests
  * (e.g. `offset=999999999`) from reaching the backend.
  */
-export const MAX_OFFSET = 100_000;
+export const MAX_OFFSET = 100_000
 
 /**
  * Clamp a requested page size into the safe range `[1, MAX_PAGE_LIMIT]`.
@@ -37,16 +37,16 @@ export const MAX_OFFSET = 100_000;
  */
 export function clampLimit(
   limit: number | undefined | null,
-  fallback: number = DEFAULT_PAGE_LIMIT,
+  fallback: number = DEFAULT_PAGE_LIMIT
 ): number {
   const safeFallback = Math.min(
     Math.max(1, Math.floor(fallback) || DEFAULT_PAGE_LIMIT),
-    MAX_PAGE_LIMIT,
-  );
-  if (limit == null || !Number.isFinite(limit)) return safeFallback;
-  const floored = Math.floor(limit);
-  if (floored < 1) return safeFallback;
-  return Math.min(floored, MAX_PAGE_LIMIT);
+    MAX_PAGE_LIMIT
+  )
+  if (limit == null || !Number.isFinite(limit)) return safeFallback
+  const floored = Math.floor(limit)
+  if (floored < 1) return safeFallback
+  return Math.min(floored, MAX_PAGE_LIMIT)
 }
 
 /**
@@ -59,10 +59,10 @@ export function clampLimit(
  * @returns A non-negative integer offset guaranteed to be within bounds.
  */
 export function clampOffset(offset: number | undefined | null): number {
-  if (offset == null || !Number.isFinite(offset)) return 0;
-  const floored = Math.floor(offset);
-  if (floored < 0) return 0;
-  return Math.min(floored, MAX_OFFSET);
+  if (offset == null || !Number.isFinite(offset)) return 0
+  const floored = Math.floor(offset)
+  if (floored < 0) return 0
+  return Math.min(floored, MAX_OFFSET)
 }
 
 /**
@@ -74,9 +74,9 @@ export function clampOffset(offset: number | undefined | null): number {
  * @returns `true` when there are still un-loaded items to fetch.
  */
 export function hasMoreByTotal(loaded: number, total: number): boolean {
-  if (!Number.isFinite(loaded) || !Number.isFinite(total)) return false;
-  if (total <= 0) return false;
-  return loaded < total;
+  if (!Number.isFinite(loaded) || !Number.isFinite(total)) return false
+  if (total <= 0) return false
+  return loaded < total
 }
 
 /**
@@ -89,6 +89,72 @@ export function hasMoreByTotal(loaded: number, total: number): boolean {
  * @returns `true` when the last page was full and another page should be tried.
  */
 export function hasMoreByPageSize(received: number, limit: number): boolean {
-  if (!Number.isFinite(received) || received <= 0) return false;
-  return received >= clampLimit(limit);
+  if (!Number.isFinite(received) || received <= 0) return false
+  return received >= clampLimit(limit)
+}
+/**
+ * Compute the page ranges to display, including ellipsis truncation.
+ *
+ * @param currentPage - The requested page number (1-indexed).
+ * @param totalItems - The total number of items available.
+ * @param pageSize - The number of items per page.
+ * @returns An array of page numbers and 'ellipsis' strings.
+ */
+export function computePageRanges(
+  currentPage: number,
+  totalItems: number,
+  pageSize: number = DEFAULT_PAGE_LIMIT
+): (number | 'ellipsis')[] {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
+  const clampedPage = Math.max(1, Math.min(currentPage, totalPages))
+
+  const pages: (number | 'ellipsis')[] = []
+  if (totalPages <= 7) {
+    for (let i = 1; i <= totalPages; i++) {
+      pages.push(i)
+    }
+  } else {
+    if (clampedPage <= 4) {
+      pages.push(1, 2, 3, 4, 5, 'ellipsis', totalPages)
+    } else if (clampedPage >= totalPages - 3) {
+      pages.push(
+        1,
+        'ellipsis',
+        totalPages - 4,
+        totalPages - 3,
+        totalPages - 2,
+        totalPages - 1,
+        totalPages
+      )
+    } else {
+      pages.push(
+        1,
+        'ellipsis',
+        clampedPage - 1,
+        clampedPage,
+        clampedPage + 1,
+        'ellipsis',
+        totalPages
+      )
+    }
+  }
+  return pages
+}
+
+/**
+ * Clamp a requested current page into the safe range [1, totalPages].
+ *
+ * @param currentPage - The requested page number.
+ * @param totalItems - The total number of items available.
+ * @param pageSize - The number of items per page.
+ * @returns An integer page number guaranteed to be within bounds.
+ */
+export function clampCurrentPage(
+  currentPage: number,
+  totalItems: number,
+  pageSize: number = DEFAULT_PAGE_LIMIT
+): number {
+  if (totalItems <= 0) return 1
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
+  return Math.max(1, Math.min(currentPage, totalPages))
 }


### PR DESCRIPTION
Closes #451 

Description
This PR addresses the under-tested boundary cases in the pagination utility utilized by table components such as ContributorsPage and DataPage. It introduces the missing computePageRanges and clampCurrentPage functions which safely generate the UI page labels (including ellipsis truncation) and restrict invalid page index requests.

Changes Included
src/shared/utils/pagination.ts:
Implemented computePageRanges: Dynamically calculates the array of page numbers or 'ellipsis' strings to display depending on the total items, page size, and the current active page.
Implemented clampCurrentPage: A utility that enforces the current page index stays within the [1, totalPages] boundary (defaulting to 1 for 0 items).
src/shared/utils/pagination.test.ts:
Added test suites for the new boundary scenarios:
Zero items (returns a single page: [1]).
Exactly one page.
Exactly-divisible item counts (e.g. 20 items / 10 limit -> 2 pages).
Partially-filled last page (e.g. 25 items / 10 limit -> 3 pages).
Validated standard ellipsis truncation behaviors correctly rendering from the start, middle, and near the end of larger page distributions.
Assured clampCurrentPage correctly handles out-of-bounds, negative, or excessive page indices.
Testing
 Run npx vitest run src/shared/utils/pagination.test.ts to ensure 100% passing specs.
 Coverage includes all newly introduced boundary logic.
 Retained the pure signature nature for integration cleanly against untrusted React UI states.