### PR TITLE
fix: wire up DiscoverPage favorite button to a real toggle state

### DIFF
--- a/src/features/dashboard/pages/DiscoverPage.test.tsx
+++ b/src/features/dashboard/pages/DiscoverPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
 import { renderWithTheme } from '../../../test/renderWithTheme'
 import { DiscoverPage, getDaysLeft } from './DiscoverPage'
@@ -145,6 +145,36 @@ describe('DiscoverPage', () => {
     // The current date in the page execution defaults to current Date,
     // so we just assert that the days left or no badge shows based on mock data.
     // Issue 2 has null deadline so its daysLeft badge is hidden.
+  })
+
+  it('toggles the favorite button state on click without opening the project', async () => {
+    mockGetRecommendedProjects.mockResolvedValue({ projects: mockProjects })
+    mockGetPublicProjectIssues.mockResolvedValue(mockIssues)
+
+    renderWithTheme(<DiscoverPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Recommended Projects (1)')).toBeInTheDocument()
+    })
+
+    const favoriteButton = screen.getByRole('button', { name: 'Add to favorites' })
+    expect(favoriteButton).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(favoriteButton)
+
+    const pressedButton = screen.getByRole('button', { name: 'Remove from favorites' })
+    expect(pressedButton).toHaveAttribute('aria-pressed', 'true')
+
+    // The button sits inside the card's own onClick-to-select handler;
+    // clicking it must not also navigate into the project detail view.
+    expect(screen.queryByText('Repo 1 description')).toBeInTheDocument()
+    expect(screen.getByText('Recommended Projects (1)')).toBeInTheDocument()
+
+    fireEvent.click(pressedButton)
+    expect(screen.getByRole('button', { name: 'Add to favorites' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
   })
 })
 

--- a/src/features/dashboard/pages/DiscoverPage.tsx
+++ b/src/features/dashboard/pages/DiscoverPage.tsx
@@ -2,7 +2,7 @@ import { logger } from '../../../shared/utils/logger'
 import { useTheme } from '../../../shared/contexts/ThemeContext'
 import { Heart, Star, GitFork, ArrowUpRight, Target, Zap } from 'lucide-react'
 import { IssueCard } from '../../../shared/components/ui/IssueCard'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, type MouseEvent } from 'react'
 import { IssueDetailPage } from './IssueDetailPage'
 import { ProjectDetailPage } from './ProjectDetailPage'
 import { getRecommendedProjects, getPublicProjectIssues } from '../../../shared/api/client'
@@ -204,6 +204,25 @@ export function DiscoverPage({ onGoToBilling, onGoToOpenSourceWeek }: DiscoverPa
     projectId?: string
   } | null>(null)
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
+  // No favorites backend endpoint exists yet (see shared/api/client.ts) --
+  // tracked as local UI state per project id, keyed independently of
+  // whichever project card is currently selected/expanded.
+  const [favoritedIds, setFavoritedIds] = useState<Set<string>>(new Set())
+
+  const toggleFavorite = (projectId: string, event: MouseEvent) => {
+    // The heart button sits inside the card's own onClick-to-select handler;
+    // stop it from also opening the project.
+    event.stopPropagation()
+    setFavoritedIds((current) => {
+      const next = new Set(current)
+      if (next.has(projectId)) {
+        next.delete(projectId)
+      } else {
+        next.add(projectId)
+      }
+      return next
+    })
+  }
 
   // Use optimistic data hook for projects with 30-second cache
   const {
@@ -527,11 +546,21 @@ export function DiscoverPage({ onGoToBilling, onGoToOpenSourceWeek }: DiscoverPa
                     </div>
                   )}
                   <button
+                    type="button"
+                    onClick={(event) => toggleFavorite(String(project.id), event)}
                     className="text-[#c9983a] hover:text-[#a67c2e] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#c9983a] rounded-lg"
-                    aria-label="Add to favorites"
-                    aria-pressed="false"
+                    aria-label={
+                      favoritedIds.has(String(project.id))
+                        ? 'Remove from favorites'
+                        : 'Add to favorites'
+                    }
+                    aria-pressed={favoritedIds.has(String(project.id))}
                   >
-                    <Heart className="w-5 h-5" aria-hidden="true" />
+                    <Heart
+                      className="w-5 h-5"
+                      aria-hidden="true"
+                      fill={favoritedIds.has(String(project.id)) ? 'currentColor' : 'none'}
+                    />
                   </button>
                 </div>
 


### PR DESCRIPTION
Closes #759

## Summary
The "Add to favorites" heart button on each `DiscoverPage` project card had full toggle-state ARIA markup (`aria-pressed="false"`) but no `onClick` handler at all — the `aria-pressed` value was a hardcoded literal string, so it could never become `"true"` no matter how many times a user clicked it, because nothing ever did.

No favorites backend endpoint exists yet (checked `shared/api/client.ts` per the issue's own suggestion), so this adds local per-project-id state — a `Set<string>` of favorited ids — and wires `onClick` to toggle it. The click handler calls `event.stopPropagation()` since the heart button sits inside the card's own `onClick`-to-select handler (without this, favoriting a project would also navigate into its detail view). `aria-pressed`, `aria-label` (now toggles between "Add to favorites" / "Remove from favorites"), and the `Heart` icon's `fill` all derive from the real state.

## Tests
Added to `DiscoverPage.test.tsx`: clicking the favorite button flips `aria-pressed`/`aria-label` and back, and confirms the click does *not* also navigate into the project detail view (the project list stays rendered).

## Verification
`npx vitest run src/features/dashboard/pages/DiscoverPage.test.tsx` — 22/22 pass (1 new + 21 pre-existing). `npx tsc --noEmit` shows no new errors. `npx eslint` shows the same 2 pre-existing warnings present identically on `main` (unrelated to this change, at different lines in the file).
