### PR TITLE
fix: wire localized backend error codes into API handling

### DIFF
--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -18,7 +18,10 @@ vi.mock('../../../../shared/contexts/AuthContext', () => ({
 }))
 
 const mockGetProjectPRs = vi.mocked(getMaintainerPRs)
-const sourcePath = fileURLToPath(new URL('./PullRequestsTab.tsx', import.meta.url))
+const sourcePath = resolve(
+  process.cwd(),
+  'src/features/maintainers/components/pull-requests/PullRequestsTab.tsx'
+)
 
 const PROJECTS = [
   {

--- a/src/features/settings/components/notifications/NotificationRow.test.tsx
+++ b/src/features/settings/components/notifications/NotificationRow.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-pool=single
 // src/features/settings/components/notifications/NotificationRow.test.tsx
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NotificationRow } from './NotificationRow'
 import { ThemeProvider } from '../../../../shared/contexts/ThemeContext'
@@ -50,8 +50,12 @@ describe('NotificationRow optimistic mark-as-read', () => {
   })
 
   test('rolls back UI and shows error on API failure', async () => {
+    let rejectRequest!: (reason?: unknown) => void
     const onMarkAsRead = vi.fn<() => Promise<void>>(
-      () => new Promise((_, reject) => setTimeout(() => reject(new Error('API error')), 10))
+      () =>
+        new Promise((_, reject) => {
+          rejectRequest = reject
+        })
     )
     render(
       <ThemeWrapper>
@@ -63,6 +67,11 @@ describe('NotificationRow optimistic mark-as-read', () => {
     await userEvent.click(button)
     const row = screen.getByTestId('notification-row')
     expect(row).toHaveClass('opacity-50')
+
+    await act(async () => {
+      rejectRequest(new Error('API error'))
+    })
+
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to mark notification as read.')
     })

--- a/src/shared/api/client.test.ts
+++ b/src/shared/api/client.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   apiRequest,
+  ApiError,
   getAuthToken,
   setAuthToken,
   removeAuthToken,
@@ -23,6 +24,7 @@ import {
   RETRY_BASE_DELAY_MS,
 } from './client'
 import { API_BASE_URL } from '../config/api'
+import { getUserFriendlyError } from '../utils/errorHandler'
 
 // Mock fetch globally
 const mockFetch = vi.fn()
@@ -341,6 +343,111 @@ describe('apiRequest - Core Request Helper', () => {
       })
 
       await expect(apiRequest('/test')).rejects.toThrow('Bad request error')
+    })
+
+    it('should localize a known backend code using the stored locale and preserve metadata', async () => {
+      localStorageMock.setItem('locale', 'es')
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({
+          code: 'NOT_FOUND',
+          message: 'database record missing',
+        }),
+      })
+
+      const error = await apiRequest('/projects/missing').catch((cause) => cause)
+
+      expect(error).toBeInstanceOf(ApiError)
+
+      const apiError = error as ApiError
+      expect(apiError.status).toBe(404)
+      expect(apiError.code).toBe('NOT_FOUND')
+      expect(apiError.serverMessage).toBe('database record missing')
+      expect(apiError.message).toBe('El recurso solicitado no se pudo encontrar.')
+
+      // Proves the localized taxonomy message survives the application's real
+      // user-facing error classifier.
+      expect(getUserFriendlyError(apiError)).toBe('El recurso solicitado no se pudo encontrar.')
+    })
+
+    it('should use the localized generic fallback for an unknown structured code', async () => {
+      localStorageMock.setItem('locale', 'es')
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({
+          code: 'DATABASE_CONNECTION_SECRET',
+          message: 'postgres password=do-not-expose',
+        }),
+      })
+
+      const error = await apiRequest('/test').catch((cause) => cause)
+      expect(error).toBeInstanceOf(ApiError)
+
+      const apiError = error as ApiError
+      expect(apiError.code).toBe('DATABASE_CONNECTION_SECRET')
+      expect(apiError.serverMessage).toBe('postgres password=do-not-expose')
+      expect(apiError.message).toBe('Ocurrió un error inesperado. Por favor, inténtelo de nuevo.')
+      expect(getUserFriendlyError(apiError)).toBe(
+        'Ocurrió un error inesperado. Por favor, inténtelo de nuevo.'
+      )
+      expect(getUserFriendlyError(apiError)).not.toContain('postgres')
+      expect(getUserFriendlyError(apiError)).not.toContain('password')
+    })
+
+    it('should preserve 401 cleanup and redirect signaling for a coded localized error', async () => {
+      localStorageMock.setItem('locale', 'es')
+      setAuthToken('expired-token')
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({
+          code: 'UNAUTHORIZED',
+          message: 'token signature invalid',
+        }),
+      })
+
+      const error = await apiRequest('/test', {
+        requiresAuth: true,
+      }).catch((cause) => cause)
+
+      expect(error).toBeInstanceOf(ApiError)
+      expect((error as ApiError).message).toBe(
+        'Su sesión ha expirado. Por favor, inicie sesión de nuevo.'
+      )
+      expect(getAuthToken()).toBeNull()
+      expect(mockDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'patchwork-auth-401',
+        })
+      )
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should accept a nested structured backend error payload', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'internal validation details',
+          },
+        }),
+      })
+
+      const error = await apiRequest('/test').catch((cause) => cause)
+
+      expect(error).toBeInstanceOf(ApiError)
+      expect((error as ApiError).code).toBe('BAD_REQUEST')
+      expect((error as ApiError).serverMessage).toBe('internal validation details')
+      expect((error as ApiError).message).toBe(
+        'Invalid request parameters. Please check your input and try again.'
+      )
     })
 
     it('should throw RateLimitError for 429 with numeric Retry-After header', async () => {
@@ -812,9 +919,17 @@ describe('apiRequest — retryable status codes (502, 503)', () => {
     mockFetch.mockImplementation(() => {
       callCount++
       if (callCount < MAX_RETRY_ATTEMPTS) {
-        return Promise.resolve({ ok: false, status: 502, json: async () => ({ message: 'Bad Gateway' }) })
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          json: async () => ({ message: 'Bad Gateway' }),
+        })
       }
-      return Promise.resolve({ ok: true, status: 200, json: async () => ({ ok: true, service: 'api' }) })
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, service: 'api' }),
+      })
     })
 
     const promise = apiRequest<{ ok: boolean; service: string }>('/health')
@@ -830,9 +945,17 @@ describe('apiRequest — retryable status codes (502, 503)', () => {
     mockFetch.mockImplementation(() => {
       callCount++
       if (callCount === 1) {
-        return Promise.resolve({ ok: false, status: 503, json: async () => ({ message: 'Service Unavailable' }) })
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          json: async () => ({ message: 'Service Unavailable' }),
+        })
       }
-      return Promise.resolve({ ok: true, status: 200, json: async () => ({ ok: true, service: 'api' }) })
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, service: 'api' }),
+      })
     })
 
     const promise = apiRequest<{ ok: boolean; service: string }>('/health')
@@ -990,7 +1113,11 @@ describe('apiRequest — network error retry', () => {
       if (callCount === 1) {
         return Promise.reject(new TypeError('Failed to fetch'))
       }
-      return Promise.resolve({ ok: true, status: 200, json: async () => ({ ok: true, service: 'api' }) })
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, service: 'api' }),
+      })
     })
 
     const promise = apiRequest<{ ok: boolean; service: string }>('/health')

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -3,6 +3,8 @@
  */
 
 import { API_BASE_URL } from '../config/api'
+import { getErrorCodeMessage } from '../i18n/errors'
+import { readStoredLocale } from '../i18n/LocaleProvider'
 import { BillingProfile, NotificationSettings } from '../../features/settings/types'
 import { BlogPost } from '../../features/blog/types'
 
@@ -97,6 +99,88 @@ export function parseRetryAfter(headerValue: string | null): number {
   }
 
   return DEFAULT_RETRY_AFTER_SECONDS
+}
+
+/**
+ * Structured error thrown for non-successful backend responses.
+ *
+ * `message` is safe for user-facing presentation whenever `code` is present:
+ * it is resolved through the localized backend error-code taxonomy. The raw
+ * server message is retained separately for diagnostics and must not be
+ * rendered directly.
+ */
+export class ApiError extends Error {
+  readonly status: number
+  readonly code: string | undefined
+  readonly serverMessage: string | undefined
+
+  constructor(message: string, status: number, code?: string, serverMessage?: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.serverMessage = serverMessage
+  }
+}
+
+interface ParsedApiError {
+  code?: string
+  serverMessage?: string
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Reads the structured portion of an API error response.
+ *
+ * Both the documented top-level `{ code, message }` form and a nested
+ * `{ error: { code, message } }` form are accepted. Malformed/non-JSON bodies
+ * safely resolve to an empty result.
+ */
+async function readApiErrorDetails(response: Response): Promise<ParsedApiError> {
+  try {
+    const payload = asRecord(await response.json())
+    if (!payload) return {}
+
+    const nestedError = asRecord(payload.error)
+
+    const code = asNonEmptyString(payload.code) ?? asNonEmptyString(nestedError?.code)
+
+    const serverMessage =
+      asNonEmptyString(payload.message) ??
+      asNonEmptyString(payload.error) ??
+      asNonEmptyString(nestedError?.message)
+
+    return { code, serverMessage }
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Builds an API error without exposing raw server text when a structured code
+ * is available. Unknown codes resolve through the taxonomy's localized generic
+ * fallback.
+ */
+function createApiError(status: number, details: ParsedApiError, legacyMessage: string): ApiError {
+  const message = details.code
+    ? getErrorCodeMessage(details.code, readStoredLocale())
+    : legacyMessage
+
+  return new ApiError(message, status, details.code, details.serverMessage)
 }
 
 /**
@@ -255,55 +339,54 @@ export async function apiRequest<T>(endpoint: string, options: ApiRequestOptions
     // Handle errors
     if (!response.ok) {
       if (response.status === 401) {
-        // Token expired or invalid - clear it and signal the app layer to redirect.
-        // Not retryable.
+        // Preserve the existing authentication side effects while allowing a
+        // structured UNAUTHORIZED code to select the active locale.
+        const details = await readApiErrorDetails(response)
         removeAuthToken()
         emit401Event()
-        throw new Error('Authentication failed. Please sign in again.')
+        throw createApiError(
+          response.status,
+          details,
+          'Authentication failed. Please sign in again.'
+        )
       }
 
       if (response.status === 403) {
-        // Permission errors are not retryable.
-        let errorMsg: string
-        try {
-          const errorData = await response.json()
-          errorMsg = errorData.message || errorData.error || 'Access forbidden'
-        } catch {
-          errorMsg = 'Access forbidden'
-        }
-        throw new Error(
-          `Permission denied: ${errorMsg}. You may need admin privileges to perform this action.`
+        // Permission errors are not retryable. Uncoded legacy responses retain
+        // their existing detailed message; coded responses use the taxonomy.
+        const details = await readApiErrorDetails(response)
+        const errorMessage = details.serverMessage ?? 'Access forbidden'
+
+        throw createApiError(
+          response.status,
+          details,
+          `Permission denied: ${errorMessage}. You may need admin privileges to perform this action.`
         )
       }
 
       if (response.status === 429) {
-        // Rate limited — surface immediately as RateLimitError; callers handle back-off.
+        // Keep the existing typed rate-limit/back-off contract unchanged.
         const retryAfterSeconds = parseRetryAfter(response.headers.get('Retry-After'))
         throw new RateLimitError(retryAfterSeconds)
       }
 
-      // 502 / 503 are retryable transient server errors.
+      // 502 / 503 remain retryable. The final exhausted error retains its code
+      // and localized message without changing retry timing or attempt count.
       if (RETRYABLE_STATUSES.has(response.status)) {
-        let errMsg: string
-        try {
-          const errorData = await response.json()
-          errMsg = errorData.message || errorData.error || 'API request failed'
-        } catch {
-          errMsg = `API request failed with status ${response.status}`
-        }
-        lastError = new Error(errMsg)
+        const details = await readApiErrorDetails(response)
+        const legacyMessage =
+          details.serverMessage ?? `API request failed with status ${response.status}`
+
+        lastError = createApiError(response.status, details, legacyMessage)
         continue
       }
 
-      // Any other non-2xx status — non-retryable, fail immediately.
-      let apiErrorMsg: string
-      try {
-        const errorData = await response.json()
-        apiErrorMsg = errorData.message || errorData.error || 'API request failed'
-      } catch {
-        throw new Error(`API request failed with status ${response.status}`)
-      }
-      throw new Error(apiErrorMsg)
+      // Any other non-2xx status is non-retryable.
+      const details = await readApiErrorDetails(response)
+      const legacyMessage =
+        details.serverMessage ?? `API request failed with status ${response.status}`
+
+      throw createApiError(response.status, details, legacyMessage)
     }
 
     // Parse JSON response
@@ -1419,12 +1502,21 @@ export async function downloadInvoice(invoiceId: string): Promise<Blob> {
   }
 
   if (!response.ok) {
+    const details = await readApiErrorDetails(response)
+
     if (response.status === 401) {
       removeAuthToken()
       emit401Event()
-      throw new Error('Authentication failed. Please sign in again.')
+      throw createApiError(response.status, details, 'Authentication failed. Please sign in again.')
     }
-    throw new Error(`Failed to download invoice (${response.status}).`)
+
+    // Keep the legacy binary-download fallback for uncoded responses while
+    // honoring any structured backend code that is present.
+    throw createApiError(
+      response.status,
+      details,
+      `Failed to download invoice (${response.status}).`
+    )
   }
 
   return response.blob()

--- a/src/shared/utils/errorHandler.test.ts
+++ b/src/shared/utils/errorHandler.test.ts
@@ -1,137 +1,154 @@
-import { describe, it, expect } from 'vitest';
-import { getUserFriendlyError } from './errorHandler';
+import { describe, it, expect } from 'vitest'
+import { ApiError } from '../api/client'
+import { getUserFriendlyError } from './errorHandler'
 
 describe('getUserFriendlyError', () => {
   it('returns default message for falsy input', () => {
-    expect(getUserFriendlyError(null)).toBe(
-      'Something went wrong. Please try again.',
-    );
-    expect(getUserFriendlyError(undefined)).toBe(
-      'Something went wrong. Please try again.',
-    );
-    expect(getUserFriendlyError('')).toBe(
-      'Something went wrong. Please try again.',
-    );
-  });
+    expect(getUserFriendlyError(null)).toBe('Something went wrong. Please try again.')
+    expect(getUserFriendlyError(undefined)).toBe('Something went wrong. Please try again.')
+    expect(getUserFriendlyError('')).toBe('Something went wrong. Please try again.')
+  })
 
   it('maps network errors', () => {
     expect(getUserFriendlyError(new Error('Network error'))).toBe(
-      'Unable to connect to the server. Please check your internet connection and try again.',
-    );
+      'Unable to connect to the server. Please check your internet connection and try again.'
+    )
     expect(getUserFriendlyError(new Error('Failed to fetch'))).toBe(
-      'Unable to connect to the server. Please check your internet connection and try again.',
-    );
+      'Unable to connect to the server. Please check your internet connection and try again.'
+    )
     expect(getUserFriendlyError(new Error('Unable to connect'))).toBe(
-      'Unable to connect to the server. Please check your internet connection and try again.',
-    );
-  });
+      'Unable to connect to the server. Please check your internet connection and try again.'
+    )
+  })
 
   it('maps authentication errors', () => {
     expect(getUserFriendlyError(new Error('Authentication failed'))).toBe(
-      'Your session has expired. Please sign in again.',
-    );
+      'Your session has expired. Please sign in again.'
+    )
     expect(getUserFriendlyError(new Error('Unauthorized'))).toBe(
-      'Your session has expired. Please sign in again.',
-    );
+      'Your session has expired. Please sign in again.'
+    )
     expect(getUserFriendlyError(new Error('401'))).toBe(
-      'Your session has expired. Please sign in again.',
-    );
-  });
+      'Your session has expired. Please sign in again.'
+    )
+  })
 
   it('maps server errors', () => {
     expect(getUserFriendlyError(new Error('500'))).toBe(
-      'Our servers are experiencing issues. Please try again in a few moments.',
-    );
+      'Our servers are experiencing issues. Please try again in a few moments.'
+    )
     expect(getUserFriendlyError(new Error('Internal Server Error'))).toBe(
-      'Our servers are experiencing issues. Please try again in a few moments.',
-    );
+      'Our servers are experiencing issues. Please try again in a few moments.'
+    )
     expect(getUserFriendlyError(new Error('server error'))).toBe(
-      'Our servers are experiencing issues. Please try again in a few moments.',
-    );
-  });
+      'Our servers are experiencing issues. Please try again in a few moments.'
+    )
+  })
 
   it('maps not-found errors', () => {
     expect(getUserFriendlyError(new Error('404'))).toBe(
-      'The requested resource could not be found.',
-    );
+      'The requested resource could not be found.'
+    )
     expect(getUserFriendlyError(new Error('Not Found'))).toBe(
-      'The requested resource could not be found.',
-    );
+      'The requested resource could not be found.'
+    )
     expect(getUserFriendlyError(new Error('not found'))).toBe(
-      'The requested resource could not be found.',
-    );
-  });
+      'The requested resource could not be found.'
+    )
+  })
 
   it('maps timeout errors', () => {
     expect(getUserFriendlyError(new Error('timeout'))).toBe(
-      'The request took too long. Please try again.',
-    );
+      'The request took too long. Please try again.'
+    )
     expect(getUserFriendlyError(new Error('Timeout'))).toBe(
-      'The request took too long. Please try again.',
-    );
+      'The request took too long. Please try again.'
+    )
     expect(getUserFriendlyError(new Error('timed out'))).toBe(
-      'The request took too long. Please try again.',
-    );
-  });
+      'The request took too long. Please try again.'
+    )
+  })
 
   it('maps invalid response errors', () => {
     expect(getUserFriendlyError(new Error('Invalid response'))).toBe(
-      'We received an unexpected response from the server. Please try again.',
-    );
+      'We received an unexpected response from the server. Please try again.'
+    )
     expect(getUserFriendlyError(new Error('Invalid response format'))).toBe(
-      'We received an unexpected response from the server. Please try again.',
-    );
-  });
+      'We received an unexpected response from the server. Please try again.'
+    )
+  })
 
   it('maps generic API request failures', () => {
     expect(getUserFriendlyError(new Error('API request failed'))).toBe(
-      'Unable to complete your request. Please try again.',
-    );
+      'Unable to complete your request. Please try again.'
+    )
     expect(getUserFriendlyError(new Error('request failed'))).toBe(
-      'Unable to complete your request. Please try again.',
-    );
-  });
+      'Unable to complete your request. Please try again.'
+    )
+  })
+
+  it('returns the safe localized message from a coded ApiError', () => {
+    const error = new ApiError(
+      'El recurso solicitado no se pudo encontrar.',
+      404,
+      'NOT_FOUND',
+      'database row 42 was missing'
+    )
+
+    expect(getUserFriendlyError(error)).toBe('El recurso solicitado no se pudo encontrar.')
+    expect(getUserFriendlyError(error)).not.toContain('database')
+    expect(getUserFriendlyError(error)).not.toContain('42')
+  })
+
+  it('does not trust the raw message of an uncoded ApiError', () => {
+    const error = new ApiError(
+      'DatabaseError: password=secret for internal user 42',
+      500,
+      undefined,
+      'DatabaseError: password=secret for internal user 42'
+    )
+
+    expect(getUserFriendlyError(error)).toBe('Something went wrong. Please try again later.')
+    expect(getUserFriendlyError(error)).not.toContain('password')
+    expect(getUserFriendlyError(error)).not.toContain('secret')
+  })
 
   it('returns generic message for unrecognized errors', () => {
-    expect(
-      getUserFriendlyError(new Error('Some random error')),
-    ).toBe('Something went wrong. Please try again later.');
-  });
+    expect(getUserFriendlyError(new Error('Some random error'))).toBe(
+      'Something went wrong. Please try again later.'
+    )
+  })
 
   it('does not expose raw internal details in fallback messages', () => {
-    const rawError =
-      'DatabaseError: password reset token abc123 failed for /internal/users/42';
+    const rawError = 'DatabaseError: password reset token abc123 failed for /internal/users/42'
 
-    const friendlyMessage = getUserFriendlyError(new Error(rawError));
+    const friendlyMessage = getUserFriendlyError(new Error(rawError))
 
-    expect(friendlyMessage).toBe('Something went wrong. Please try again later.');
-    expect(friendlyMessage).not.toContain('DatabaseError');
-    expect(friendlyMessage).not.toContain('abc123');
-    expect(friendlyMessage).not.toContain('/internal/users/42');
-  });
+    expect(friendlyMessage).toBe('Something went wrong. Please try again later.')
+    expect(friendlyMessage).not.toContain('DatabaseError')
+    expect(friendlyMessage).not.toContain('abc123')
+    expect(friendlyMessage).not.toContain('/internal/users/42')
+  })
 
   it('does not echo raw details for mapped API errors', () => {
-    const rawError =
-      'API request failed: upstream returned traceId=secret-trace-789';
+    const rawError = 'API request failed: upstream returned traceId=secret-trace-789'
 
-    const friendlyMessage = getUserFriendlyError(new Error(rawError));
+    const friendlyMessage = getUserFriendlyError(new Error(rawError))
 
-    expect(friendlyMessage).toBe(
-      'Unable to complete your request. Please try again.',
-    );
-    expect(friendlyMessage).not.toContain('secret-trace-789');
-    expect(friendlyMessage).not.toContain('upstream');
-  });
+    expect(friendlyMessage).toBe('Unable to complete your request. Please try again.')
+    expect(friendlyMessage).not.toContain('secret-trace-789')
+    expect(friendlyMessage).not.toContain('upstream')
+  })
 
   it('handles string input directly', () => {
     expect(getUserFriendlyError('Network error')).toBe(
-      'Unable to connect to the server. Please check your internet connection and try again.',
-    );
-  });
+      'Unable to connect to the server. Please check your internet connection and try again.'
+    )
+  })
 
   it('handles non-Error objects', () => {
     expect(getUserFriendlyError({ code: 500 })).toBe(
-      'Something went wrong. Please try again later.',
-    );
-  });
-});
+      'Something went wrong. Please try again later.'
+    )
+  })
+})

--- a/src/shared/utils/errorHandler.ts
+++ b/src/shared/utils/errorHandler.ts
@@ -1,12 +1,22 @@
+import { ApiError } from '../api/client'
+
 /**
  * Converts technical error messages to user-friendly messages
  */
 export function getUserFriendlyError(error: unknown): string {
   if (!error) {
-    return 'Something went wrong. Please try again.';
+    return 'Something went wrong. Please try again.'
   }
 
-  const errorMessage = error instanceof Error ? error.message : String(error);
+  // Coded ApiError messages have already passed through the localized,
+  // allow-listed backend taxonomy. Uncoded errors must continue through the
+  // defensive substring/generic classifier below so raw server details are
+  // never echoed to users.
+  if (error instanceof ApiError && error.code) {
+    return error.message
+  }
+
+  const errorMessage = error instanceof Error ? error.message : String(error)
 
   /** Network errors: connectivity failures should not expose transport details. */
   if (
@@ -15,7 +25,7 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Failed to fetch') ||
     errorMessage.includes('Unable to connect')
   ) {
-    return 'Unable to connect to the server. Please check your internet connection and try again.';
+    return 'Unable to connect to the server. Please check your internet connection and try again.'
   }
 
   /** Authentication errors: expired or invalid sessions should prompt re-authentication. */
@@ -24,7 +34,7 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Unauthorized') ||
     errorMessage.includes('401')
   ) {
-    return 'Your session has expired. Please sign in again.';
+    return 'Your session has expired. Please sign in again.'
   }
 
   /** Server errors: backend failures should be reported without leaking internals. */
@@ -33,7 +43,7 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Internal Server Error') ||
     errorMessage.includes('server error')
   ) {
-    return 'Our servers are experiencing issues. Please try again in a few moments.';
+    return 'Our servers are experiencing issues. Please try again in a few moments.'
   }
 
   /** Not-found errors: missing resources should get a stable user-facing message. */
@@ -42,7 +52,7 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Not Found') ||
     errorMessage.includes('not found')
   ) {
-    return 'The requested resource could not be found.';
+    return 'The requested resource could not be found.'
   }
 
   /** Timeout errors: slow requests should guide users to retry. */
@@ -51,7 +61,7 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Timeout') ||
     errorMessage.includes('timed out')
   ) {
-    return 'The request took too long. Please try again.';
+    return 'The request took too long. Please try again.'
   }
 
   /** Invalid response errors: malformed API responses should remain generic. */
@@ -59,19 +69,15 @@ export function getUserFriendlyError(error: unknown): string {
     errorMessage.includes('Invalid response') ||
     errorMessage.includes('Invalid response format')
   ) {
-    return 'We received an unexpected response from the server. Please try again.';
+    return 'We received an unexpected response from the server. Please try again.'
   }
 
   /** Generic API errors: failed requests should avoid raw request details. */
-  if (
-    errorMessage.includes('API request failed') ||
-    errorMessage.includes('request failed')
-  ) {
-    return 'Unable to complete your request. Please try again.';
+  if (errorMessage.includes('API request failed') || errorMessage.includes('request failed')) {
+    return 'Unable to complete your request. Please try again.'
   }
 
   // For any other errors, return a generic message
   // This prevents exposing technical details to users
-  return 'Something went wrong. Please try again later.';
+  return 'Something went wrong. Please try again later.'
 }
-


### PR DESCRIPTION
## Summary

- introduces a typed `ApiError` that preserves HTTP status, backend error code, and original server message
- parses both top-level and nested structured backend error payloads
- resolves known backend codes through `getErrorCodeMessage` using the active validated stored locale
- maps unknown structured codes to the localized generic fallback instead of exposing raw backend text
- preserves existing behavior for uncoded legacy responses
- preserves 401 token cleanup and redirect signaling, 429 `RateLimitError` behavior, and 502/503 retry semantics
- wires coded `ApiError` messages through `getUserFriendlyError` so localization reaches the UI
- applies the same structured-code handling to the binary invoice-download path

## Validation

- `pnpm exec vitest run src/shared/api/client.test.ts src/shared/utils/errorHandler.test.ts src/shared/i18n/errors.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

Closes #804