### PR TITLE
fix: remove per-render debug log from EcosystemsPage ecosystem card map

### DIFF
--- a/src/features/dashboard/pages/EcosystemsPage.tsx
+++ b/src/features/dashboard/pages/EcosystemsPage.tsx
@@ -410,7 +410,6 @@ export function EcosystemsPage({ onEcosystemClick }: EcosystemsPageProps) {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-5">
           {filteredEcosystems.map((ecosystem) => {
-            logger.debug('Rendering ecosystem:', ecosystem)
             return (
               <div
                 key={ecosystem.id}


### PR DESCRIPTION
## Summary
- Removes the `logger.debug('Rendering ecosystem:', ecosystem)` call left inside the `filteredEcosystems.map()` render callback in `EcosystemsPage.tsx`.
- This call fired once per ecosystem on every render (search/filter changes, theme toggles, any parent re-render), adding unnecessary work in the render hot path and console noise in dev, unlike the file's other `logger.debug` calls which only fire once per fetch inside the data-fetch effect.
- Ecosystem card rendering is otherwise unchanged.

Fixes #794

## Test plan
- [x] Existing `EcosystemsPage.test.tsx` suite (33 tests) still covers rendering, search filtering, and re-render-triggering event dispatch - passes with the log removed.
- [x] Verified two unrelated pre-existing timeouts in that suite (`caps name at 120 characters`, `resets form fields after a successful submit`) also fail identically against the unmodified file, confirming they are unrelated to this change.