### PR TITLE
perf: use a stable trend-icon lookup in ProjectsTable, matching ContributorsTable

### DIFF
--- a/src/features/leaderboard/components/ProjectsTable.test.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.test.tsx
@@ -133,6 +133,63 @@ describe('ProjectsTable — View Project navigation', () => {
   })
 })
 
+describe('ProjectsTable — trend icons', () => {
+  /** The trend cell is the second column of a row; icons live inside it. */
+  const trendIcons = (container: HTMLElement) =>
+    Array.from(
+      container.querySelectorAll<SVGElement>('svg[class*="lucide-trending"], svg.lucide-minus')
+    )
+
+  it.each([
+    ['up' as const, 'lucide-trending-up', 'text-green-600'],
+    ['down' as const, 'lucide-trending-down', 'text-red-600'],
+    ['same' as const, 'lucide-minus', 'text-[#7a6b5a]'],
+  ])('renders the %s trend with its icon and colour', (trend, iconClass, colourClass) => {
+    const { container } = renderTable([{ ...projects[0], trend }])
+
+    const icons = trendIcons(container)
+    expect(icons).toHaveLength(1)
+    expect(icons[0]).toHaveClass(iconClass, 'w-4', 'h-4', colourClass)
+  })
+
+  it('renders one icon per row even when rows share the same trend', () => {
+    const { container } = renderTable([
+      { ...projects[0], trend: 'up' },
+      { ...projects[1], trend: 'up' },
+    ])
+
+    // The icons come from a shared, module-level lookup; reusing the same
+    // element across rows must still produce one distinct node per row.
+    const icons = trendIcons(container)
+    expect(icons).toHaveLength(2)
+    expect(icons[0]).not.toBe(icons[1])
+    icons.forEach((icon) => expect(icon).toHaveClass('lucide-trending-up', 'text-green-600'))
+  })
+
+  it('keeps trend icons stable across re-renders with unchanged data', () => {
+    const { container, rerender } = renderTable()
+    const before = trendIcons(container)
+
+    rerender(
+      <ThemeProvider>
+        <MemoryRouter initialEntries={['/dashboard/leaderboard']}>
+          <Routes>
+            <Route
+              path="/dashboard/leaderboard"
+              element={<ProjectsTable data={projects} activeFilter="overall" isLoaded />}
+            />
+            <Route path="/dashboard/projects/:projectId" element={<ProjectProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    )
+
+    const after = trendIcons(container)
+    expect(after).toHaveLength(before.length)
+    after.forEach((icon, i) => expect(icon).toBe(before[i]))
+  })
+})
+
 describe('ProjectsTable states', () => {
   it('renders an accessible empty state for zero rows', () => {
     renderTable([])

--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -19,11 +19,16 @@ interface ProjectsTableProps {
   onRetry?: () => void
 }
 
-const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
-  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
-  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
-  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
-}
+// ---------------------------------------------------------------------------
+// Stable icon map - avoids creating new JSX nodes on every getTrendIcon call.
+// ---------------------------------------------------------------------------
+const TREND_ICONS = {
+  up: <TrendingUp className="w-4 h-4 text-green-600" />,
+  down: <TrendingDown className="w-4 h-4 text-red-600" />,
+  same: <Minus className="w-4 h-4 text-[#7a6b5a]" />,
+} as const
+
+const getTrendIcon = (trend: 'up' | 'down' | 'same') => TREND_ICONS[trend]
 
 /**
  * Build the in-app route to a project's detail page.


### PR DESCRIPTION
Closes #791

## What

`ProjectsTable`'s `getTrendIcon` built a fresh JSX element on every call:

```tsx
const getTrendIcon = (trend: 'up' | 'down' | 'same') => {
  if (trend === 'up') return <TrendingUp className="w-4 h-4 text-green-600" />
  if (trend === 'down') return <TrendingDown className="w-4 h-4 text-red-600" />
  return <Minus className="w-4 h-4 text-[#7a6b5a]" />
}
```

Since the table calls it once per row, every render allocated one new icon element per row. Its sibling `ContributorsTable` already hoists the same three trend icons into a module-level lookup for exactly this reason, with a comment documenting the intent.

This PR applies that same pattern to `ProjectsTable`, so the icons are created once at module scope and reused across rows and renders:

```tsx
// ---------------------------------------------------------------------------
// Stable icon map - avoids creating new JSX nodes on every getTrendIcon call.
// ---------------------------------------------------------------------------
const TREND_ICONS = {
  up: <TrendingUp className="w-4 h-4 text-green-600" />,
  down: <TrendingDown className="w-4 h-4 text-red-600" />,
  same: <Minus className="w-4 h-4 text-[#7a6b5a]" />,
} as const

const getTrendIcon = (trend: 'up' | 'down' | 'same') => TREND_ICONS[trend]
```

The const is structurally identical to `ContributorsTable.tsx`'s, including the comment banner, so the two siblings now read the same.

## Tests

Added a `ProjectsTable — trend icons` block to the existing suite:

- Each of the three trend states renders its expected icon and colour class. The `down` branch previously had no test at all — the fixtures only ever used `up` and `same`.
- Rows sharing a trend still render one distinct icon node each. This is the one real risk of a shared-element lookup, so it is asserted directly.
- Icon nodes are preserved across a re-render with unchanged data.

## Verification

- `ProjectsTable.test.tsx`: 14 passed
- Full leaderboard suite: 76 passed, 2 skipped across 12 files — no regressions
- `ProjectsTable.tsx` coverage: 100% statements / functions / lines
- `tsc --noEmit` clean; ESLint reports no new issues

## Acceptance criteria

- [x] `getTrendIcon` returns from a stable, module-level lookup object instead of constructing new JSX per call
- [x] Rendered trend icons are visually unchanged — same components, same `w-4 h-4` sizing, same colour classes, now asserted per trend
