### PR TITLE
fix: share a single defensive formatCountBadge helper across NotificationsDropdown and IssueListSidebar (Closes #775)

### DIFF
--- a/src/features/maintainers/components/issues/IssueListSidebar.tsx
+++ b/src/features/maintainers/components/issues/IssueListSidebar.tsx
@@ -2,6 +2,7 @@ import { Search, Filter, Loader2 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../../shared/hooks/useDebouncedValue'
+import { formatCountBadge } from '../../../../shared/utils/formatCountBadge'
 import { Issue } from '../../types'
 import { MaintainerIssueCard } from './MaintainerIssueCard'
 import { IssueFilterDropdown } from './IssueFilterDropdown'
@@ -17,18 +18,6 @@ interface IssueListSidebarProps {
   appliedFilterCount: number
   onFilterClick: () => void
   onIssueSelect: (issue: Issue) => void
-}
-
-/**
- * Formats the filter-count badge value to avoid layout overflow.
- *
- * - 0..99 => exact count
- * - >= 100 => "99+"
- */
-function formatCountBadge(count: number): string {
-  const safe = Number.isFinite(count) ? Math.max(0, count) : 0
-  if (safe >= 100) return '99+'
-  return String(Math.trunc(safe))
 }
 
 /**

--- a/src/shared/components/NotificationsDropdown.tsx
+++ b/src/shared/components/NotificationsDropdown.tsx
@@ -1,6 +1,7 @@
 import { Bell } from 'lucide-react'
 import { useTheme } from '../contexts/ThemeContext'
 import { useState, useEffect } from 'react'
+import { formatCountBadge } from '../utils/formatCountBadge'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,9 +43,6 @@ export function NotificationsDropdown({
   }
 
   // Format count for display (99+ for counts over 99)
-  const formatCount = (count: number): string => {
-    return count > 99 ? '99+' : count.toString()
-  }
 
   return (
     <DropdownMenu onOpenChange={handleOpenChange}>
@@ -85,7 +83,7 @@ export function NotificationsDropdown({
               }`}
             >
               <span className="text-[10px] font-bold leading-none tabular-nums">
-                {formatCount(notificationCount)}
+                {formatCountBadge(notificationCount)}
               </span>
             </div>
           )}

--- a/src/shared/utils/formatCountBadge.test.ts
+++ b/src/shared/utils/formatCountBadge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { formatCountBadge } from './formatCountBadge'
+
+describe('formatCountBadge', () => {
+  // ── normal range ──────────────────────────────────────────────────────────
+  it.each([
+    [0, '0'],
+    [1, '1'],
+    [50, '50'],
+    [99, '99'],
+  ])('returns exact string for %i → %s', (input, expected) => {
+    expect(formatCountBadge(input)).toBe(expected)
+  })
+
+  // ── overflow ──────────────────────────────────────────────────────────────
+  it.each([
+    [100, '99+'],
+    [101, '99+'],
+    [999, '99+'],
+    [1_000_000, '99+'],
+  ])('caps at 99+ for %i → %s', (input, expected) => {
+    expect(formatCountBadge(input)).toBe(expected)
+  })
+
+  // ── fractional ────────────────────────────────────────────────────────────
+  it.each([
+    [3.7, '3'],
+    [99.9, '99'],
+    [100.1, '99+'],
+  ])('truncates decimals for %i → %s', (input, expected) => {
+    expect(formatCountBadge(input)).toBe(expected)
+  })
+
+  // ── negative / non-finite ─────────────────────────────────────────────────
+  it.each([
+    [-1, '0'],
+    [-100, '0'],
+    [NaN, '0'],
+    [Infinity, '0'],
+    [-Infinity, '0'],
+  ] as const)('clamps %s to 0', (input, expected) => {
+    expect(formatCountBadge(input)).toBe(expected)
+  })
+})

--- a/src/shared/utils/formatCountBadge.ts
+++ b/src/shared/utils/formatCountBadge.ts
@@ -1,0 +1,12 @@
+/**
+ * Formats a count value for display in a badge, with overflow protection.
+ *
+ * - 0..99 => exact count (truncated to integer)
+ * - >= 100 => "99+"
+ * - Negative / NaN / Infinity => "0"
+ */
+export function formatCountBadge(count: number): string {
+  const safe = Number.isFinite(count) ? Math.max(0, count) : 0
+  if (safe >= 100) return '99+'
+  return String(Math.trunc(safe))
+}


### PR DESCRIPTION
## Summary
Extracts the duplicated `formatCountBadge` helper into `src/shared/utils/formatCountBadge.ts` and updates both consumers to import it, removing their local copies.

## Changes
- `src/shared/utils/formatCountBadge.ts` — new shared helper using the defensive implementation (clamps negative/non-finite inputs, caps at 99+)
- `src/shared/utils/formatCountBadge.test.ts` — 16 unit tests covering normal range, overflow, fractional truncation, and negative/non-finite clamping
- `src/shared/components/NotificationsDropdown.tsx` — replaces local `formatCount` with imported `formatCountBadge` (now also clamps negative/NaN counts)
- `src/features/maintainers/components/issues/IssueListSidebar.tsx` — replaces local `formatCountBadge` with the shared import

## Testing
- `16/16` formatCountBadge unit tests pass
- Component tests have pre-existing failures unrelated to this change

Closes #775