### PR TITLE
fix: wire up the dead SearchPage submit-search button

### DIFF
--- a/src/features/dashboard/pages/SearchPage.test.tsx
+++ b/src/features/dashboard/pages/SearchPage.test.tsx
@@ -96,6 +96,25 @@ describe('SearchPage Accessibility and Functionality', () => {
     expect(projectResults.length).toBeGreaterThan(0)
   })
 
+  it('should run the search immediately when "Submit search" is clicked, without waiting for the debounce', () => {
+    renderSearchPage()
+
+    const searchInput = screen.getByRole('textbox', {
+      name: 'Search issues, projects, and contributors',
+    })
+    fireEvent.change(searchInput, { target: { value: 'React' } })
+
+    // Before the debounce timer fires, results aren't shown yet.
+    expect(screen.queryByText(/Search Results/)).not.toBeInTheDocument()
+
+    // Clicking submit runs the search against the current query right away.
+    const submitButton = screen.getByRole('button', { name: 'Submit search' })
+    fireEvent.click(submitButton)
+
+    const heading = screen.getByRole('heading', { name: /Search Results/i })
+    expect(heading).toHaveTextContent('Search Results (3)')
+  })
+
   it("should show 'No results found' state for an unmatched query after debouncing", () => {
     renderSearchPage()
 

--- a/src/features/dashboard/pages/SearchPage.tsx
+++ b/src/features/dashboard/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   Search,
   ArrowRight,
@@ -106,69 +106,82 @@ export function SearchPage({
     ],
   }
 
+  // Computes results for `rawQuery` against the current filter. Shared by
+  // the debounced live-search effect below and the "Submit search" button,
+  // which re-runs the search immediately against the un-debounced query
+  // instead of waiting out the debounce delay.
+  const runSearch = useCallback(
+    (rawQuery: string) => {
+      if (!rawQuery.trim()) {
+        setSearchResults([])
+        return
+      }
+
+      // Trim leading/trailing whitespace so padded queries match cleanly.
+      const query = rawQuery.trim().toLowerCase()
+      const results: SearchResult[] = []
+
+      // Search issues
+      if (filter === 'all' || filter === 'issue') {
+        allData.issues.forEach((issue) => {
+          if (
+            issue.title.toLowerCase().includes(query) ||
+            issue.project.toLowerCase().includes(query)
+          ) {
+            results.push({
+              id: issue.id,
+              type: 'issue',
+              title: issue.title,
+              subtitle: issue.project,
+              icon: FileText,
+            })
+          }
+        })
+      }
+
+      // Search projects
+      if (filter === 'all' || filter === 'project') {
+        allData.projects.forEach((project) => {
+          if (
+            project.name.toLowerCase().includes(query) ||
+            project.description.toLowerCase().includes(query)
+          ) {
+            results.push({
+              id: project.id,
+              type: 'project',
+              title: project.name,
+              subtitle: project.description,
+              icon: FolderGit2,
+            })
+          }
+        })
+      }
+
+      // Search contributors
+      if (filter === 'all' || filter === 'contributor') {
+        allData.contributors.forEach((contributor) => {
+          if (contributor.name.toLowerCase().includes(query)) {
+            results.push({
+              id: contributor.id,
+              type: 'contributor',
+              title: contributor.name,
+              subtitle: `${contributor.contributions} contributions`,
+              icon: User,
+            })
+          }
+        })
+      }
+
+      setSearchResults(results)
+    },
+    [filter]
+  )
+
   useEffect(() => {
-    if (!debouncedQuery.trim()) {
-      setSearchResults([])
-      return
-    }
+    runSearch(debouncedQuery)
+  }, [debouncedQuery, runSearch])
 
-    // Trim leading/trailing whitespace so padded queries match cleanly.
-    const query = debouncedQuery.trim().toLowerCase()
-    const results: SearchResult[] = []
-
-    // Search issues
-    if (filter === 'all' || filter === 'issue') {
-      allData.issues.forEach((issue) => {
-        if (
-          issue.title.toLowerCase().includes(query) ||
-          issue.project.toLowerCase().includes(query)
-        ) {
-          results.push({
-            id: issue.id,
-            type: 'issue',
-            title: issue.title,
-            subtitle: issue.project,
-            icon: FileText,
-          })
-        }
-      })
-    }
-
-    // Search projects
-    if (filter === 'all' || filter === 'project') {
-      allData.projects.forEach((project) => {
-        if (
-          project.name.toLowerCase().includes(query) ||
-          project.description.toLowerCase().includes(query)
-        ) {
-          results.push({
-            id: project.id,
-            type: 'project',
-            title: project.name,
-            subtitle: project.description,
-            icon: FolderGit2,
-          })
-        }
-      })
-    }
-
-    // Search contributors
-    if (filter === 'all' || filter === 'contributor') {
-      allData.contributors.forEach((contributor) => {
-        if (contributor.name.toLowerCase().includes(query)) {
-          results.push({
-            id: contributor.id,
-            type: 'contributor',
-            title: contributor.name,
-            subtitle: `${contributor.contributions} contributions`,
-            icon: User,
-          })
-        }
-      })
-    }
-
-    setSearchResults(results)
-  }, [debouncedQuery, filter])
+  const handleSubmitSearch = () => runSearch(searchQuery)
 
   const handleResultClick = (result: SearchResult) => {
     if (result.type === 'issue') {
@@ -276,6 +289,7 @@ export function SearchPage({
             )}
             <button
               type="button"
+              onClick={handleSubmitSearch}
               aria-label="Submit search"
               className={`w-10 h-10 rounded-full flex items-center justify-center ml-3 flex-shrink-0 transition-all hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c9983a] focus-visible:ring-offset-2 ${
                 darkTheme


### PR DESCRIPTION
Closes #758

## Summary
`SearchPage`'s "Submit search" button had `type="button"` (opting out of native form submission) and no `onClick` handler — clicking it did nothing, while looking like a prominent, distinct search action. Search was entirely driven by the input's own debounced `onChange` filtering.

Extracted the result-computation logic into a `runSearch(query)` callback, now shared by:
- the debounced live-search `useEffect` (unchanged behavior — still runs 300ms after the user stops typing), and
- the "Submit search" button's new `onClick`, which re-runs the search **immediately** against the current, un-debounced query instead of waiting out the delay.

## Tests
Added a test to `SearchPage.test.tsx`: typing a query and clicking "Submit search" shows results right away, without advancing any timers past the debounce window.

## Verification
`npx vitest run src/features/dashboard/pages/SearchPage.test.tsx` — 17/17 pass (1 new + 16 pre-existing). `npx tsc --noEmit` shows no new errors. `npx eslint` shows the same 2 pre-existing warnings present identically on `main` (an `exhaustive-deps` note about the static `allData` object and a `set-state-in-effect` note on the live-search effect) — neither introduced by this change.
