### PR TITLE
chore: remove UserProfileDropdown's dead query-param navigation fallback

### DIFF
--- a/src/shared/components/UserProfileDropdown.test.tsx
+++ b/src/shared/components/UserProfileDropdown.test.tsx
@@ -1,12 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAuth } from '../contexts/AuthContext';
-import { getUserInitials, UserAvatar } from './UserAvatar';
-import { UserProfileDropdown } from './UserProfileDropdown';
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuth } from '../contexts/AuthContext'
+import { getUserInitials, UserAvatar } from './UserAvatar'
+import { UserProfileDropdown } from './UserProfileDropdown'
 
-vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
-vi.mock('../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
-vi.mock('../contexts/ThemeContext', () => ({ useTheme: () => ({ theme: 'light' }) }));
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('../contexts/ThemeContext', () => ({ useTheme: () => ({ theme: 'light' }) }))
 vi.mock('./ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -14,9 +14,9 @@ vi.mock('./ui/dropdown-menu', () => ({
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
+}))
 
-const mockUseAuth = vi.mocked(useAuth);
+const mockUseAuth = vi.mocked(useAuth)
 
 function mockAuthenticatedUser(github: { login: string; avatar_url: string; name?: string }) {
   mockUseAuth.mockReturnValue({
@@ -27,50 +27,50 @@ function mockAuthenticatedUser(github: { login: string; avatar_url: string; name
     isAuthenticated: true,
     isLoading: false,
     login: vi.fn(),
-  });
+  })
 }
 
 describe('UserProfileDropdown avatar fallback', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks())
 
   it('derives initials from a display name before the GitHub login', () => {
-    expect(getUserInitials('Ada Lovelace', 'octocat')).toBe('AL');
-    expect(getUserInitials('  Grace Brewster Murray Hopper  ', 'grace')).toBe('GB');
-  });
+    expect(getUserInitials('Ada Lovelace', 'octocat')).toBe('AL')
+    expect(getUserInitials('  Grace Brewster Murray Hopper  ', 'grace')).toBe('GB')
+  })
 
   it('derives initials from the login when a display name is absent', () => {
-    expect(getUserInitials(undefined, 'octocat')).toBe('OC');
-    expect(getUserInitials('', 'octo-cat')).toBe('OC');
-  });
+    expect(getUserInitials(undefined, 'octocat')).toBe('OC')
+    expect(getUserInitials('', 'octo-cat')).toBe('OC')
+  })
 
   it('replaces a broken avatar image with high-contrast name initials', () => {
     mockAuthenticatedUser({
       login: 'ada-dev',
       name: 'Ada Lovelace',
       avatar_url: 'https://example.test/broken-avatar.png',
-    });
-    render(<UserProfileDropdown showMobileNav />);
+    })
+    render(<UserProfileDropdown showMobileNav onPageChange={vi.fn()} />)
 
-    fireEvent.error(screen.getAllByRole('img', { name: 'Ada Lovelace avatar' })[0]);
+    fireEvent.error(screen.getAllByRole('img', { name: 'Ada Lovelace avatar' })[0])
 
-    const fallback = screen.getByLabelText('Ada Lovelace avatar fallback');
-    expect(fallback).toHaveTextContent('AL');
-    expect(fallback).toHaveClass('bg-[#2d2820]', 'text-white');
-    expect(screen.getAllByRole('img', { name: 'Ada Lovelace avatar' })).toHaveLength(1);
-  });
+    const fallback = screen.getByLabelText('Ada Lovelace avatar fallback')
+    expect(fallback).toHaveTextContent('AL')
+    expect(fallback).toHaveClass('bg-[#2d2820]', 'text-white')
+    expect(screen.getAllByRole('img', { name: 'Ada Lovelace avatar' })).toHaveLength(1)
+  })
 
   it('uses login initials when the image is missing and no name is available', () => {
-    mockAuthenticatedUser({ login: 'octocat', avatar_url: '' });
-    render(<UserProfileDropdown showMobileNav />);
+    mockAuthenticatedUser({ login: 'octocat', avatar_url: '' })
+    render(<UserProfileDropdown showMobileNav onPageChange={vi.fn()} />)
 
-    const fallbacks = screen.getAllByLabelText('octocat avatar fallback');
-    expect(fallbacks).toHaveLength(2);
-    expect(fallbacks[0]).toHaveTextContent('OC');
-  });
+    const fallbacks = screen.getAllByLabelText('octocat avatar fallback')
+    expect(fallbacks).toHaveLength(2)
+    expect(fallbacks[0]).toHaveTextContent('OC')
+  })
 
   it('uses a neutral fallback when no user identity is available', () => {
-    render(<UserAvatar size="large" />);
+    render(<UserAvatar size="large" />)
 
-    expect(screen.getByLabelText('User avatar fallback')).toHaveTextContent('?');
-  });
-});
+    expect(screen.getByLabelText('User avatar fallback')).toHaveTextContent('?')
+  })
+})

--- a/src/shared/components/UserProfileDropdown.tsx
+++ b/src/shared/components/UserProfileDropdown.tsx
@@ -9,11 +9,11 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from './ui/dropdown-menu';
-import { UserAvatar } from './UserAvatar';
+} from './ui/dropdown-menu'
+import { UserAvatar } from './UserAvatar'
 
 interface UserProfileDropdownProps {
-  onPageChange?: (page: string) => void
+  onPageChange: (page: string) => void
   showMobileNav: boolean
 }
 
@@ -24,19 +24,11 @@ export function UserProfileDropdown({ onPageChange, showMobileNav }: UserProfile
   const darkTheme = theme === 'dark'
 
   const handleProfileClick = () => {
-    if (onPageChange) {
-      onPageChange('profile')
-    } else {
-      navigate('/dashboard?page=profile')
-    }
+    onPageChange('profile')
   }
 
   const handleSettingsClick = () => {
-    if (onPageChange) {
-      onPageChange('settings')
-    } else {
-      navigate('/dashboard?page=settings')
-    }
+    onPageChange('settings')
   }
 
   const handleSignIn = () => {
@@ -77,11 +69,13 @@ export function UserProfileDropdown({ onPageChange, showMobileNav }: UserProfile
           ${showMobileNav ? ' flex ' : ' hidden lg:flex '}
           `}
         >
-          <div className={`absolute inset-0 pointer-events-none rounded-full ${
-            darkTheme
-              ? 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]'
-              : 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]'
-          }`} />
+          <div
+            className={`absolute inset-0 pointer-events-none rounded-full ${
+              darkTheme
+                ? 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.5),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.11)]'
+                : 'shadow-[inset_1px_-1px_1px_0px_rgba(0,0,0,0.15),inset_-2px_2px_1px_-1px_rgba(255,255,255,0.35)]'
+            }`}
+          />
           <UserAvatar
             src={user.github?.avatar_url}
             name={user.github?.name}
@@ -183,5 +177,5 @@ export function UserProfileDropdown({ onPageChange, showMobileNav }: UserProfile
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
-  );
+  )
 }


### PR DESCRIPTION
Closes #780

  - Made `onPageChange` a required prop on `UserProfileDropdownProps`
  - Removed the dead `navigate('/dashboard?page=...')` fallback branches
  - Updated existing tests to pass the now-required prop
  - `npx tsc --noEmit` passes, all 5 existing tests pass