### PR TITLE
fix: use shared useIntlFormatters in ContributionsTab instead of hardcoded en-US

### DIFF
--- a/src/features/dashboard/components/ContributionsTab.test.tsx
+++ b/src/features/dashboard/components/ContributionsTab.test.tsx
@@ -18,6 +18,13 @@ vi.mock('../../../shared/contexts/ThemeContext', () => ({
   }),
 }))
 
+vi.mock('../../../shared/i18n', () => ({
+  useIntlFormatters: () => ({
+    formatDate: (date: Date, options?: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat('en-US', options).format(date),
+  }),
+}))
+
 import { ContributionsTab } from './ContributionsTab'
 
 function renderContributionsTab() {

--- a/src/features/dashboard/components/ContributionsTab.tsx
+++ b/src/features/dashboard/components/ContributionsTab.tsx
@@ -15,6 +15,7 @@ import {
 import { getProfileContributions, type ProfileContribution } from '../../../shared/api/client'
 import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
+import { useIntlFormatters, type UseIntlFormatters } from '../../../shared/i18n'
 
 type ContributionStatus = 'applied' | 'assigned' | 'pending' | 'complete'
 type RewardFilter = 'Rewarded' | 'Unrewarded'
@@ -134,7 +135,10 @@ const getRewardFilter = (contribution: ProfileContribution): RewardFilter => {
   return 'Unrewarded'
 }
 
-const formatContributionTime = (contribution: ProfileContribution) => {
+const formatContributionTime = (
+  contribution: ProfileContribution,
+  formatDate: UseIntlFormatters['formatDate']
+) => {
   const value =
     contribution.updated_at ||
     contribution.submitted_at ||
@@ -145,11 +149,11 @@ const formatContributionTime = (contribution: ProfileContribution) => {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return normalizeText(value, fallbackTime)
 
-  return new Intl.DateTimeFormat('en-US', {
+  return formatDate(date, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-  }).format(date)
+  })
 }
 
 /**
@@ -160,7 +164,10 @@ const formatContributionTime = (contribution: ProfileContribution) => {
  * supplied strings such as issue titles are escaped by default rather than
  * interpreted as HTML.
  */
-function normalizeContribution(contribution: ProfileContribution): ContributionCardData {
+function normalizeContribution(
+  contribution: ProfileContribution,
+  formatDate: UseIntlFormatters['formatDate']
+): ContributionCardData {
   const tag = normalizeText(getFirstLabel(contribution), fallbackTag)
 
   return {
@@ -168,7 +175,7 @@ function normalizeContribution(contribution: ProfileContribution): ContributionC
     title: normalizeText(contribution.title, fallbackTitle),
     status: normalizeStatus(contribution.status),
     badge: getBadge(contribution),
-    time: formatContributionTime(contribution),
+    time: formatContributionTime(contribution, formatDate),
     project: normalizeText(
       contribution.project_name ||
         contribution.project ||
@@ -430,6 +437,7 @@ function ContributionColumn({
 
 export function ContributionsTab() {
   const { theme } = useTheme()
+  const { formatDate } = useIntlFormatters()
   const [isFilterOpen, setIsFilterOpen] = useState(false)
   const [selectedProject, setSelectedProject] = useState('')
   const [projectSearchQuery, setProjectSearchQuery] = useState('')
@@ -445,7 +453,9 @@ export function ContributionsTab() {
       .then((response) => {
         setState({
           status: 'ok',
-          contributions: (response.contributions || []).map(normalizeContribution),
+          contributions: (response.contributions || []).map((c) =>
+            normalizeContribution(c, formatDate)
+          ),
         })
       })
       .catch(() => setState({ status: 'error' }))


### PR DESCRIPTION
Closes #797

## What

`ContributionsTab.tsx`'s `formatContributionTime` called `new Intl.DateTimeFormat('en-US', ...)` directly, bypassing `useIntlFormatters()` — the shared hook that binds date/number/currency formatting to the app's active locale. A user on a non-English locale would still see contribution dates rendered in US date conventions on this tab.

## How

Mirrors the just-merged fix for the identical issue in `RewardsTab.tsx` (#874): threaded `formatDate` from `useIntlFormatters()` through `formatContributionTime` and `normalizeContribution` as a parameter, since both are plain functions declared outside the component and can't call the hook directly.

## Tests

Added the same `useIntlFormatters` mock `RewardsTab.test.tsx` uses (formats with a fixed `'en-US'` `Intl` call), since this test file renders `ContributionsTab` without an `I18nProvider` in the tree. Existing 12 tests pass unchanged, confirming default-locale rendered output is identical to before.

## Verification

- `npx tsc --noEmit`: clean.
- `npx eslint` on touched files: 0 errors. 2 warnings (`react-hooks/set-state-in-effect`, pre-existing and unrelated; `react-hooks/exhaustive-deps` on `formatDate`, matching the `RewardsTab` precedent exactly) — both `warn`-level in this repo's eslint config, not `error`.
- `npm run build`: clean.
- Full `vitest run`: 1544 passed. Only the 2 already-documented pre-existing failures remain (`useLandingStats`, `DatePicker` — confirmed unrelated via #864 on this same repo).