### PR TITLE
fix: use a dedicated fallback for missing contributor names in ContributionsTab

### DIFF
--- a/src/features/dashboard/components/ContributionsTab.test.tsx
+++ b/src/features/dashboard/components/ContributionsTab.test.tsx
@@ -324,6 +324,34 @@ describe('ContributionsTab', () => {
     expect(screen.getByRole('button', { name: /rewarded\s*1/i })).toBeInTheDocument()
   })
 
+  it('uses a contributor-specific fallback (not "Unknown project") when contributor_login and author_login are missing', async () => {
+    mockGetProfileContributions.mockResolvedValue({
+      contributions: [
+        {
+          id: 'no-contributor',
+          title: 'Contribution with no author',
+          status: 'applied',
+          project_name: 'Test Project',
+          contributor_login: null,
+          author_login: null,
+        },
+      ],
+    })
+
+    renderContributionsTab()
+
+    await screen.findByText('Contribution with no author')
+
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'Unknown contributor')
+
+    expect(screen.getByText('Contribution with no author')).toBeInTheDocument()
+
+    await userEvent.clear(screen.getByPlaceholderText('Search'))
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'Unknown project')
+
+    expect(screen.queryByText('Contribution with no author')).not.toBeInTheDocument()
+  })
+
   it('renders repository-supplied titles as escaped text', async () => {
     mockGetProfileContributions.mockResolvedValue({
       contributions: [

--- a/src/features/dashboard/components/ContributionsTab.tsx
+++ b/src/features/dashboard/components/ContributionsTab.tsx
@@ -62,6 +62,7 @@ const fallbackTitle = 'Untitled contribution'
 const fallbackProject = 'Unknown project'
 const fallbackTag = 'contribution'
 const fallbackTime = 'Recently'
+const fallbackContributor = 'Unknown contributor'
 
 const normalizeText = (value: unknown, fallback: string) => {
   if (typeof value !== 'string' && typeof value !== 'number') return fallback
@@ -177,7 +178,7 @@ function normalizeContribution(contribution: ProfileContribution): ContributionC
     ),
     contributor: normalizeText(
       contribution.contributor_login || contribution.author_login,
-      fallbackProject
+      fallbackContributor
     ),
     tag,
     tagType: getTagType(tag),


### PR DESCRIPTION
Closes #813

## Changes
- Added `fallbackContributor = 'Unknown contributor'` constant alongside existing fallback constants
- Updated `normalizeContribution`'s `contributor` field to use `fallbackContributor` instead of reusing `fallbackProject`
- Added test asserting a contribution with no `contributor_login`/`author_login` uses the contributor-specific fallback (not `"Unknown project"`)

## Verification
- `npm run build` — passes
- `npm run typecheck` — passes  
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run test` — ContributionsTab tests: 12/12 passed (the 2 pre-existing failures in DiscoverPage are unrelated)