### PR TITLE
fix: replace hardcoded 'en-US' locale in ProfilePage with useIntlFormatters hook [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/features/dashboard/pages/ProfilePage.test.tsx
+++ b/src/features/dashboard/pages/ProfilePage.test.tsx
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { IntlProvider } from 'react-intl'
 
 // ---------------------------------------------------------------------------
 // Mock API client — declared BEFORE vi.mock() factory so they are in scope
@@ -110,7 +111,9 @@ function makeContributedProjects() {
 function renderPage(props: Partial<React.ComponentProps<typeof ProfilePage>> = {}) {
   return render(
     <ThemeProvider>
-      <ProfilePage {...props} />
+      <IntlProvider locale="en" messages={{}}>
+        <ProfilePage {...props} />
+      </IntlProvider>
     </ThemeProvider>
   )
 }

--- a/src/features/dashboard/pages/ProfilePage.tsx
+++ b/src/features/dashboard/pages/ProfilePage.tsx
@@ -41,6 +41,7 @@ import {
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
 import { LanguageIcon } from '../../../shared/components/LanguageIcon'
 import { GithubIcon } from '../../../shared/components/GithubIcon'
+import { useIntlFormatters } from '../../../shared/i18n/useIntlFormatters'
 
 /**
  * Inline error panel with a retry affordance, rendered when a profile section's
@@ -145,6 +146,7 @@ export function ProfilePage({
 }: ProfilePageProps) {
   const { theme } = useTheme()
   const { user } = useAuth()
+  const { formatDate } = useIntlFormatters()
   const [profileData, setProfileData] = useState<ProfileData | null>(null)
   const [viewingUser, setViewingUser] = useState<{ login: string; avatar_url?: string } | null>(
     null
@@ -485,7 +487,7 @@ export function ProfilePage({
       title: activity.title,
       project: activity.project_name,
       project_id: activity.project_id,
-      date: new Date(activity.date).toLocaleDateString('en-US', { day: 'numeric', month: 'short' }),
+      date: formatDate(activity.date, { day: 'numeric', month: 'short' }),
       url: activity.url,
     })
   })


### PR DESCRIPTION
## Description

This PR replaces the hardcoded `'en-US'` locale in `ProfilePage.tsx` with the shared `useIntlFormatters()` hook.

### Changes

1. **`ProfilePage.tsx`**:
   - Imported `useIntlFormatters` from `shared/i18n/useIntlFormatters`
   - Replaced `new Date(activity.date).toLocaleDateString('en-US', { day: 'numeric', month: 'short' })` with `formatDate(activity.date, { day: 'numeric', month: 'short' })`

2. **`ProfilePage.test.tsx`**:
   - Added `IntlProvider` wrapper to support the `useIntlFormatters` hook in tests

### Why

The `useIntlFormatters` hook centralizes locale-aware date formatting so it automatically follows the app's active locale, rather than always rendering US date conventions.

Closes #798