### PR TITLE
fix: use shared intl formatters in RewardsTab

### DIFF
--- a/src/features/dashboard/components/RewardsTab.test.tsx
+++ b/src/features/dashboard/components/RewardsTab.test.tsx
@@ -18,6 +18,15 @@ vi.mock('../../../shared/contexts/ThemeContext', () => ({
   }),
 }))
 
+vi.mock('../../../shared/i18n', () => ({
+  useIntlFormatters: () => ({
+    formatCurrency: (value: number, options: { currency: string; maximumFractionDigits?: number }) =>
+      new Intl.NumberFormat('en-US', { style: 'currency', ...options }).format(value),
+    formatDate: (date: Date, options?: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat('en-US', options).format(date),
+  }),
+}))
+
 import { RewardsTab } from './RewardsTab'
 
 // Radix UI components (Popover) require pointer-capture shims under jsdom.

--- a/src/features/dashboard/components/RewardsTab.tsx
+++ b/src/features/dashboard/components/RewardsTab.tsx
@@ -6,6 +6,7 @@ import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { useLocalStorage } from '../../../shared/hooks/useLocalStorage'
 import { Popover, PopoverContent, PopoverTrigger } from '../../../shared/components/ui/popover'
+import { useIntlFormatters, type UseIntlFormatters } from '../../../shared/i18n'
 
 type RewardRow = {
   id: string
@@ -38,7 +39,11 @@ const normalizeText = (value?: string | null) => {
  * invalid currency codes fall back to `USD` so `Intl.NumberFormat` cannot throw
  * and the UI never concatenates an `"undefined"` currency string.
  */
-function formatRewardAmount(amount?: number | string | null, currency?: string | null) {
+function formatRewardAmount(
+  amount: number | string | null | undefined,
+  currency: string | null | undefined,
+  formatCurrency: UseIntlFormatters['formatCurrency']
+) {
   const parsedAmount = typeof amount === 'number' ? amount : Number.parseFloat(String(amount ?? ''))
 
   if (!Number.isFinite(parsedAmount)) return fallbackText
@@ -46,42 +51,47 @@ function formatRewardAmount(amount?: number | string | null, currency?: string |
   const normalizedCurrency = currency?.trim().toUpperCase() || 'USD'
 
   try {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
+    return formatCurrency(parsedAmount, {
       currency: normalizedCurrency,
       maximumFractionDigits: Number.isInteger(parsedAmount) ? 0 : 2,
-    }).format(parsedAmount)
+    })
   } catch {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
+    return formatCurrency(parsedAmount, {
       currency: 'USD',
       maximumFractionDigits: Number.isInteger(parsedAmount) ? 0 : 2,
-    }).format(parsedAmount)
+    })
   }
 }
 
-const formatRewardDate = (reward: ProfileReward) => {
+const formatRewardDate = (
+  reward: ProfileReward,
+  formatDate: UseIntlFormatters['formatDate']
+) => {
   const dateValue = reward.date || reward.awarded_at || reward.created_at
   if (!dateValue) return fallbackText
 
   const date = new Date(dateValue)
   if (Number.isNaN(date.getTime())) return normalizeText(dateValue)
 
-  return new Intl.DateTimeFormat('en-US', {
+  return formatDate(date, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-  }).format(date)
+  })
 }
 
-const normalizeReward = (reward: ProfileReward): RewardRow => ({
+const normalizeReward = (
+  reward: ProfileReward,
+  formatCurrency: UseIntlFormatters['formatCurrency'],
+  formatDate: UseIntlFormatters['formatDate']
+): RewardRow => ({
   id: String(reward.id),
-  date: formatRewardDate(reward),
+  date: formatRewardDate(reward, formatDate),
   project: normalizeText(reward.project_name || reward.project),
   logo: normalizeText(reward.project_logo).slice(0, 2),
   from: normalizeText(reward.contributor_login || reward.from),
   contribution: normalizeText(reward.contribution_title || reward.contribution),
-  amount: formatRewardAmount(reward.amount, reward.currency),
+  amount: formatRewardAmount(reward.amount, reward.currency, formatCurrency),
   status: normalizeText(reward.status),
 })
 
@@ -168,6 +178,7 @@ function RewardsSkeleton() {
 
 export function RewardsTab() {
   const { theme } = useTheme()
+  const { formatCurrency, formatDate } = useIntlFormatters()
   const [isColumnsModalOpen, setIsColumnsModalOpen] = useState(false)
   const [selectedColumns, setSelectedColumns] = useLocalStorage<string[]>(
     'rewards_selected_columns',
@@ -189,7 +200,7 @@ export function RewardsTab() {
       .then((response) => {
         setState({
           status: 'ok',
-          rewards: (response.rewards || []).map(normalizeReward),
+          rewards: (response.rewards || []).map((r) => normalizeReward(r, formatCurrency, formatDate)),
         })
       })
       .catch(() => {

--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -18,7 +18,10 @@ vi.mock('../../../../shared/contexts/AuthContext', () => ({
 }))
 
 const mockGetProjectPRs = vi.mocked(getMaintainerPRs)
-const sourcePath = fileURLToPath(new URL('./PullRequestsTab.tsx', import.meta.url))
+const sourcePath = resolve(
+  process.cwd(),
+  'src/features/maintainers/components/pull-requests/PullRequestsTab.tsx'
+)
 
 const PROJECTS = [
   {

--- a/src/features/settings/components/notifications/NotificationRow.test.tsx
+++ b/src/features/settings/components/notifications/NotificationRow.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-pool=single
 // src/features/settings/components/notifications/NotificationRow.test.tsx
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NotificationRow } from './NotificationRow'
 import { ThemeProvider } from '../../../../shared/contexts/ThemeContext'
@@ -50,8 +50,12 @@ describe('NotificationRow optimistic mark-as-read', () => {
   })
 
   test('rolls back UI and shows error on API failure', async () => {
+    let rejectRequest!: (reason?: unknown) => void
     const onMarkAsRead = vi.fn<() => Promise<void>>(
-      () => new Promise((_, reject) => setTimeout(() => reject(new Error('API error')), 10))
+      () =>
+        new Promise((_, reject) => {
+          rejectRequest = reject
+        })
     )
     render(
       <ThemeWrapper>
@@ -63,6 +67,11 @@ describe('NotificationRow optimistic mark-as-read', () => {
     await userEvent.click(button)
     const row = screen.getByTestId('notification-row')
     expect(row).toHaveClass('opacity-50')
+
+    await act(async () => {
+      rejectRequest(new Error('API error'))
+    })
+
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to mark notification as read.')
     })


### PR DESCRIPTION
## Summary

- replaces hardcoded `en-US` currency and date formatting in `RewardsTab`
- routes reward formatting through the shared `useIntlFormatters` abstraction
- preserves invalid amount, date, and currency fallback behavior
- includes the existing CI-harness stabilization from #869 while that PR remains unmerged

## Validation

- focused `RewardsTab` suite: 18 tests passed
- full suite: 134 test files passed, 1,540 tests passed, 4 skipped
- TypeScript typecheck
- ESLint with zero errors
- production build
- `git diff --check`

Closes #796