### PR TITLE
fix(PaymentMethodsTab): generate unique payment method ids with a counter instead of Date.now()

### DIFF
--- a/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
@@ -151,6 +151,27 @@ describe('PaymentMethodsTab - wallet address validation', () => {
     )
   })
 
+  it('assigns distinct ids to two payment methods added within the same millisecond', async () => {
+    const fixedNow = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(fixedNow)
+
+    const { onAddPaymentMethod } = setup()
+    await openModal()
+    await typeAddress(VALID_G)
+    await submit()
+
+    await openModal()
+    await typeAddress(VALID_C)
+    await submit()
+
+    expect(onAddPaymentMethod).toHaveBeenCalledTimes(2)
+    const firstId = onAddPaymentMethod.mock.calls[0][0].id
+    const secondId = onAddPaymentMethod.mock.calls[1][0].id
+    expect(firstId).not.toBe(secondId)
+
+    vi.restoreAllMocks()
+  })
+
   it('trims whitespace before validation and uses trimmed address', async () => {
     const { onAddPaymentMethod } = setup()
     await openModal()

--- a/src/features/settings/components/billing/PaymentMethodsTab.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.tsx
@@ -38,6 +38,13 @@ export function validateWalletAddress(address: string): string | null {
   return null
 }
 
+// Monotonically increasing, seeded from the current timestamp so ids stay
+// roughly chronological. A plain `Date.now()` per add can collide when two
+// payment methods are added within the same millisecond (e.g. rapid
+// double-submit); incrementing guarantees every id generated in this
+// session is unique regardless of timing.
+let nextPaymentMethodId = Date.now()
+
 interface PaymentMethodsTabProps {
   paymentMethods: PaymentMethod[]
   onAddPaymentMethod: (method: PaymentMethod) => void
@@ -75,7 +82,7 @@ export function PaymentMethodsTab({
     setWalletAddressError(null)
 
     const newMethod: PaymentMethod = {
-      id: Date.now(),
+      id: nextPaymentMethodId++,
       ecosystem: selectedEcosystem,
       cryptoType: selectedCrypto,
       walletAddress: trimmed,


### PR DESCRIPTION
## Summary
New payment method ids were generated with `Date.now()`. Two payment methods added within the same millisecond (e.g. a fast double-submit, or a slow/fast click sequence on a quick machine) get the same `id`, which breaks anything keyed on it (React list `key`, `onRemovePaymentMethod(id)`, `onSetDefault(id)` would target/remove the wrong or both entries).

Fix: a module-level counter seeded once from `Date.now()` at load time, incremented on every add. This keeps ids roughly chronological (same ballpark of magnitude as before) while guaranteeing every id generated in a session is strictly unique, regardless of timing.

## Tests
Added a test that stubs `Date.now()` to return a fixed value and adds two payment methods back-to-back, asserting the two `onAddPaymentMethod` calls receive different ids — this reproduces the collision against the old code (fails without the fix) and passes with it.

`npx vitest run src/features/settings/components/billing/PaymentMethodsTab.test.tsx`: 31/31 pass. `npx eslint`: 1 pre-existing unrelated warning, 0 errors. `tsc --noEmit`: clean.

Closes #742