### PR TITLE
fix: type ProjectsTab's project prop instead of any

### DIFF
--- a/src/features/dashboard/components/ProjectsTab.tsx
+++ b/src/features/dashboard/components/ProjectsTab.tsx
@@ -3,12 +3,26 @@ import { GithubIcon } from '../../../shared/components/GithubIcon'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { useMemo, useCallback, memo } from 'react'
 
+interface Project {
+  id: string | number
+  logo: string
+  name: string
+  lead?: string
+  billingProfile?: string
+  contributors: number
+  availableIssues: string
+  myContributions: number
+  myRewards: string
+  languages: string[]
+  repository?: string
+}
+
 /**
  * Props for the ProjectRow component.
  */
 interface ProjectRowProps {
   /** The project data to display. */
-  project: any
+  project: Project
   /** The index of the row, used for alternating background colors. */
   idx: number
   /** The current theme ("dark" or "light"). */
@@ -176,7 +190,7 @@ const ProjectRow = memo(({ project, idx, theme, getLanguageIcon }: ProjectRowPro
  */
 interface ProjectMobileCardProps {
   /** The project data to display. */
-  project: any
+  project: Project
   /** The current theme ("dark" or "light"). */
   theme: string
   /** Helper function to get the icon and color for a given language. */


### PR DESCRIPTION
Closes #781

## Summary
Replaces `project: any` in both `ProjectRowProps` and `ProjectMobileCardProps` with a proper `Project` interface, defined locally in `ProjectsTab.tsx`.

## Changes
- Added a `Project` interface covering all fields read by the desktop `ProjectRow` and mobile `ProjectMobileCard` components (id, logo, name, lead, billingProfile, contributors, availableIssues, myContributions, myRewards, languages, repository).
- Replaced both `project: any` declarations with `project: Project`.

## Verification
- `tsc --noEmit` passes with no errors.
- Existing tests in `ProjectsTab.test.tsx` pass (3/3).
- No JSX or rendering logic was changed, only type annotations, so visual output is unaffected.

## Notes
Kept this scoped strictly to the type-safety fix, as intended, and didn't touch the "See project" button logic, since it has two other open issues tracking it separately.