### PR TITLE
fix: update calendar.tsx to react-day-picker v10's classNames/compone…

### DIFF
--- a/src/shared/components/ui/DatePicker.test.tsx
+++ b/src/shared/components/ui/DatePicker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DatePicker, parseUtcDate, formatUtcDate } from './DatePicker'
 import { renderWithTheme } from '../../../test/renderWithTheme'
@@ -122,13 +122,7 @@ describe('DatePicker Component', () => {
     expect(screen.getByText('*')).toBeInTheDocument()
   })
 
-  // Pre-existing bug, unrelated to CI setup: `./calendar.tsx` still uses
-  // react-day-picker v8's `classNames`/`components` API (e.g. `day_selected`,
-  // `IconLeft`/`IconRight`), but the installed dependency is v10.0.1, which
-  // replaced that API. The popover opens, but day-cell selection no longer
-  // wires up the same way, so these two interaction tests can't pass without
-  // rewriting the Calendar wrapper for the new API. Skipped pending that fix.
-  it.skip('should open calendar on click and call onChange when a day is selected', async () => {
+  it('should open calendar on click and call onChange when a day is selected', async () => {
     // Disable pointerEventsCheck since Radix uses custom pointer trapping
     const user = userEvent.setup({ pointerEventsCheck: 0 })
     const handleChange = vi.fn()
@@ -144,20 +138,22 @@ describe('DatePicker Component', () => {
     const dialog = await screen.findByRole('dialog')
     expect(dialog).toBeInTheDocument()
 
-    // Find the day button representing the 22nd day of the month by its gridcell role
+    // Find the grid cell representing the 22nd day of the month, then the
+    // interactive day button nested inside it (react-day-picker v10 puts the
+    // `gridcell` role on the cell and renders a separate `button` inside it)
     const dayCells = screen.getAllByRole('gridcell')
-    const dayButton = dayCells.find((btn) => btn.textContent === '22')
-    expect(dayButton).toBeDefined()
+    const dayCell = dayCells.find((cell) => cell.textContent === '22')
+    expect(dayCell).toBeDefined()
+    const dayButton = within(dayCell!).getByRole('button')
 
     // Select the new day
-    await user.click(dayButton!)
+    await user.click(dayButton)
 
     // onChange should be called with the selected date in yyyy-MM-dd format
     expect(handleChange).toHaveBeenCalledWith('2026-06-22')
   })
 
-  // Same pre-existing react-day-picker v8-vs-v10 API mismatch as above.
-  it.skip('should handle focus management when date is selected', async () => {
+  it('should handle focus management when date is selected', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 })
     const handleChange = vi.fn()
     renderWithTheme(<DatePicker value="2026-06-21" onChange={handleChange} />)
@@ -172,11 +168,12 @@ describe('DatePicker Component', () => {
     await screen.findByRole('dialog')
 
     const dayCells = screen.getAllByRole('gridcell')
-    const dayButton = dayCells.find((btn) => btn.textContent === '22')
-    expect(dayButton).toBeDefined()
+    const dayCell = dayCells.find((cell) => cell.textContent === '22')
+    expect(dayCell).toBeDefined()
+    const dayButton = within(dayCell!).getByRole('button')
 
     // Click a day
-    await user.click(dayButton!)
+    await user.click(dayButton)
 
     // Focus should return to the button
     await waitFor(() => {

--- a/src/shared/components/ui/DatePicker.tsx
+++ b/src/shared/components/ui/DatePicker.tsx
@@ -150,7 +150,12 @@ export function DatePicker({
             triggerRef.current?.focus()
           }}
         >
-          <Calendar mode="single" selected={calendarSelected} onSelect={handleSelect} />
+          <Calendar
+            mode="single"
+            selected={calendarSelected}
+            onSelect={handleSelect}
+            defaultMonth={calendarSelected}
+          />
         </PopoverContent>
       </Popover>
       {isError && <p className="text-[12px] mt-1.5 text-red-500">{error}</p>}

--- a/src/shared/components/ui/calendar.tsx
+++ b/src/shared/components/ui/calendar.tsx
@@ -2,9 +2,47 @@
 
 import * as React from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { DayPicker } from 'react-day-picker'
+import { DayPicker, type DayButtonProps } from 'react-day-picker'
 
 import { cn } from './utils'
+
+const navButtonClassNames = cn(
+  'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 border border-border text-foreground hover:bg-accent hover:text-accent-foreground rounded-md transition-colors'
+)
+
+function CalendarDayButton({ className, day, modifiers, ...props }: DayButtonProps) {
+  const ref = React.useRef<HTMLButtonElement>(null)
+
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-day={day.date.toDateString()}
+      data-selected={modifiers.selected || undefined}
+      data-range-start={modifiers.range_start || undefined}
+      data-range-end={modifiers.range_end || undefined}
+      data-range-middle={modifiers.range_middle || undefined}
+      data-today={modifiers.today || undefined}
+      data-outside={modifiers.outside || undefined}
+      className={cn(
+        'size-8 p-0 font-normal rounded-md transition-colors hover:bg-accent hover:text-accent-foreground text-foreground',
+        'data-[outside=true]:text-muted-foreground',
+        'data-[today=true]:bg-accent data-[today=true]:text-accent-foreground data-[today=true]:border data-[today=true]:border-border',
+        'data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground',
+        'data-[selected=true]:bg-[#c9983a] data-[selected=true]:text-white data-[selected=true]:hover:bg-[#c9983a]/90 data-[selected=true]:focus:bg-[#c9983a] data-[selected=true]:focus:text-white',
+        'data-[range-start=true]:bg-[#c9983a] data-[range-start=true]:text-white',
+        'data-[range-end=true]:bg-[#c9983a] data-[range-end=true]:text-white',
+        'disabled:text-muted-foreground disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 function Calendar({
   className,
@@ -16,54 +54,36 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn('p-3', className)}
-      classNames={
-        {
-          months: 'flex flex-col sm:flex-row gap-2',
-          month: 'flex flex-col gap-4',
-          caption: 'flex justify-center pt-1 relative items-center w-full',
-          caption_label: 'text-sm font-medium',
-          nav: 'flex items-center gap-1',
-          nav_button: cn(
-            'size-7 bg-transparent p-0 opacity-50 hover:opacity-100 border border-border text-foreground hover:bg-accent hover:text-accent-foreground rounded-md transition-colors'
+      classNames={{
+        months: 'flex flex-col sm:flex-row gap-2',
+        month: 'flex flex-col gap-4',
+        month_caption: 'flex justify-center pt-1 relative items-center w-full',
+        caption_label: 'text-sm font-medium',
+        nav: 'flex items-center gap-1',
+        button_previous: cn(navButtonClassNames, 'absolute left-1'),
+        button_next: cn(navButtonClassNames, 'absolute right-1'),
+        month_grid: 'w-full border-collapse space-x-1',
+        weekdays: 'flex',
+        weekday: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
+        week: 'flex w-full mt-2',
+        day: cn(
+          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([data-selected=true])]:bg-accent',
+          props.mode === 'range'
+            ? '[&:has([data-range-end=true])]:rounded-r-md [&:has([data-range-start=true])]:rounded-l-md first:[&:has([data-selected=true])]:rounded-l-md last:[&:has([data-selected=true])]:rounded-r-md'
+            : '[&:has([data-selected=true])]:rounded-md'
+        ),
+        hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ className: chevronClassName, orientation }) =>
+          orientation === 'right' ? (
+            <ChevronRight className={cn('size-4 text-foreground', chevronClassName)} />
+          ) : (
+            <ChevronLeft className={cn('size-4 text-foreground', chevronClassName)} />
           ),
-          nav_button_previous: 'absolute left-1',
-          nav_button_next: 'absolute right-1',
-          table: 'w-full border-collapse space-x-1',
-          head_row: 'flex',
-          head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
-          row: 'flex w-full mt-2',
-          cell: cn(
-            'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md',
-            props.mode === 'range'
-              ? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
-              : '[&:has([aria-selected])]:rounded-md'
-          ),
-          day: cn(
-            'size-8 p-0 font-normal aria-selected:opacity-100 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground text-foreground'
-          ),
-          day_range_start: 'day-range-start aria-selected:bg-[#c9983a] aria-selected:text-white',
-          day_range_end: 'day-range-end aria-selected:bg-[#c9983a] aria-selected:text-white',
-          day_selected:
-            'bg-[#c9983a] text-white hover:bg-[#c9983a]/90 focus:bg-[#c9983a] focus:text-white',
-          day_today: 'bg-accent text-accent-foreground border border-border',
-          day_outside: 'day-outside text-muted-foreground aria-selected:text-muted-foreground',
-          day_disabled: 'text-muted-foreground opacity-50',
-          day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
-          day_hidden: 'invisible',
-          ...classNames,
-        } as React.ComponentProps<typeof DayPicker>['classNames']
-      }
-      components={
-        {
-          IconLeft: ({ className: cls, ...rest }: { className?: string }) => (
-            <ChevronLeft className={cn('size-4 text-foreground', cls)} {...rest} />
-          ),
-          IconRight: ({ className: cls, ...rest }: { className?: string }) => (
-            <ChevronRight className={cn('size-4 text-foreground', cls)} {...rest} />
-          ),
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any
-      }
+        DayButton: CalendarDayButton,
+      }}
       {...props}
     />
   )


### PR DESCRIPTION
…nts API

react-day-picker v10 dropped the v8-era classNames keys (day_selected, day_range_start, etc.) and the IconLeft/IconRight components in favor of UI-element keys (day_button, selected, range_start, ...) and a single Chevron component. calendar.tsx still targeted the old API, so clicking a day never wired up selection against the installed v10.0.1 dependency.

Rewrite the DayPicker classNames/components config for v10, using a custom DayButton that reflects modifiers (selected/range/today/outside) as data attributes for styling, since v10 no longer applies those modifier classes to the day button itself. Also pass defaultMonth to Calendar in DatePicker.tsx so the popover opens on the selected date's month instead of the current month.

Un-skip the two DatePicker.test.tsx interaction tests, updating them to click the day button nested in the gridcell (v10 moved the gridcell role to the wrapping cell).

Closes #785