### PR TITLE
fix(RoleGuard): fall back to in-app home route when there is no history to go back to

### DIFF
--- a/src/shared/components/RoleGuard.test.tsx
+++ b/src/shared/components/RoleGuard.test.tsx
@@ -1,153 +1,211 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { RoleGuard } from './RoleGuard';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RoleGuard } from './RoleGuard'
 
 // ─── mock dependencies ────────────────────────────────────────────────────────
 
 vi.mock('../contexts/AuthContext', () => ({
   useAuth: vi.fn(),
-}));
+}))
 
 vi.mock('../contexts/ThemeContext', () => ({
   useTheme: () => ({ theme: 'dark' }),
-}));
+}))
 
-import { useAuth } from '../contexts/AuthContext';
+vi.mock('react-router-dom', () => ({
+  useNavigate: vi.fn(),
+}))
 
-const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
+import { useAuth } from '../contexts/AuthContext'
+import { useNavigate } from 'react-router-dom'
+
+const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>
+const mockUseNavigate = useNavigate as unknown as ReturnType<typeof vi.fn>
+const mockNavigate = vi.fn()
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 function setRole(role: string | null) {
-  mockUseAuth.mockReturnValue({ userRole: role });
+  mockUseAuth.mockReturnValue({ userRole: role })
 }
 
-const ProtectedContent = () => <div>protected content</div>;
+const ProtectedContent = () => <div>protected content</div>
 
 // ─── tests ────────────────────────────────────────────────────────────────────
 
 describe('RoleGuard', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-  });
+    vi.clearAllMocks()
+    mockUseNavigate.mockReturnValue(mockNavigate)
+  })
 
   describe('allowed role', () => {
     it('renders children when userRole matches a single allowed role', () => {
-      setRole('admin');
+      setRole('admin')
       render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('protected content')).toBeInTheDocument();
-    });
+        </RoleGuard>
+      )
+      expect(screen.getByText('protected content')).toBeInTheDocument()
+    })
 
     it('renders children when userRole is one of multiple allowed roles', () => {
-      setRole('maintainer');
+      setRole('maintainer')
       render(
         <RoleGuard allow={['admin', 'maintainer']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('protected content')).toBeInTheDocument();
-    });
-  });
+        </RoleGuard>
+      )
+      expect(screen.getByText('protected content')).toBeInTheDocument()
+    })
+  })
 
   describe('disallowed role', () => {
     it('renders unauthorized state when role is not in allow list', () => {
-      setRole('contributor');
+      setRole('contributor')
       render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.queryByText('protected content')).not.toBeInTheDocument();
-      expect(screen.getByText('Access Restricted')).toBeInTheDocument();
-    });
+        </RoleGuard>
+      )
+      expect(screen.queryByText('protected content')).not.toBeInTheDocument()
+      expect(screen.getByText('Access Restricted')).toBeInTheDocument()
+    })
 
     it('renders unauthorized state when role is maintainer and only admin is allowed', () => {
-      setRole('maintainer');
+      setRole('maintainer')
       render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('Access Restricted')).toBeInTheDocument();
-    });
-  });
+        </RoleGuard>
+      )
+      expect(screen.getByText('Access Restricted')).toBeInTheDocument()
+    })
+  })
 
   describe('null role', () => {
     it('renders unauthorized state when userRole is null', () => {
-      setRole(null);
+      setRole(null)
       render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.queryByText('protected content')).not.toBeInTheDocument();
-      expect(screen.getByText('Access Restricted')).toBeInTheDocument();
-    });
-  });
+        </RoleGuard>
+      )
+      expect(screen.queryByText('protected content')).not.toBeInTheDocument()
+      expect(screen.getByText('Access Restricted')).toBeInTheDocument()
+    })
+  })
 
   describe('custom fallback', () => {
     it('renders custom fallback instead of default unauthorized state when access is denied', () => {
-      setRole('contributor');
+      setRole('contributor')
       render(
         <RoleGuard allow={['admin']} fallback={<div>custom fallback</div>}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('custom fallback')).toBeInTheDocument();
-      expect(screen.queryByText('Access Restricted')).not.toBeInTheDocument();
-    });
+        </RoleGuard>
+      )
+      expect(screen.getByText('custom fallback')).toBeInTheDocument()
+      expect(screen.queryByText('Access Restricted')).not.toBeInTheDocument()
+    })
 
     it('does not render custom fallback when role is allowed', () => {
-      setRole('admin');
+      setRole('admin')
       render(
         <RoleGuard allow={['admin']} fallback={<div>custom fallback</div>}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('protected content')).toBeInTheDocument();
-      expect(screen.queryByText('custom fallback')).not.toBeInTheDocument();
-    });
-  });
+        </RoleGuard>
+      )
+      expect(screen.getByText('protected content')).toBeInTheDocument()
+      expect(screen.queryByText('custom fallback')).not.toBeInTheDocument()
+    })
+  })
 
   describe('role switch updates', () => {
     it('re-renders correctly when userRole changes from disallowed to allowed', () => {
-      mockUseAuth.mockReturnValue({ userRole: 'contributor' });
+      mockUseAuth.mockReturnValue({ userRole: 'contributor' })
       const { rerender } = render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.queryByText('protected content')).not.toBeInTheDocument();
+        </RoleGuard>
+      )
+      expect(screen.queryByText('protected content')).not.toBeInTheDocument()
 
-      mockUseAuth.mockReturnValue({ userRole: 'admin' });
+      mockUseAuth.mockReturnValue({ userRole: 'admin' })
       rerender(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('protected content')).toBeInTheDocument();
-    });
+        </RoleGuard>
+      )
+      expect(screen.getByText('protected content')).toBeInTheDocument()
+    })
 
     it('re-renders correctly when userRole changes from allowed to disallowed', () => {
-      mockUseAuth.mockReturnValue({ userRole: 'admin' });
+      mockUseAuth.mockReturnValue({ userRole: 'admin' })
       const { rerender } = render(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('protected content')).toBeInTheDocument();
+        </RoleGuard>
+      )
+      expect(screen.getByText('protected content')).toBeInTheDocument()
 
-      mockUseAuth.mockReturnValue({ userRole: 'contributor' });
+      mockUseAuth.mockReturnValue({ userRole: 'contributor' })
       rerender(
         <RoleGuard allow={['admin']}>
           <ProtectedContent />
-        </RoleGuard>,
-      );
-      expect(screen.getByText('Access Restricted')).toBeInTheDocument();
-    });
-  });
-});
+        </RoleGuard>
+      )
+      expect(screen.getByText('Access Restricted')).toBeInTheDocument()
+    })
+  })
+
+  describe('"Go Back" button', () => {
+    const originalState = window.history.state
+
+    afterEach(() => {
+      window.history.replaceState(originalState, '')
+    })
+
+    it('navigates back in-app when there is prior in-app history', () => {
+      window.history.replaceState({ idx: 2 }, '')
+      setRole('contributor')
+      render(
+        <RoleGuard allow={['admin']}>
+          <ProtectedContent />
+        </RoleGuard>
+      )
+
+      screen.getByRole('button', { name: 'Go Back' }).click()
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1)
+    })
+
+    it('redirects to the home route instead of leaving the app when there is no in-app history', () => {
+      window.history.replaceState({ idx: 0 }, '')
+      setRole('contributor')
+      render(
+        <RoleGuard allow={['admin']}>
+          <ProtectedContent />
+        </RoleGuard>
+      )
+
+      screen.getByRole('button', { name: 'Go Back' }).click()
+
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+    })
+
+    it('redirects to the home route when history state has no idx (e.g. a deep link)', () => {
+      window.history.replaceState(null, '')
+      setRole('contributor')
+      render(
+        <RoleGuard allow={['admin']}>
+          <ProtectedContent />
+        </RoleGuard>
+      )
+
+      screen.getByRole('button', { name: 'Go Back' }).click()
+
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+    })
+  })
+})

--- a/src/shared/components/RoleGuard.tsx
+++ b/src/shared/components/RoleGuard.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from 'react';
-import { ShieldOff } from 'lucide-react';
-import { useAuth, type UserRole } from '../contexts/AuthContext';
-import { useTheme } from '../contexts/ThemeContext';
+import type { ReactNode } from 'react'
+import { ShieldOff } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth, type UserRole } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
 
 /** Roles that can be passed to the `allow` prop. */
-export type AllowedRole = Exclude<UserRole, null>;
+export type AllowedRole = Exclude<UserRole, null>
 
 export interface RoleGuardProps {
   /**
@@ -12,14 +13,14 @@ export interface RoleGuardProps {
    * @example allow={['admin']}
    * @example allow={['admin', 'maintainer']}
    */
-  allow: AllowedRole[];
+  allow: AllowedRole[]
   /** Content rendered when the user has an allowed role. */
-  children: ReactNode;
+  children: ReactNode
   /**
    * Optional custom fallback rendered when access is denied.
    * When omitted the built-in themed "Unauthorized" state is shown.
    */
-  fallback?: ReactNode;
+  fallback?: ReactNode
 }
 
 /**
@@ -34,18 +35,33 @@ export interface RoleGuardProps {
  * client-side checks for security.
  */
 export function RoleGuard({ allow, children, fallback }: RoleGuardProps) {
-  const { userRole } = useAuth();
+  const { userRole } = useAuth()
 
   if (userRole !== null && allow.includes(userRole as AllowedRole)) {
-    return <>{children}</>;
+    return <>{children}</>
   }
 
-  return fallback !== undefined ? <>{fallback}</> : <UnauthorizedState />;
+  return fallback !== undefined ? <>{fallback}</> : <UnauthorizedState />
 }
 
 function UnauthorizedState() {
-  const { theme } = useTheme();
-  const dark = theme === 'dark';
+  const { theme } = useTheme()
+  const navigate = useNavigate()
+  const dark = theme === 'dark'
+
+  // `window.history.state.idx` is stamped by react-router's browser history
+  // on every entry it pushes. A value > 0 means there is an in-app entry to
+  // return to; otherwise (deep link, new tab, first navigation) falling back
+  // to `history.back()` would leave the app entirely or no-op, stranding the
+  // user on this screen with no way back in.
+  const handleGoBack = () => {
+    const idx = (window.history.state as { idx?: number } | null)?.idx
+    if (typeof idx === 'number' && idx > 0) {
+      navigate(-1)
+    } else {
+      navigate('/', { replace: true })
+    }
+  }
 
   return (
     <div
@@ -62,9 +78,7 @@ function UnauthorizedState() {
       {/* Card */}
       <div
         className={`relative z-10 w-full max-w-md backdrop-blur-[40px] border rounded-[28px] p-8 shadow-[0_8px_32px_rgba(0,0,0,0.08)] transition-colors ${
-          dark
-            ? 'bg-white/[0.08] border-white/15'
-            : 'bg-white/[0.15] border-white/25'
+          dark ? 'bg-white/[0.08] border-white/15' : 'bg-white/[0.15] border-white/25'
         }`}
       >
         {/* Icon */}
@@ -83,18 +97,15 @@ function UnauthorizedState() {
           >
             Access Restricted
           </h2>
-          <p
-            className={`text-sm transition-colors ${
-              dark ? 'text-[#d4c5b0]' : 'text-[#7a6b5a]'
-            }`}
-          >
-            You don't have permission to view this page. Contact an administrator if you believe this is a mistake.
+          <p className={`text-sm transition-colors ${dark ? 'text-[#d4c5b0]' : 'text-[#7a6b5a]'}`}>
+            You don't have permission to view this page. Contact an administrator if you believe
+            this is a mistake.
           </p>
         </div>
 
         {/* Action */}
         <button
-          onClick={() => window.history.back()}
+          onClick={handleGoBack}
           className={`w-full py-3 rounded-[12px] font-medium transition-all flex items-center justify-center ${
             dark
               ? 'bg-white/[0.08] hover:bg-white/[0.12] text-[#f5efe5] border border-white/15'
@@ -105,5 +116,5 @@ function UnauthorizedState() {
         </button>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
`RoleGuard`'s unauthorized-state "Go Back" button called `window.history.back()` unconditionally. When a user lands on a protected route with no prior in-app history (deep link, new tab, first navigation after auth), this either no-ops or navigates the user out of the app entirely to whatever was previously in the tab's browser history, stranding them.

Fix: check `window.history.state.idx` (stamped by react-router's browser history on every entry it pushes) — if there's a prior in-app entry (`idx > 0`), navigate back via `navigate(-1)`; otherwise redirect to `/` with `replace: true` so the user lands somewhere useful in-app instead.

## Tests
Added three cases covering: in-app history present (navigates back), no in-app history (`idx: 0`, redirects home), and no history state at all / deep link (`null`, redirects home). Existing tests needed `react-router-dom`'s `useNavigate` mocked since `UnauthorizedState` now calls it — updated the mock setup accordingly; all previously-passing assertions are unchanged.

`npx vitest run src/shared/components/RoleGuard.test.tsx`: 12/12 pass. `npx eslint` clean. `tsc --noEmit` clean (ran automatically via the repo's pre-push hook).

Closes #723