### PR TITLE
fix: treat project id of 0 as valid in isValidProject

### DIFF
--- a/src/shared/utils/projectFilter.test.ts
+++ b/src/shared/utils/projectFilter.test.ts
@@ -88,7 +88,7 @@ describe('isValidProject', () => {
   describe('rejects falsy or incomplete projects', () => {
     /**
      * Each case targets one short-circuit in the guard
-     * `!project || !project.id || !project.github_full_name`.
+     * `!project || project.id == null || !project.github_full_name`.
      */
     const invalidCases: ReadonlyArray<{ name: string; project: unknown }> = [
       { name: 'null', project: null },
@@ -96,7 +96,6 @@ describe('isValidProject', () => {
       { name: 'false', project: false },
       { name: 'missing id', project: { github_full_name: 'owner/repo' } },
       { name: 'empty-string id', project: makeProject({ id: '' }) },
-      { name: 'zero id', project: makeProject({ id: 0 }) },
       {
         name: 'missing github_full_name',
         project: { id: 'proj-1' },
@@ -145,6 +144,10 @@ describe('isValidProject', () => {
       {
         name: 'a numeric id',
         project: makeProject({ id: 42 }),
+      },
+      {
+        name: 'an id of 0 (falsy but valid)',
+        project: makeProject({ id: 0 }),
       },
       {
         name: 'a github_full_name without a slash',

--- a/src/shared/utils/projectFilter.ts
+++ b/src/shared/utils/projectFilter.ts
@@ -46,7 +46,7 @@ export function filterProjects<T extends FilterableProject>(
 }
 
 export function isValidProject(project: any): boolean {
-  if (!project || !project.id || !project.github_full_name) {
+  if (!project || project.id == null || project.id === '' || !project.github_full_name) {
     return false
   }
 


### PR DESCRIPTION
## Summary
Fixes `isValidProject` incorrectly rejecting projects with `id: 0`.

## Problem
The validator used a truthy check (`!project.id`). Since `0` is falsy in
JavaScript, projects with a numeric id of `0` were treated as invalid.

## Fix
Changed the check to explicitly test for `null`, `undefined`, and empty
string (`''`), while allowing `0` through as a valid id.

## Testing
- Moved the `id: 0` case from `invalidCases` to `validCases` in
  `projectFilter.test.ts`
- Confirmed empty-string id is still correctly rejected
- All 35 tests in `projectFilter.test.ts` pass

Fixes #714