### PR TITLE
fix(PaymentMethodsTab): add aria-label to copy-address button and handle clipboard write failures

### DIFF
--- a/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { screen, within } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { screen, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { PaymentMethodsTab, validateWalletAddress } from './PaymentMethodsTab'
 import { renderWithTheme } from '../../../../test/renderWithTheme'
@@ -357,5 +357,61 @@ describe('PaymentMethodsTab - delete confirmation', () => {
 
     expect(onRemovePaymentMethod).toHaveBeenCalledTimes(1)
     expect(onRemovePaymentMethod).toHaveBeenCalledWith(2)
+  })
+})
+
+describe('PaymentMethodsTab - copy address', () => {
+  const sampleMethods: PaymentMethod[] = [
+    {
+      id: 1,
+      ecosystem: 'stellar',
+      cryptoType: 'usdc',
+      walletAddress: VALID_G,
+      isDefault: false,
+      createdAt: '2024-01-15T10:00:00Z',
+    },
+  ]
+
+  const originalClipboard = navigator.clipboard
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    })
+  })
+
+  function stubClipboard(writeText: ReturnType<typeof vi.fn>) {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+  }
+
+  it('has an accessible name before copying', () => {
+    setup(sampleMethods)
+    expect(screen.getByRole('button', { name: 'Copy wallet address' })).toBeInTheDocument()
+  })
+
+  it('updates the accessible name and copies the address on click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    stubClipboard(writeText)
+    setup(sampleMethods)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy wallet address' }))
+
+    expect(writeText).toHaveBeenCalledWith(VALID_G)
+    expect(await screen.findByRole('button', { name: 'Address copied' })).toBeInTheDocument()
+  })
+
+  it('shows an alert instead of silently failing when the clipboard write rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'))
+    stubClipboard(writeText)
+    setup(sampleMethods)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy wallet address' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't copy address/i)
+    expect(screen.getByRole('button', { name: 'Copy wallet address' })).toBeInTheDocument()
   })
 })

--- a/src/features/settings/components/billing/PaymentMethodsTab.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.tsx
@@ -58,6 +58,7 @@ export function PaymentMethodsTab({
   const [walletAddress, setWalletAddress] = useState('')
   const [walletAddressError, setWalletAddressError] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<number | null>(null)
+  const [copyErrorId, setCopyErrorId] = useState<number | null>(null)
   const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
 
   const getAvailableCryptos = (): CryptoType[] => ['usdc', 'usdt', 'xlm']
@@ -91,9 +92,18 @@ export function PaymentMethodsTab({
   }
 
   const handleCopyAddress = (id: number, address: string) => {
-    navigator.clipboard.writeText(address)
-    setCopiedId(id)
-    setTimeout(() => setCopiedId(null), 2000)
+    navigator.clipboard
+      .writeText(address)
+      .then(() => {
+        setCopyErrorId(null)
+        setCopiedId(id)
+        setTimeout(() => setCopiedId(null), 2000)
+      })
+      .catch(() => {
+        setCopiedId(null)
+        setCopyErrorId(id)
+        setTimeout(() => setCopyErrorId(null), 2000)
+      })
   }
 
   const getEcosystemColor = (_ecosystem: EcosystemType) => '#14B6E7' // Stellar brand color
@@ -187,6 +197,10 @@ export function PaymentMethodsTab({
                       </code>
                       <button
                         onClick={() => handleCopyAddress(method.id, method.walletAddress)}
+                        aria-label={
+                          copiedId === method.id ? 'Address copied' : 'Copy wallet address'
+                        }
+                        aria-live="polite"
                         className={`p-1.5 rounded-[8px] transition-all ${
                           theme === 'dark' ? 'hover:bg-white/[0.15]' : 'hover:bg-white/[0.2]'
                         }`}
@@ -202,6 +216,11 @@ export function PaymentMethodsTab({
                         )}
                       </button>
                     </div>
+                    {copyErrorId === method.id && (
+                      <p role="alert" className="text-[12px] text-[#e05252] mb-2">
+                        Couldn't copy address. Please copy it manually.
+                      </p>
+                    )}
 
                     <p
                       className={`text-[12px] transition-colors ${


### PR DESCRIPTION
## Summary
The copy-address button in `PaymentMethodsTab` had no accessible name (icon-only, no `aria-label`), so screen reader users couldn't tell what it did. It also called `navigator.clipboard.writeText()` without handling rejection — a denied clipboard permission or unsupported browser silently did nothing, with no feedback and an unhandled promise rejection.

Fix:
- `aria-label` toggling between "Copy wallet address" / "Address copied" (mirrors the existing icon swap), plus `aria-live="polite"` so the state change is announced
- `.writeText()` now has a real `.then()/.catch()`: success sets `copiedId` as before; failure sets a new `copyErrorId` that renders a `role="alert"` message instead of failing silently

## Tests
Added a "copy address" suite: accessible name before copy, name updates and clipboard is called on success, and the alert renders (without changing the button's own label back) on a rejected write. Had to stub `navigator.clipboard` via `Object.defineProperty` (jsdom doesn't implement it) and switch those two new assertions to `fireEvent.click` — `userEvent.click` didn't dispatch through to this button reliably in this environment for reasons unrelated to the fix itself; existing tests are untouched.

`npx vitest run src/features/settings/components/billing/PaymentMethodsTab.test.tsx`: 33/33 pass. `npx eslint`: 1 pre-existing unrelated warning (`_ecosystem` unused param, not touched by this change), 0 errors. `tsc --noEmit`: clean (repo's pre-push hook).

Closes #751