### PR TITLE
Type PR fetch aggregate error as unknown

### DIFF
--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -16,6 +18,7 @@ vi.mock('../../../../shared/contexts/AuthContext', () => ({
 }))
 
 const mockGetProjectPRs = vi.mocked(getMaintainerPRs)
+const sourcePath = fileURLToPath(new URL('./PullRequestsTab.tsx', import.meta.url))
 
 const PROJECTS = [
   {
@@ -127,5 +130,14 @@ describe('PullRequestsTab accessibility', () => {
 
     expect(headers[3]).toHaveTextContent('Indicators')
     expect(headers[3]).toHaveAttribute('scope', 'col')
+  })
+})
+
+describe('PullRequestsTab fetch error typing', () => {
+  it('keeps the aggregated PR fetch error typed as unknown instead of any', () => {
+    const source = readFileSync(sourcePath, 'utf8')
+
+    expect(source).toContain('let lastError: unknown | null = null')
+    expect(source).not.toContain('let lastError: any')
   })
 })

--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
@@ -119,7 +119,7 @@ export function PullRequestsTab({ selectedProjects }: PullRequestsTabProps) {
 
       // Fetch PRs from all selected projects in parallel
       let successCount = 0
-      let lastError: any = null
+      let lastError: unknown | null = null
 
       const prPromises = selectedProjects.map(async (project: Project) => {
         try {


### PR DESCRIPTION
## Summary
- type the aggregated PullRequestsTab fetch error as `unknown | null` instead of `any` before rethrowing it
- add a regression test that locks the PR tab source away from `lastError: any`

Closes #745

## Verification
- Static marker check confirmed `PullRequestsTab.tsx` contains `let lastError: unknown | null = null` and no `let lastError: any`.
- `git diff --check` passed locally.
- I did not run the full project test suite because this workspace avoids dependency installation/toolchain execution for safety.