### PR TITLE
fix: consolidate duplicated isLogoUrl helper into shared utils (Closes #790)

### DIFF
--- a/src/features/leaderboard/components/ProjectsPodium.tsx
+++ b/src/features/leaderboard/components/ProjectsPodium.tsx
@@ -1,10 +1,7 @@
 import { Medal, Trophy, Crown, Sparkles } from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { ProjectData } from '../types'
-
-function isLogoUrl(logo: string): boolean {
-  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
-}
+import { isLogoUrl } from '../utils'
 
 interface ProjectsPodiumProps {
   topThree: ProjectData[]

--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { ProjectData, FilterType } from '../types'
 import { getAvatarGradient } from '../data/leaderboardData'
 import { LeaderboardTableState } from './LeaderboardTableState'
+import { isLogoUrl } from '../utils'
 
 interface ProjectsTableProps {
   data: ProjectData[]
@@ -22,10 +23,6 @@ const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
   if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
   if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
   return <Minus className="w-4 h-4 text-[#7a6b5a]" />
-}
-
-function isLogoUrl(logo: string): boolean {
-  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
 }
 
 /**

--- a/src/features/leaderboard/utils/index.ts
+++ b/src/features/leaderboard/utils/index.ts
@@ -1,0 +1,3 @@
+export function isLogoUrl(logo: string): boolean {
+  return typeof logo === 'string' && (logo.startsWith('http://') || logo.startsWith('https://'))
+}


### PR DESCRIPTION
## Summary

Extracts the byte-for-byte identical `isLogoUrl` helper function that was duplicated in both `ProjectsPodium.tsx` and `ProjectsTable.tsx` into a shared utility at `src/features/leaderboard/utils/index.ts`.

## Changes

- Created `src/features/leaderboard/utils/index.ts` with the exported `isLogoUrl` function
- Updated `ProjectsPodium.tsx` to import from shared utils
- Updated `ProjectsTable.tsx` to import from shared utils

Closes #790