### PR TITLE
test: cover StatsCardSkeleton theme branching and structure

### DIFF
--- a/src/features/maintainers/components/dashboard/StatsCardSkeleton.test.tsx
+++ b/src/features/maintainers/components/dashboard/StatsCardSkeleton.test.tsx
@@ -1,0 +1,100 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { renderWithTheme } from '../../../../test/renderWithTheme'
+import { StatsCardSkeleton } from './StatsCardSkeleton'
+
+/** The skeleton's outer card — the element that carries the theme-dependent classes. */
+function renderSkeleton(theme: 'light' | 'dark') {
+  const { container } = renderWithTheme(<StatsCardSkeleton />, { theme })
+  return container.firstElementChild as HTMLElement
+}
+
+describe('StatsCardSkeleton', () => {
+  // --- theme branching (acceptance criteria 1 & 2) ---
+
+  it('renders dark-mode container classes when theme is dark', () => {
+    const card = renderSkeleton('dark')
+
+    expect(card).toHaveClass('bg-[#2d2820]/[0.4]', 'border-white/10')
+    expect(card).not.toHaveClass('bg-white/[0.12]')
+    expect(card).not.toHaveClass('border-white/20')
+  })
+
+  it('renders light-mode container classes when theme is light', () => {
+    const card = renderSkeleton('light')
+
+    expect(card).toHaveClass('bg-white/[0.12]', 'border-white/20')
+    expect(card).not.toHaveClass('bg-[#2d2820]/[0.4]')
+    expect(card).not.toHaveClass('border-white/10')
+  })
+
+  it('keeps the theme-independent card chrome in both themes', () => {
+    for (const theme of ['light', 'dark'] as const) {
+      const card = renderSkeleton(theme)
+      expect(card).toHaveClass(
+        'backdrop-blur-[40px]',
+        'rounded-[20px]',
+        'border',
+        'p-6',
+        'relative',
+        'overflow-hidden',
+        'transition-colors'
+      )
+    }
+  })
+
+  // --- placeholder structure (acceptance criterion 3) ---
+
+  it('renders exactly the five expected SkeletonLoader placeholders', () => {
+    renderSkeleton('dark')
+
+    expect(screen.getAllByTestId('skeleton-loader')).toHaveLength(5)
+  })
+
+  it('shapes each placeholder for the StatsCard element it stands in for', () => {
+    renderSkeleton('light')
+
+    const [label, subLabel, icon, value, badge] = screen.getAllByTestId('skeleton-loader')
+
+    // label + sub-label sit in the left column of the header row
+    expect(label).toHaveClass('h-4', 'w-32', 'mb-2')
+    expect(subLabel).toHaveClass('h-3', 'w-20')
+
+    // icon is the only circle variant, matching StatsCard's 40px icon badge
+    expect(icon).toHaveClass('w-10', 'h-10', 'rounded-full')
+    expect(label).not.toHaveClass('rounded-full')
+
+    // value, then the trend badge
+    expect(value).toHaveClass('h-8', 'w-16')
+    expect(badge).toHaveClass('h-5', 'w-20', 'rounded-[6px]')
+  })
+
+  it('places the label pair and the icon in the header row, value and badge below', () => {
+    const card = renderSkeleton('dark')
+    const [label, subLabel, icon, value, badge] = screen.getAllByTestId('skeleton-loader')
+
+    const header = card.querySelector('.flex.items-start.justify-between')
+    expect(header).not.toBeNull()
+    expect(header).toContainElement(label)
+    expect(header).toContainElement(subLabel)
+    expect(header).toContainElement(icon)
+    expect(header).not.toContainElement(value)
+    expect(header).not.toContainElement(badge)
+
+    // label and sub-label share the flex-1 column; the icon does not
+    const labelColumn = header!.querySelector('.flex-1')
+    expect(labelColumn).toContainElement(label)
+    expect(labelColumn).toContainElement(subLabel)
+    expect(labelColumn).not.toContainElement(icon)
+
+    // the badge is the last child of the card, after the value block
+    expect(card.lastElementChild).toBe(badge)
+  })
+
+  it('renders no text content while loading', () => {
+    const card = renderSkeleton('dark')
+
+    expect(card.textContent).toBe('')
+    expect(screen.queryByTestId('stats-card-value')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #660

## What

Adds `src/features/maintainers/components/dashboard/StatsCardSkeleton.test.tsx`.
The component had no dedicated test file — the "skeleton-to-content transition
test" referenced in #516 lives in `StatsCard.test.tsx`, so this file was
untested in isolation.

## Coverage

7 tests, all passing:

- **Dark mode** — the container renders `bg-[#2d2820]/[0.4] border-white/10`
  when `theme === 'dark'`, and *not* the light classes.
- **Light mode** — the container renders `bg-white/[0.12] border-white/20`
  when `theme === 'light'`, and *not* the dark classes.
- **Theme-independent chrome** — `backdrop-blur-[40px]`, `rounded-[20px]`,
  `p-6`, `transition-colors`, etc. hold in both themes.
- **All five `SkeletonLoader` placeholders** are present and shaped correctly:
  label (`h-4 w-32 mb-2`), sub-label (`h-3 w-20`), icon circle
  (`variant="circle"`, `w-10 h-10`), value (`h-8 w-16`) and badge
  (`h-5 w-20 rounded-[6px]`).
- **Layout** — label + sub-label share the `flex-1` column of the header row,
  the icon sits outside it, and the badge is the card's last child.
- **No text content** while loading.

The negative class assertions matter: without them a component emitting *both*
class sets would still pass, and the acceptance criteria are about the
branching specifically.

## Notes

Uses `renderWithTheme` (as the issue suggests) rather than the `vi.hoisted`
`ThemeContext` mock used in `StatsCard.test.tsx`. That sibling needs the mock
because it renders without a provider; here the real `ThemeProvider` is seeded
via `localStorage`, which also lets the child `SkeletonLoader`s read the real
theme instead of a stub.

Only the test file is added — `StatsCardSkeleton.tsx` is unchanged.

## Verification

npx vitest run StatsCardSkeleton     # 7/7 passed

Coverage on `StatsCardSkeleton.tsx`: **100%** statements, branches, functions
and lines (the two branches are exactly the `theme === 'dark'` ternary arms) —
above the 95% minimum.