### PR TITLE
fix(security): strip OAuth token from URL/history on AuthCallbackPage error paths

### DIFF
--- a/src/features/auth/pages/AuthCallbackPage.tsx
+++ b/src/features/auth/pages/AuthCallbackPage.tsx
@@ -1,145 +1,125 @@
-import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../../shared/contexts/AuthContext';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { logger } from '../../../shared/utils/logger';
+import { useEffect, useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../../shared/contexts/AuthContext'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { logger } from '../../../shared/utils/logger'
 
-const AUTH_RETURN_TO_KEY = 'authReturnTo';
+const AUTH_RETURN_TO_KEY = 'authReturnTo'
 
 function isValidAuthReturnTo(returnTo: string | null): returnTo is string {
-  if (!returnTo || returnTo.startsWith('//')) return false;
+  if (!returnTo || returnTo.startsWith('//')) return false
   return (
     returnTo === '/dashboard' ||
     returnTo.startsWith('/dashboard/') ||
     returnTo.startsWith('/dashboard?') ||
     returnTo.startsWith('/dashboard#')
-  );
+  )
 }
 
 export function AuthCallbackPage() {
-  const navigate = useNavigate();
-  const { login, isAuthenticated } = useAuth();
-  const { theme } = useTheme();
-  const [error, setError] = useState<string | null>(null);
-  const [isProcessing, setIsProcessing] = useState(true);
-  const hasProcessed = useRef(false);
+  const navigate = useNavigate()
+  const { login, isAuthenticated } = useAuth()
+  const { theme } = useTheme()
+  const [error, setError] = useState<string | null>(null)
+  const [isProcessing, setIsProcessing] = useState(true)
+  const hasProcessed = useRef(false)
 
   // Redirect to dashboard (or returnTo from "review their application" link) once authenticated
   useEffect(() => {
     if (isAuthenticated && !error) {
-      const returnTo = sessionStorage.getItem(AUTH_RETURN_TO_KEY);
-      sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
+      const returnTo = sessionStorage.getItem(AUTH_RETURN_TO_KEY)
+      sessionStorage.removeItem(AUTH_RETURN_TO_KEY)
       if (isValidAuthReturnTo(returnTo)) {
-        logger.info('User is authenticated, redirecting to', returnTo);
-        navigate(returnTo, { replace: true });
+        logger.info('User is authenticated, redirecting to', returnTo)
+        navigate(returnTo, { replace: true })
       } else {
-        logger.info('User is authenticated, redirecting to dashboard...');
-        navigate('/dashboard', { replace: true });
+        logger.info('User is authenticated, redirecting to dashboard...')
+        navigate('/dashboard', { replace: true })
       }
     }
-  }, [isAuthenticated, error, navigate]);
+  }, [isAuthenticated, error, navigate])
 
   useEffect(() => {
     // Prevent running twice in React Strict Mode
     if (hasProcessed.current) {
-      return;
+      return
     }
-    
+
     const handleCallback = async () => {
-      hasProcessed.current = true;
-                                                                                                
-                                                                                                                                                  
-          
+      hasProcessed.current = true
 
-                                                                                                                                                            
-                                                                                                                                          
-                                                                                                                                                                                      
-
-                                                                                                                                                                
-                                                                                                                                                                                            
-                                                                                                                                                                                                                  
-                                                                                                                                                                                                                        
-                                                                                                                                                                                                                                    
-                                                                                                                                                                                                                                                      
-
-                                                                                                                                                                                                                                          
-                                                                                                                                                                                                                                                          
-                                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                                    
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
-                                                                                                                                                                                                                                                                                          
-                                                                                                                                                                                                                                                                                            
-                                                                     
-                                                                                                                      
-                                                                                                                                        
-                                                            
-      
-  try {
+      try {
         // Get the token from URL parameters
-        const params = new URLSearchParams(window.location.search);
-        const token = params.get('token');
-        const github = params.get('github');
-        const errorParam = params.get('error');
+        const params = new URLSearchParams(window.location.search)
+        const token = params.get('token')
+        const github = params.get('github')
+        const errorParam = params.get('error')
 
-        logger.debug('OAuth Callback - Processing callback URL');
-        logger.debug('OAuth Callback - Token present:', !!token);
-        logger.debug('OAuth Callback - GitHub username present:', !!github);
+        // Strip the query string from the URL immediately so the token
+        // never lingers in the visible address bar or browser history.
+        window.history.replaceState({}, '', window.location.pathname)
+
+        logger.debug('OAuth Callback - Processing callback URL')
+        logger.debug('OAuth Callback - Token present:', !!token)
+        logger.debug('OAuth Callback - GitHub username present:', !!github)
         if (errorParam) {
-          logger.warn('OAuth Callback - Error param:', errorParam);
+          logger.warn('OAuth Callback - Error param:', errorParam)
         }
 
         if (errorParam) {
-          logger.error('OAuth Error:', errorParam);
-          sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
+          logger.error('OAuth Error:', errorParam)
+          sessionStorage.removeItem(AUTH_RETURN_TO_KEY)
           if (errorParam === 'access_denied') {
-            setError('Login was cancelled. Please try again.');
+            setError('Login was cancelled. Please try again.')
           } else {
-            setError(errorParam || 'An unexpected error occurred');
+            setError(errorParam || 'An unexpected error occurred')
           }
-          setIsProcessing(false);
+          setIsProcessing(false)
           // Redirect to signin after 3 seconds
-          setTimeout(() => navigate('/signin'), 3000);
-          return;
+          setTimeout(() => navigate('/signin', { replace: true }), 3000)
+          return
         }
 
         if (!token) {
-          logger.error('No token found in URL');
-          sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
-          setError('No authentication token received');
-          setIsProcessing(false);
-          setTimeout(() => navigate('/signin'), 3000);
-          return;
+          logger.error('No token found in URL')
+          sessionStorage.removeItem(AUTH_RETURN_TO_KEY)
+          setError('No authentication token received')
+          setIsProcessing(false)
+          setTimeout(() => navigate('/signin', { replace: true }), 3000)
+          return
         }
 
         // Login with the token
-        logger.debug('Attempting login...');
-        await login(token);
-        logger.debug('Login successful! Auth state should update shortly...');
-        setIsProcessing(false);
+        logger.debug('Attempting login...')
+        await login(token)
+        logger.debug('Login successful! Auth state should update shortly...')
+        setIsProcessing(false)
         // The redirect will happen via the useEffect watching isAuthenticated
       } catch (err) {
-        logger.error('Authentication failed:', err instanceof Error ? err.message : err);
-        sessionStorage.removeItem(AUTH_RETURN_TO_KEY);
-        setError(err instanceof Error ? err.message : 'Authentication failed');
-        setIsProcessing(false);
-        setTimeout(() => navigate('/signin'), 3000);
+        logger.error('Authentication failed:', err instanceof Error ? err.message : err)
+        sessionStorage.removeItem(AUTH_RETURN_TO_KEY)
+        setError(err instanceof Error ? err.message : 'Authentication failed')
+        setIsProcessing(false)
+        setTimeout(() => navigate('/signin', { replace: true }), 3000)
       }
-    } 
-  
-    handleCallback();
- }, [login, navigate]);
+    }
+
+    handleCallback()
+  }, [login, navigate])
 
   return (
-    <div className={`min-h-screen flex items-center justify-center transition-colors ${
-      theme === 'dark'
-        ? 'bg-gradient-to-br from-[#1a1512] via-[#231c17] to-[#2d241d]'
-        : 'bg-gradient-to-br from-[#e8dfd0] via-[#d4c5b0] to-[#c9b89a]'
-    }`}>
-      <div className={`p-8 rounded-[24px] backdrop-blur-[40px] border max-w-md w-full mx-4 transition-colors ${
+    <div
+      className={`min-h-screen flex items-center justify-center transition-colors ${
         theme === 'dark'
-          ? 'bg-[#2d2820]/[0.4] border-white/10'
-          : 'bg-white/[0.35] border-white'
-      }`}>
+          ? 'bg-gradient-to-br from-[#1a1512] via-[#231c17] to-[#2d241d]'
+          : 'bg-gradient-to-br from-[#e8dfd0] via-[#d4c5b0] to-[#c9b89a]'
+      }`}
+    >
+      <div
+        className={`p-8 rounded-[24px] backdrop-blur-[40px] border max-w-md w-full mx-4 transition-colors ${
+          theme === 'dark' ? 'bg-[#2d2820]/[0.4] border-white/10' : 'bg-white/[0.35] border-white'
+        }`}
+      >
         {error ? (
           <div className="text-center">
             <div className="mb-4">
@@ -157,19 +137,25 @@ export function AuthCallbackPage() {
                 />
               </svg>
             </div>
-            <h2 className={`text-xl mb-2 transition-colors ${
-              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+            <h2
+              className={`text-xl mb-2 transition-colors ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               Authentication Failed
             </h2>
-            <p className={`text-sm transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-            }`}>
+            <p
+              className={`text-sm transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
               {error}
             </p>
-            <p className={`text-xs mt-4 transition-colors ${
-              theme === 'dark' ? 'text-[#a3a3a3]' : 'text-[#8a7d6f]'
-            }`}>
+            <p
+              className={`text-xs mt-4 transition-colors ${
+                theme === 'dark' ? 'text-[#a3a3a3]' : 'text-[#8a7d6f]'
+              }`}
+            >
               Redirecting to sign in...
             </p>
           </div>
@@ -178,14 +164,18 @@ export function AuthCallbackPage() {
             <div className="mb-4">
               <div className="mx-auto h-12 w-12 border-4 border-[#c9983a] border-t-transparent rounded-full animate-spin"></div>
             </div>
-            <h2 className={`text-xl mb-2 transition-colors ${
-              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+            <h2
+              className={`text-xl mb-2 transition-colors ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               Completing Authentication
             </h2>
-            <p className={`text-sm transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-            }`}>
+            <p
+              className={`text-sm transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
               Please wait while we sign you in...
             </p>
           </div>
@@ -206,19 +196,23 @@ export function AuthCallbackPage() {
                 />
               </svg>
             </div>
-            <h2 className={`text-xl mb-2 transition-colors ${
-              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+            <h2
+              className={`text-xl mb-2 transition-colors ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               Authentication Successful
             </h2>
-            <p className={`text-sm transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-            }`}>
+            <p
+              className={`text-sm transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
               Redirecting to dashboard...
             </p>
           </div>
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/src/features/auth/pages/SignInPage.test.tsx
+++ b/src/features/auth/pages/SignInPage.test.tsx
@@ -306,4 +306,43 @@ describe('AuthCallbackPage returnTo lifecycle', () => {
 
     await waitFor(() => expect(sessionStorage.getItem(AUTH_RETURN_TO_KEY)).toBeNull())
   })
+
+  it('strips the token query parameter from the URL immediately after reading it', async () => {
+    mockUseAuth.mockReturnValue({
+      login: vi.fn().mockResolvedValue(undefined),
+      isAuthenticated: false,
+    })
+
+    renderCallback('/auth/callback?token=some-jwt')
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('')
+    })
+  })
+
+  it('strips the error query parameter from the URL immediately after reading it', async () => {
+    mockUseAuth.mockReturnValue({
+      login: vi.fn().mockResolvedValue(undefined),
+      isAuthenticated: false,
+    })
+
+    renderCallback('/auth/callback?error=access_denied')
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('')
+    })
+  })
+
+  it('replaces history entry when logging in fails', async () => {
+    mockUseAuth.mockReturnValue({
+      login: vi.fn().mockRejectedValue(new Error('bad token')),
+      isAuthenticated: false,
+    })
+
+    renderCallback('/auth/callback?token=bad-jwt')
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/signin'), {
+      timeout: 5000,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #773

This PR fixes a token-exposure window where the OAuth token URL remains in the browser history after error-path redirects on `AuthCallbackPage`.

## Changes

1. **Strip query params from URL immediately** — Added `window.history.replaceState({}, '', window.location.pathname)` right after reading the token/error from `URLSearchParams`, so the token never lingers in the visible address bar or browser history even during the processing window.

2. **Replace history on error redirects** — Changed all three `setTimeout(() => navigate('/signin'), 3000)` calls to `setTimeout(() => navigate('/signin', { replace: true }), 3000)` so the original token-bearing URL is removed from the history stack.

3. **Tests added**:
   - Verifies the `token` query parameter is stripped from the URL immediately after being read
   - Verifies the `error` query parameter is stripped from the URL immediately after being read
   - Verifies the history entry is replaced (redirects to `/signin`) when login fails

## Verification

- All 16 tests pass (including 3 new tests)