### PR TITLE
fix: type nav/search-result icons as LucideIcon instead of any

### DIFF
--- a/src/features/dashboard/DashboardLayout.tsx
+++ b/src/features/dashboard/DashboardLayout.tsx
@@ -16,6 +16,7 @@ import {
   Shield,
   X,
   Menu,
+  LucideIcon,
 } from 'lucide-react'
 import { useModeAnimation } from 'react-theme-switch-animation'
 import { useAuth } from '../../shared/contexts/AuthContext'
@@ -162,7 +163,7 @@ export function DashboardLayout() {
   }
 
   // Role-based navigation items
-  const navItems = [
+  const navItems: { id: string; icon: LucideIcon; label: string; path: string }[] = [
     {
       id: 'discover',
       icon: Compass,
@@ -303,7 +304,7 @@ export function DashboardLayout() {
             <nav className={`space-y-2 mb-auto ${isSidebarCollapsed ? 'px-[8px]' : 'px-2'}`}>
               {navItems.map((item) => {
                 const isActive = currentPage === item.id
-                const Icon = item.icon as any
+                const Icon = item.icon
                 return (
                   <Link
                     key={item.id}

--- a/src/features/dashboard/pages/SearchPage.tsx
+++ b/src/features/dashboard/pages/SearchPage.tsx
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react'
-import { Search, ArrowRight, X, FileText, FolderGit2, User, ChevronLeft } from 'lucide-react'
+import {
+  Search,
+  ArrowRight,
+  X,
+  FileText,
+  FolderGit2,
+  User,
+  ChevronLeft,
+  LucideIcon,
+} from 'lucide-react'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { useDebouncedValue } from '../../../shared/hooks/useDebouncedValue'
 
@@ -31,7 +40,7 @@ interface SearchResult {
   type: 'issue' | 'project' | 'contributor'
   title: string
   subtitle?: string
-  icon: any
+  icon: LucideIcon
 }
 
 /**


### PR DESCRIPTION
## Summary
- Types `navItems` in `DashboardLayout.tsx` so `item.icon` is `LucideIcon`, removing the `as any` cast when rendering the dynamic nav icon.
- Types `SearchResult.icon` in `SearchPage.tsx` as `LucideIcon` instead of `any`.
- Imports `LucideIcon` from `lucide-react` in both files, matching the existing pattern in `ProfilePage.tsx`.

## Test plan
- [x] `tsc --noEmit` passes with no new errors
- [x] `eslint` on both changed files shows no new errors (only pre-existing, unrelated warnings)

Closes #783