### PR TITLE
fix(security): actually strip sensitive fields before persisting billing profiles

### DIFF
--- a/src/features/settings/contexts/BillingProfilesContext.test.tsx
+++ b/src/features/settings/contexts/BillingProfilesContext.test.tsx
@@ -87,6 +87,73 @@ describe('BillingProfilesContext', () => {
     expect(result.current.profiles).toEqual([company])
   })
 
+  it('does not persist taxId, paymentMethods, or invoices to localStorage', () => {
+    const sensitiveProfile: BillingProfile = {
+      id: 3,
+      name: 'Sensitive Corp',
+      type: 'organization',
+      status: 'verified',
+      taxId: '123-45-6789',
+      paymentMethods: [
+        {
+          id: 1,
+          ecosystem: 'stellar',
+          cryptoType: 'usdc',
+          walletAddress: 'GABC',
+          isDefault: true,
+          createdAt: '2026-01-01',
+        },
+      ],
+      invoices: [
+        {
+          id: 'inv-1',
+          invoiceNumber: 'INV-001',
+          date: '2026-01-01',
+          amount: 100,
+          currency: 'USD',
+          status: 'paid',
+          description: 'Test',
+          billingPeriod: 'Jan 2026',
+        },
+      ],
+    }
+    const { result } = renderHook(() => useBillingProfiles(), { wrapper })
+
+    act(() => expect(result.current.addProfile(sensitiveProfile)).toBe(true))
+
+    const stored = localStorage.getItem('billing_profiles')!
+    expect(stored).not.toContain('123-45-6789')
+    expect(stored).not.toContain('paymentMethods')
+    expect(stored).not.toContain('invoices')
+  })
+
+  it('keeps sensitive fields in in-memory state for the current session', () => {
+    const sensitiveProfile: BillingProfile = {
+      id: 4,
+      name: 'In-Memory Corp',
+      type: 'organization',
+      status: 'verified',
+      taxId: '987-65-4321',
+      paymentMethods: [
+        {
+          id: 2,
+          ecosystem: 'stellar',
+          cryptoType: 'xlm',
+          walletAddress: 'GDEF',
+          isDefault: false,
+          createdAt: '2026-02-01',
+        },
+      ],
+    }
+    const { result } = renderHook(() => useBillingProfiles(), { wrapper })
+
+    act(() => expect(result.current.addProfile(sensitiveProfile)).toBe(true))
+
+    // In-memory state retains the full profile
+    expect(result.current.profiles[0].taxId).toBe('987-65-4321')
+    expect(result.current.profiles[0].paymentMethods).toHaveLength(1)
+  })
+
   it('rolls back a create that cannot be persisted without logging sensitive data', () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined)
     const { result } = renderHook(() => useBillingProfiles(), { wrapper })

--- a/src/features/settings/contexts/BillingProfilesContext.tsx
+++ b/src/features/settings/contexts/BillingProfilesContext.tsx
@@ -3,10 +3,20 @@ import { logger } from '../../../shared/utils/logger'
 import { BillingProfile } from '../types'
 
 /**
- * Subset of BillingProfile that is safe to persist in localStorage.
- * taxId, paymentMethods, and invoices are intentionally excluded to avoid
- * storing sensitive financial data in plaintext client-side storage.
+ * Returns a copy of the given profile with sensitive fields removed so they are
+ * never written to localStorage in plaintext.
+ *
+ * Fields stripped: `taxId`, `paymentMethods`, `invoices`.
+ * The original in-memory object is not mutated; the full profile remains
+ * available to the current session through React state.
  */
+export function toPersistableProfile(
+  profile: BillingProfile
+): Omit<BillingProfile, 'taxId' | 'paymentMethods' | 'invoices'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { taxId: _taxId, paymentMethods: _paymentMethods, invoices: _invoices, ...safe } = profile
+  return safe
+}
 
 /**
  * Public API exposed by BillingProfilesContext.
@@ -42,7 +52,7 @@ function loadProfilesFromStorage(): BillingProfile[] {
 
 function saveProfilesToStorage(profiles: BillingProfile[]): boolean {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles.map(toPersistableProfile)))
     return true
   } catch {
     logStorageFailure('save')


### PR DESCRIPTION
## What

Implements the stripping that `BillingProfilesContext` already documents in its docstring but never actually performed.

## Root Cause

`saveProfilesToStorage` was calling `JSON.stringify(profiles)` verbatim, so `taxId`, `paymentMethods`, and `invoices` were written to `localStorage` in plaintext on every state change — including after `BillingTab.tsx`'s `updateProfileWithKYCData` populates `taxId` from a KYC document extraction. Exactly the outcome the code comments claimed was prevented.

## Fix

Added `toPersistableProfile(profile)` — a pure function that destructures out the three sensitive fields and returns only the safe remainder. `saveProfilesToStorage` now maps every profile through it before serializing. In-memory React state is untouched, so the full profile (including `taxId`) remains available for the current session as intended.



## Tests Added (2 new, 16 total — all green)

- **`does not persist taxId, paymentMethods, or invoices to localStorage`** — asserts the raw `localStorage` string does not contain the sensitive field values or keys after `addProfile`.
- **`keeps sensitive fields in in-memory state for the current session`** — asserts `profiles[0].taxId` and `profiles[0].paymentMethods` remain accessible from React state after persisting.

## Verification

- `tsc --noEmit`: clean.
- `vitest run BillingProfilesContext.test.tsx`: **16/16 passing**.

Closes #803