### PR TITLE
fix: add aria-label to close buttons in three maintainer modals

### DIFF
--- a/src/features/maintainers/components/AddRepositoryModal.test.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.test.tsx
@@ -223,4 +223,14 @@ describe('AddRepositoryModal', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('has an accessible name on the close button', async () => {
+    renderWithTheme(<AddRepositoryModal {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument()
+    })
+
+    const closeButton = screen.getByRole('button', { name: 'Close' })
+    expect(closeButton).toBeInTheDocument()
+  })
 })

--- a/src/features/maintainers/components/AddRepositoryModal.tsx
+++ b/src/features/maintainers/components/AddRepositoryModal.tsx
@@ -150,13 +150,14 @@ export function AddRepositoryModal({ isOpen, onClose, onSuccess }: AddRepository
           <button
             onClick={handleClose}
             disabled={isSubmitting}
+            aria-label="Close"
             className={`p-2 rounded-[10px] transition-all ${
               darkTheme
                 ? 'hover:bg-white/10 text-[#b8a898] hover:text-[#e8dfd0]'
                 : 'hover:bg-white/20 text-[#7a6b5a] hover:text-[#2d2820]'
             } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 

--- a/src/features/maintainers/components/InstallGitHubAppModal.test.tsx
+++ b/src/features/maintainers/components/InstallGitHubAppModal.test.tsx
@@ -77,6 +77,11 @@ describe('InstallGitHubAppModal', () => {
     expect(screen.getByText('Install Grainlify GitHub App')).toBeInTheDocument()
   })
 
+  it('has an accessible name on the close button', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
   it('validates the "don\'t show again" flag on mount and calls onClose', () => {
     localStorage.setItem('github_app_modal_dismissed', 'true')
     renderModal()

--- a/src/features/maintainers/components/InstallGitHubAppModal.tsx
+++ b/src/features/maintainers/components/InstallGitHubAppModal.tsx
@@ -257,13 +257,14 @@ export function InstallGitHubAppModal({ isOpen, onClose, onSuccess }: InstallGit
           <button
             onClick={onClose}
             disabled={isInstalling}
+            aria-label="Close"
             className={`p-2 rounded-[10px] transition-all ${
               darkTheme
                 ? 'hover:bg-white/10 text-[#b8a898] hover:text-[#e8dfd0]'
                 : 'hover:bg-white/20 text-[#7a6b5a] hover:text-[#2d2820]'
             } ${isInstalling ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 

--- a/src/features/maintainers/components/NewProjectSetupModal.test.tsx
+++ b/src/features/maintainers/components/NewProjectSetupModal.test.tsx
@@ -1,27 +1,27 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { renderWithTheme } from '../../../test/renderWithTheme';
-import { NewProjectSetupModal } from './NewProjectSetupModal';
-import type { PendingSetupProject } from '../../../shared/api/client';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithTheme } from '../../../test/renderWithTheme'
+import { NewProjectSetupModal } from './NewProjectSetupModal'
+import type { PendingSetupProject } from '../../../shared/api/client'
 
 // --- Mock the API client -------------------------------------------------
 // The modal calls `getEcosystems` on open and `updateProjectMetadata` on
 // submit. Both are mocked so tests stay deterministic and offline.
-const getEcosystems = vi.fn();
-const updateProjectMetadata = vi.fn();
+const getEcosystems = vi.fn()
+const updateProjectMetadata = vi.fn()
 vi.mock('../../../shared/api/client', () => ({
   getEcosystems: (...args: unknown[]) => getEcosystems(...args),
   updateProjectMetadata: (...args: unknown[]) => updateProjectMetadata(...args),
-}));
+}))
 
 const ECOSYSTEMS = {
   ecosystems: [
     { name: 'Stellar', slug: 'stellar' },
     { name: 'Ethereum', slug: 'ethereum' },
   ],
-};
+}
 
 function makeProject(overrides: Partial<PendingSetupProject> = {}): PendingSetupProject {
   return {
@@ -34,38 +34,37 @@ function makeProject(overrides: Partial<PendingSetupProject> = {}): PendingSetup
     tags: ['Payments', 'DeFi'],
     category: 'Backend',
     ...overrides,
-  };
+  }
 }
 
 /** A deferred promise so a test can hold a submission "in flight". */
 function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
   const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 const getDescription = () =>
-  screen.getByPlaceholderText('Brief description of the project') as HTMLTextAreaElement;
+  screen.getByPlaceholderText('Brief description of the project') as HTMLTextAreaElement
 const getTags = () =>
-  screen.getByPlaceholderText('e.g., Payments, DeFi, Tooling') as HTMLInputElement;
-const getCategory = () =>
-  screen.getByPlaceholderText('e.g., Frontend, Backend') as HTMLInputElement;
+  screen.getByPlaceholderText('e.g., Payments, DeFi, Tooling') as HTMLInputElement
+const getCategory = () => screen.getByPlaceholderText('e.g., Frontend, Backend') as HTMLInputElement
 
 beforeEach(() => {
-  getEcosystems.mockReset();
-  updateProjectMetadata.mockReset();
-  getEcosystems.mockResolvedValue(ECOSYSTEMS);
-  updateProjectMetadata.mockResolvedValue({ ok: true });
-});
+  getEcosystems.mockReset()
+  updateProjectMetadata.mockReset()
+  getEcosystems.mockResolvedValue(ECOSYSTEMS)
+  updateProjectMetadata.mockResolvedValue({ ok: true })
+})
 
 afterEach(() => {
-  vi.useRealTimers();
-  cleanup();
-});
+  vi.useRealTimers()
+  cleanup()
+})
 
 describe('NewProjectSetupModal', () => {
   describe('rendering', () => {
@@ -76,11 +75,11 @@ describe('NewProjectSetupModal', () => {
           project={makeProject()}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
-      expect(container).toBeEmptyDOMElement();
-      expect(screen.queryByText('New Project Setup')).not.toBeInTheDocument();
-    });
+        />
+      )
+      expect(container).toBeEmptyDOMElement()
+      expect(screen.queryByText('New Project Setup')).not.toBeInTheDocument()
+    })
 
     it('populates the form from the project when opened', async () => {
       renderWithTheme(
@@ -89,36 +88,45 @@ describe('NewProjectSetupModal', () => {
           project={makeProject()}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      expect(getTags()).toHaveValue('Payments, DeFi');
-      expect(getCategory()).toHaveValue('Backend');
-    });
-  });
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      expect(getTags()).toHaveValue('Payments, DeFi')
+      expect(getCategory()).toHaveValue('Backend')
+    })
+
+    it('has an accessible name on the close button', async () => {
+      renderWithTheme(
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+    })
+  })
 
   describe('form reset on close', () => {
     it('starts clean when reopened for a different project after closing before submit', async () => {
-      const user = userEvent.setup();
-      const project = makeProject();
+      const user = userEvent.setup()
+      const project = makeProject()
       const { rerender } = renderWithTheme(
-        <NewProjectSetupModal
-          isOpen
-          project={project}
-          onClose={vi.fn()}
-          onSuccess={vi.fn()}
-        />,
-      );
+        <NewProjectSetupModal isOpen project={project} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
 
       // User edits the draft, then the modal is closed without submitting.
-      await user.clear(getDescription());
-      await user.type(getDescription(), 'Half-written draft');
-      await user.clear(getTags());
-      await user.type(getTags(), 'leaky, draft');
-      expect(getDescription()).toHaveValue('Half-written draft');
+      await user.clear(getDescription())
+      await user.type(getDescription(), 'Half-written draft')
+      await user.clear(getTags())
+      await user.type(getTags(), 'leaky, draft')
+      expect(getDescription()).toHaveValue('Half-written draft')
 
       rerender(
         <NewProjectSetupModal
@@ -126,8 +134,8 @@ describe('NewProjectSetupModal', () => {
           project={project}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
+        />
+      )
 
       // Reopen for a DIFFERENT project: no trace of the previous draft.
       const other = makeProject({
@@ -136,39 +144,29 @@ describe('NewProjectSetupModal', () => {
         description: 'Other description',
         tags: ['Tooling'],
         category: 'Frontend',
-      });
+      })
       rerender(
-        <NewProjectSetupModal
-          isOpen
-          project={other}
-          onClose={vi.fn()}
-          onSuccess={vi.fn()}
-        />,
-      );
+        <NewProjectSetupModal isOpen project={other} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Other description'));
-      expect(getTags()).toHaveValue('Tooling');
-      expect(getCategory()).toHaveValue('Frontend');
+      await waitFor(() => expect(getDescription()).toHaveValue('Other description'))
+      expect(getTags()).toHaveValue('Tooling')
+      expect(getCategory()).toHaveValue('Frontend')
       // The stale draft text is nowhere to be found.
-      expect(screen.queryByDisplayValue('Half-written draft')).not.toBeInTheDocument();
-      expect(screen.queryByDisplayValue('leaky, draft')).not.toBeInTheDocument();
-    });
+      expect(screen.queryByDisplayValue('Half-written draft')).not.toBeInTheDocument()
+      expect(screen.queryByDisplayValue('leaky, draft')).not.toBeInTheDocument()
+    })
 
     it('clears the form to empty when reopened with a project that has empty metadata', async () => {
-      const user = userEvent.setup();
-      const project = makeProject();
+      const user = userEvent.setup()
+      const project = makeProject()
       const { rerender } = renderWithTheme(
-        <NewProjectSetupModal
-          isOpen
-          project={project}
-          onClose={vi.fn()}
-          onSuccess={vi.fn()}
-        />,
-      );
+        <NewProjectSetupModal isOpen project={project} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.clear(getDescription());
-      await user.type(getDescription(), 'Edited');
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.clear(getDescription())
+      await user.type(getDescription(), 'Edited')
 
       // Close, then reopen for a sparse project (nulls/empty arrays).
       rerender(
@@ -177,8 +175,8 @@ describe('NewProjectSetupModal', () => {
           project={project}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
+        />
+      )
       const sparse = makeProject({
         id: 'proj-3',
         github_full_name: 'acme/sparse',
@@ -187,264 +185,306 @@ describe('NewProjectSetupModal', () => {
         language: null,
         tags: [],
         category: null,
-      });
+      })
       rerender(
-        <NewProjectSetupModal
-          isOpen
-          project={sparse}
-          onClose={vi.fn()}
-          onSuccess={vi.fn()}
-        />,
-      );
+        <NewProjectSetupModal isOpen project={sparse} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(screen.getByText('acme/sparse')).toBeInTheDocument());
-      expect(getDescription()).toHaveValue('');
-      expect(getTags()).toHaveValue('');
-      expect(getCategory()).toHaveValue('');
-      expect(screen.getByText('Select an ecosystem')).toBeInTheDocument();
-    });
-  });
+      await waitFor(() => expect(screen.getByText('acme/sparse')).toBeInTheDocument())
+      expect(getDescription()).toHaveValue('')
+      expect(getTags()).toHaveValue('')
+      expect(getCategory()).toHaveValue('')
+      expect(screen.getByText('Select an ecosystem')).toBeInTheDocument()
+    })
+  })
 
   describe('in-flight submission on close', () => {
     it('does not fire success callbacks when the modal is closed mid-submission', async () => {
-      const user = userEvent.setup();
-      const onSuccess = vi.fn();
-      const onClose = vi.fn();
-      const pending = deferred<{ ok: boolean }>();
-      updateProjectMetadata.mockReturnValue(pending.promise);
+      const user = userEvent.setup()
+      const onSuccess = vi.fn()
+      const onClose = vi.fn()
+      const pending = deferred<{ ok: boolean }>()
+      updateProjectMetadata.mockReturnValue(pending.promise)
 
-      const project = makeProject();
+      const project = makeProject()
       const { rerender } = renderWithTheme(
-        <NewProjectSetupModal isOpen project={project} onClose={onClose} onSuccess={onSuccess} />,
-      );
+        <NewProjectSetupModal isOpen project={project} onClose={onClose} onSuccess={onSuccess} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
 
       // Start the submission; it stays pending.
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
-      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1));
-      expect(screen.getByText('Saving...')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
+      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1))
+      expect(screen.getByText('Saving...')).toBeInTheDocument()
 
       // Parent force-closes the modal while the request is still in flight.
       rerender(
-        <NewProjectSetupModal isOpen={false} project={project} onClose={onClose} onSuccess={onSuccess} />,
-      );
+        <NewProjectSetupModal
+          isOpen={false}
+          project={project}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      )
 
       // Now the in-flight request resolves — but the modal already closed.
-      pending.resolve({ ok: true });
-      await Promise.resolve();
+      pending.resolve({ ok: true })
+      await Promise.resolve()
 
       // The stale submission must not re-trigger success/close handlers.
-      await waitFor(() => expect(onSuccess).not.toHaveBeenCalled());
-      expect(screen.queryByText('Project details saved.')).not.toBeInTheDocument();
-    });
+      await waitFor(() => expect(onSuccess).not.toHaveBeenCalled())
+      expect(screen.queryByText('Project details saved.')).not.toBeInTheDocument()
+    })
 
     it('reopens with a clean form after a submission is abandoned by closing', async () => {
-      const user = userEvent.setup();
-      const pending = deferred<{ ok: boolean }>();
-      updateProjectMetadata.mockReturnValue(pending.promise);
+      const user = userEvent.setup()
+      const pending = deferred<{ ok: boolean }>()
+      updateProjectMetadata.mockReturnValue(pending.promise)
 
-      const project = makeProject();
+      const project = makeProject()
       const { rerender } = renderWithTheme(
-        <NewProjectSetupModal isOpen project={project} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal isOpen project={project} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.clear(getDescription());
-      await user.type(getDescription(), 'Submitting this one');
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
-      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.clear(getDescription())
+      await user.type(getDescription(), 'Submitting this one')
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
+      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1))
 
       // Close mid-submission, then let the request settle.
       rerender(
-        <NewProjectSetupModal isOpen={false} project={project} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
-      pending.resolve({ ok: true });
-      await Promise.resolve();
+        <NewProjectSetupModal
+          isOpen={false}
+          project={project}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+      pending.resolve({ ok: true })
+      await Promise.resolve()
 
       // Reopen for another project — clean slate, no leaked draft and no
       // lingering "Saving..." state.
-      const next = makeProject({ id: 'proj-9', github_full_name: 'acme/next', description: 'Fresh' });
-      rerender(
-        <NewProjectSetupModal isOpen project={next} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+      const next = makeProject({
+        id: 'proj-9',
+        github_full_name: 'acme/next',
+        description: 'Fresh',
+      })
+      rerender(<NewProjectSetupModal isOpen project={next} onClose={vi.fn()} onSuccess={vi.fn()} />)
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Fresh'));
-      expect(screen.queryByDisplayValue('Submitting this one')).not.toBeInTheDocument();
-      expect(screen.queryByText('Saving...')).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /save & continue/i })).toBeEnabled();
-    });
+      await waitFor(() => expect(getDescription()).toHaveValue('Fresh'))
+      expect(screen.queryByDisplayValue('Submitting this one')).not.toBeInTheDocument()
+      expect(screen.queryByText('Saving...')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /save & continue/i })).toBeEnabled()
+    })
 
     it('closes via the backdrop when no submission is in flight', async () => {
-      const user = userEvent.setup();
-      const onClose = vi.fn();
+      const user = userEvent.setup()
+      const onClose = vi.fn()
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={onClose} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={onClose}
+          onSuccess={vi.fn()}
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
 
       // The modal renders through a portal on document.body; the backdrop is
       // the aria-hidden overlay sitting behind the dialog.
-      const backdrop = document.querySelector('.bg-black\\/50[aria-hidden]') as HTMLElement;
-      expect(backdrop).toBeTruthy();
-      await user.click(backdrop);
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
+      const backdrop = document.querySelector('.bg-black\\/50[aria-hidden]') as HTMLElement
+      expect(backdrop).toBeTruthy()
+      await user.click(backdrop)
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
 
     it('blocks the user-initiated close (X button) while submitting', async () => {
-      const user = userEvent.setup();
-      const onClose = vi.fn();
-      const pending = deferred<{ ok: boolean }>();
-      updateProjectMetadata.mockReturnValue(pending.promise);
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      const pending = deferred<{ ok: boolean }>()
+      updateProjectMetadata.mockReturnValue(pending.promise)
 
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={onClose} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={onClose}
+          onSuccess={vi.fn()}
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
-      await waitFor(() => expect(screen.getByText('Saving...')).toBeInTheDocument());
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
+      await waitFor(() => expect(screen.getByText('Saving...')).toBeInTheDocument())
 
       // The X button is disabled mid-submit, so onClose is never called.
-      const xButton = screen.getAllByRole('button').find((b) => b.querySelector('svg.lucide-x'));
-      expect(xButton).toBeDefined();
-      if (xButton) await user.click(xButton);
-      expect(onClose).not.toHaveBeenCalled();
+      const xButton = screen.getAllByRole('button').find((b) => b.querySelector('svg.lucide-x'))
+      expect(xButton).toBeDefined()
+      if (xButton) await user.click(xButton)
+      expect(onClose).not.toHaveBeenCalled()
 
-      pending.resolve({ ok: true });
-    });
-  });
+      pending.resolve({ ok: true })
+    })
+  })
 
   describe('successful submit', () => {
     it('saves, shows success, and fires onSuccess + onClose', async () => {
-      const user = userEvent.setup();
-      const onSuccess = vi.fn();
-      const onClose = vi.fn();
+      const user = userEvent.setup()
+      const onSuccess = vi.fn()
+      const onClose = vi.fn()
 
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={onClose} onSuccess={onSuccess} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
 
-      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1))
       expect(updateProjectMetadata).toHaveBeenCalledWith('proj-1', {
         description: 'Original description',
         ecosystem_name: 'Stellar',
         language: 'TypeScript',
         tags: ['Payments', 'DeFi'],
         category: 'Backend',
-      });
+      })
 
-      await waitFor(() => expect(screen.getByText('Project details saved.')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Project details saved.')).toBeInTheDocument())
 
       // The success path waits 800ms before closing; give it room with a
       // real-timer wait so it does not race the async ecosystem load.
-      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 2000 });
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 2000 })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
 
     it('shows a validation error and never calls the API when ecosystem is empty', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup()
       renderWithTheme(
         <NewProjectSetupModal
           isOpen
           project={makeProject({ ecosystem_name: '' })}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
 
-      expect(await screen.findByText('Ecosystem is required')).toBeInTheDocument();
-      expect(updateProjectMetadata).not.toHaveBeenCalled();
-    });
+      expect(await screen.findByText('Ecosystem is required')).toBeInTheDocument()
+      expect(updateProjectMetadata).not.toHaveBeenCalled()
+    })
 
     it('surfaces an API error and stays open for retry', async () => {
-      const user = userEvent.setup();
-      updateProjectMetadata.mockRejectedValue(new Error('Server exploded'));
+      const user = userEvent.setup()
+      updateProjectMetadata.mockRejectedValue(new Error('Server exploded'))
 
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
 
-      expect(await screen.findByText('Server exploded')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /save & continue/i })).toBeEnabled();
-    });
-  });
+      expect(await screen.findByText('Server exploded')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /save & continue/i })).toBeEnabled()
+    })
+  })
 
   describe('ecosystem dropdown', () => {
     it('opens the dropdown and selects an ecosystem, submitting the chosen value', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup()
       renderWithTheme(
         <NewProjectSetupModal
           isOpen
           project={makeProject({ ecosystem_name: '' })}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
-        />,
-      );
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
 
       // Open the listbox and pick an ecosystem.
-      await user.click(screen.getByRole('button', { name: /select an ecosystem/i }));
-      const listbox = await screen.findByRole('listbox');
-      await user.click(screen.getByRole('option', { name: 'Ethereum' }));
+      await user.click(screen.getByRole('button', { name: /select an ecosystem/i }))
+      const listbox = await screen.findByRole('listbox')
+      await user.click(screen.getByRole('option', { name: 'Ethereum' }))
 
-      await waitFor(() => expect(listbox).not.toBeInTheDocument());
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
+      await waitFor(() => expect(listbox).not.toBeInTheDocument())
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
 
-      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1));
-      expect(updateProjectMetadata.mock.calls[0][1].ecosystem_name).toBe('Ethereum');
-    });
+      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1))
+      expect(updateProjectMetadata.mock.calls[0][1].ecosystem_name).toBe('Ethereum')
+    })
 
     it('closes the open dropdown on an outside click', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup()
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /stellar/i }));
-      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /stellar/i }))
+      expect(await screen.findByRole('listbox')).toBeInTheDocument()
 
-      fireEvent.mouseDown(document.body);
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
-    });
-  });
+      fireEvent.mouseDown(document.body)
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+    })
+  })
 
   describe('theming', () => {
     it('renders without regressions in dark theme', async () => {
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={vi.fn()} onSuccess={vi.fn()} />,
-        { theme: 'dark' },
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+        { theme: 'dark' }
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      expect(screen.getByText('New Project Setup')).toBeInTheDocument();
-      expect(screen.getByText('acme/widgets')).toBeInTheDocument();
-    });
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      expect(screen.getByText('New Project Setup')).toBeInTheDocument()
+      expect(screen.getByText('acme/widgets')).toBeInTheDocument()
+    })
 
     it('surfaces a submit error in dark theme', async () => {
-      const user = userEvent.setup();
-      updateProjectMetadata.mockRejectedValue(new Error('Dark mode failure'));
+      const user = userEvent.setup()
+      updateProjectMetadata.mockRejectedValue(new Error('Dark mode failure'))
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={vi.fn()} onSuccess={vi.fn()} />,
-        { theme: 'dark' },
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+        { theme: 'dark' }
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('Original description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
-      expect(await screen.findByText('Dark mode failure')).toBeInTheDocument();
-    });
+      await waitFor(() => expect(getDescription()).toHaveValue('Original description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
+      expect(await screen.findByText('Dark mode failure')).toBeInTheDocument()
+    })
 
     it('uses the title override when provided', async () => {
       renderWithTheme(
@@ -454,55 +494,69 @@ describe('NewProjectSetupModal', () => {
           onClose={vi.fn()}
           onSuccess={vi.fn()}
           title="Edit project"
-        />,
-      );
+        />
+      )
 
-      await waitFor(() => expect(screen.getByText('Edit project')).toBeInTheDocument());
-      expect(screen.queryByText('New Project Setup')).not.toBeInTheDocument();
-    });
-  });
+      await waitFor(() => expect(screen.getByText('Edit project')).toBeInTheDocument())
+      expect(screen.queryByText('New Project Setup')).not.toBeInTheDocument()
+    })
+  })
 
   describe('ecosystem load failure', () => {
     it('shows an error when ecosystems fail to load', async () => {
-      getEcosystems.mockRejectedValue(new Error('Network down'));
+      getEcosystems.mockRejectedValue(new Error('Network down'))
       renderWithTheme(
-        <NewProjectSetupModal isOpen project={makeProject()} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal
+          isOpen
+          project={makeProject()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
 
-      expect(await screen.findByText('Network down')).toBeInTheDocument();
-    });
-  });
+      expect(await screen.findByText('Network down')).toBeInTheDocument()
+    })
+  })
 
   describe('security', () => {
     it('does not submit a previous project draft for a newly opened project', async () => {
-      const user = userEvent.setup();
-      const projectA = makeProject({ id: 'A', description: 'A secret draft' });
+      const user = userEvent.setup()
+      const projectA = makeProject({ id: 'A', description: 'A secret draft' })
       const { rerender } = renderWithTheme(
-        <NewProjectSetupModal isOpen project={projectA} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal isOpen project={projectA} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('A secret draft'));
-      await user.clear(getDescription());
-      await user.type(getDescription(), 'Tampered draft for A');
+      await waitFor(() => expect(getDescription()).toHaveValue('A secret draft'))
+      await user.clear(getDescription())
+      await user.type(getDescription(), 'Tampered draft for A')
 
       // Close A's modal without submitting, then open project B.
       rerender(
-        <NewProjectSetupModal isOpen={false} project={projectA} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
-      const projectB = makeProject({ id: 'B', github_full_name: 'acme/b', description: 'B description' });
+        <NewProjectSetupModal
+          isOpen={false}
+          project={projectA}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+      const projectB = makeProject({
+        id: 'B',
+        github_full_name: 'acme/b',
+        description: 'B description',
+      })
       rerender(
-        <NewProjectSetupModal isOpen project={projectB} onClose={vi.fn()} onSuccess={vi.fn()} />,
-      );
+        <NewProjectSetupModal isOpen project={projectB} onClose={vi.fn()} onSuccess={vi.fn()} />
+      )
 
-      await waitFor(() => expect(getDescription()).toHaveValue('B description'));
-      await user.click(screen.getByRole('button', { name: /save & continue/i }));
+      await waitFor(() => expect(getDescription()).toHaveValue('B description'))
+      await user.click(screen.getByRole('button', { name: /save & continue/i }))
 
-      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(updateProjectMetadata).toHaveBeenCalledTimes(1))
       // B's id is used and A's tampered draft never reaches the API.
-      const [calledId, payload] = updateProjectMetadata.mock.calls[0];
-      expect(calledId).toBe('B');
-      expect(payload.description).toBe('B description');
-      expect(payload.description).not.toBe('Tampered draft for A');
-    });
-  });
-});
+      const [calledId, payload] = updateProjectMetadata.mock.calls[0]
+      expect(calledId).toBe('B')
+      expect(payload.description).toBe('B description')
+      expect(payload.description).not.toBe('Tampered draft for A')
+    })
+  })
+})

--- a/src/features/maintainers/components/NewProjectSetupModal.tsx
+++ b/src/features/maintainers/components/NewProjectSetupModal.tsx
@@ -1,21 +1,21 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { createPortal } from 'react-dom';
-import { X, Loader2, AlertCircle, CheckCircle2, ChevronDown } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Loader2, AlertCircle, CheckCircle2, ChevronDown } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
 import {
   getEcosystems,
   updateProjectMetadata,
   type PendingSetupProject,
-} from '../../../shared/api/client';
-import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
+} from '../../../shared/api/client'
+import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
 
 interface NewProjectSetupModalProps {
-  isOpen: boolean;
-  project: PendingSetupProject | null;
-  onClose: () => void;
-  onSuccess: () => void;
+  isOpen: boolean
+  project: PendingSetupProject | null
+  onClose: () => void
+  onSuccess: () => void
   /** Optional title (e.g. "Edit project" when editing). */
-  title?: string;
+  title?: string
 }
 
 export function NewProjectSetupModal({
@@ -25,22 +25,22 @@ export function NewProjectSetupModal({
   onSuccess,
   title: titleOverride,
 }: NewProjectSetupModalProps) {
-  const { theme } = useTheme();
-  const darkTheme = theme === 'dark';
+  const { theme } = useTheme()
+  const darkTheme = theme === 'dark'
 
-  const [description, setDescription] = useState('');
-  const [ecosystemName, setEcosystemName] = useState('');
-  const [language, setLanguage] = useState('');
-  const [tags, setTags] = useState('');
-  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('')
+  const [ecosystemName, setEcosystemName] = useState('')
+  const [language, setLanguage] = useState('')
+  const [tags, setTags] = useState('')
+  const [category, setCategory] = useState('')
 
-  const [ecosystems, setEcosystems] = useState<Array<{ name: string; slug: string }>>([]);
-  const [isLoadingEcosystems, setIsLoadingEcosystems] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [ecosystemDropdownOpen, setEcosystemDropdownOpen] = useState(false);
-  const ecosystemDropdownRef = useRef<HTMLDivElement>(null);
+  const [ecosystems, setEcosystems] = useState<Array<{ name: string; slug: string }>>([])
+  const [isLoadingEcosystems, setIsLoadingEcosystems] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [ecosystemDropdownOpen, setEcosystemDropdownOpen] = useState(false)
+  const ecosystemDropdownRef = useRef<HTMLDivElement>(null)
 
   /**
    * Tracks the live `isOpen` value for async callbacks. A submission started
@@ -49,10 +49,10 @@ export function NewProjectSetupModal({
    * modal is gone and bail out instead of firing success handlers — or leaking
    * state — for a project that is no longer being edited.
    */
-  const isOpenRef = useRef(isOpen);
+  const isOpenRef = useRef(isOpen)
   useEffect(() => {
-    isOpenRef.current = isOpen;
-  }, [isOpen]);
+    isOpenRef.current = isOpen
+  }, [isOpen])
 
   /**
    * Restores every form and submission field to its empty initial value.
@@ -63,41 +63,52 @@ export function NewProjectSetupModal({
    * leak into another's submission.
    */
   const resetForm = useCallback(() => {
-    setDescription('');
-    setEcosystemName('');
-    setLanguage('');
-    setTags('');
-    setCategory('');
-    setError(null);
-    setSuccess(false);
-    setIsSubmitting(false);
-    setEcosystemDropdownOpen(false);
-  }, []);
+    setDescription('')
+    setEcosystemName('')
+    setLanguage('')
+    setTags('')
+    setCategory('')
+    setError(null)
+    setSuccess(false)
+    setIsSubmitting(false)
+    setEcosystemDropdownOpen(false)
+  }, [])
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (ecosystemDropdownRef.current && !ecosystemDropdownRef.current.contains(e.target as Node)) {
-        setEcosystemDropdownOpen(false);
+      if (
+        ecosystemDropdownRef.current &&
+        !ecosystemDropdownRef.current.contains(e.target as Node)
+      ) {
+        setEcosystemDropdownOpen(false)
       }
-    };
-    if (ecosystemDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
     }
-  }, [ecosystemDropdownOpen]);
+    if (ecosystemDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [ecosystemDropdownOpen])
 
   // Populate form whenever the modal opens or the project changes (so Edit shows existing data)
   useEffect(() => {
     if (isOpen && project) {
-      setDescription(project.description ?? '');
-      setEcosystemName(project.ecosystem_name ?? '');
-      setLanguage(project.language ?? '');
-      setTags(Array.isArray(project.tags) ? project.tags.join(', ') : '');
-      setCategory(project.category ?? '');
-      setError(null);
-      setSuccess(false);
+      setDescription(project.description ?? '')
+      setEcosystemName(project.ecosystem_name ?? '')
+      setLanguage(project.language ?? '')
+      setTags(Array.isArray(project.tags) ? project.tags.join(', ') : '')
+      setCategory(project.category ?? '')
+      setError(null)
+      setSuccess(false)
     }
-  }, [isOpen, project?.id, project?.description, project?.ecosystem_name, project?.language, project?.tags, project?.category]);
+  }, [
+    isOpen,
+    project?.id,
+    project?.description,
+    project?.ecosystem_name,
+    project?.language,
+    project?.tags,
+    project?.category,
+  ])
 
   // Reset the form whenever the modal transitions to closed. The component
   // stays mounted across opens (the parent only toggles `isOpen`), so React
@@ -107,47 +118,47 @@ export function NewProjectSetupModal({
   // still in flight. This is what guarantees the next open is clean.
   useEffect(() => {
     if (!isOpen) {
-      resetForm();
+      resetForm()
     }
-  }, [isOpen, resetForm]);
+  }, [isOpen, resetForm])
 
   useEffect(() => {
     if (isOpen) {
-      loadEcosystems();
+      loadEcosystems()
     }
-  }, [isOpen]);
+  }, [isOpen])
 
   const loadEcosystems = async () => {
-    setIsLoadingEcosystems(true);
-    setError(null);
+    setIsLoadingEcosystems(true)
+    setError(null)
     try {
-      const data = await getEcosystems();
-      setEcosystems(data.ecosystems.map((eco) => ({ name: eco.name, slug: eco.slug })));
+      const data = await getEcosystems()
+      setEcosystems(data.ecosystems.map((eco) => ({ name: eco.name, slug: eco.slug })))
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load ecosystems');
+      setError(err instanceof Error ? err.message : 'Failed to load ecosystems')
     } finally {
-      setIsLoadingEcosystems(false);
+      setIsLoadingEcosystems(false)
     }
-  };
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!project) return;
-    setError(null);
-    setSuccess(false);
+    e.preventDefault()
+    if (!project) return
+    setError(null)
+    setSuccess(false)
 
     if (!ecosystemName.trim()) {
-      setError('Ecosystem is required');
-      return;
+      setError('Ecosystem is required')
+      return
     }
 
-    setIsSubmitting(true);
+    setIsSubmitting(true)
 
     try {
       const tagsArray = tags
         .split(',')
         .map((tag) => tag.trim())
-        .filter((tag) => tag.length > 0);
+        .filter((tag) => tag.length > 0)
 
       await updateProjectMetadata(project.id, {
         description: description.trim() || undefined,
@@ -155,31 +166,31 @@ export function NewProjectSetupModal({
         language: language.trim() || undefined,
         tags: tagsArray.length > 0 ? tagsArray : undefined,
         category: category.trim() || undefined,
-      });
+      })
 
       // The modal may have been closed (e.g. parent-driven) while this request
       // was in flight. If so, the form has already been reset — do not flash a
       // success state or fire callbacks for what is now a stale submission.
-      if (!isOpenRef.current) return;
+      if (!isOpenRef.current) return
 
-      setSuccess(true);
+      setSuccess(true)
       setTimeout(() => {
         // Re-check on the deferred callback too: the modal could close during
         // the 800ms success delay.
-        if (!isOpenRef.current) return;
-        onSuccess();
-        onClose();
-        setSuccess(false);
-      }, 800);
+        if (!isOpenRef.current) return
+        onSuccess()
+        onClose()
+        setSuccess(false)
+      }, 800)
     } catch (err) {
       // Swallow the error if the modal closed mid-request; surfacing it would
       // write to state the close already cleared.
-      if (!isOpenRef.current) return;
-      setError(err instanceof Error ? err.message : 'Failed to save project details');
+      if (!isOpenRef.current) return
+      setError(err instanceof Error ? err.message : 'Failed to save project details')
     } finally {
-      setIsSubmitting(false);
+      setIsSubmitting(false)
     }
-  };
+  }
 
   // User-initiated close (X button / backdrop). Blocked while a submission is
   // in flight so the user cannot abandon an active save by accident. The form
@@ -187,11 +198,11 @@ export function NewProjectSetupModal({
   // effect, so there is no per-field cleanup to duplicate here.
   const handleClose = () => {
     if (!isSubmitting) {
-      onClose();
+      onClose()
     }
-  };
+  }
 
-  if (!isOpen || !project) return null;
+  if (!isOpen || !project) return null
 
   const modalContent = (
     <div className="fixed inset-0 z-[10000] flex items-center justify-center p-4">
@@ -203,9 +214,7 @@ export function NewProjectSetupModal({
 
       <div
         className={`relative w-full max-w-[520px] rounded-[24px] border-2 shadow-[0_16px_64px_rgba(0,0,0,0.4)] transition-colors ${
-          darkTheme
-            ? 'bg-[#3a3228] border-white/30'
-            : 'bg-[#d4c5b0] border-white/40'
+          darkTheme ? 'bg-[#3a3228] border-white/30' : 'bg-[#d4c5b0] border-white/40'
         }`}
       >
         <div
@@ -224,13 +233,14 @@ export function NewProjectSetupModal({
             type="button"
             onClick={handleClose}
             disabled={isSubmitting}
+            aria-label="Close"
             className={`p-2 rounded-[10px] transition-all cursor-pointer ${
               darkTheme
                 ? 'hover:bg-white/10 text-[#b8a898] hover:text-[#e8dfd0]'
                 : 'hover:bg-white/20 text-[#7a6b5a] hover:text-[#2d2820]'
             } ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 
@@ -319,7 +329,10 @@ export function NewProjectSetupModal({
               <div className="relative">
                 <button
                   type="button"
-                  onClick={() => !(isSubmitting || ecosystems.length === 0) && setEcosystemDropdownOpen((o) => !o)}
+                  onClick={() =>
+                    !(isSubmitting || ecosystems.length === 0) &&
+                    setEcosystemDropdownOpen((o) => !o)
+                  }
                   disabled={isSubmitting || ecosystems.length === 0}
                   className={`w-full px-4 py-3 rounded-[12px] border-2 transition-all flex items-center justify-between gap-2 text-left ${
                     darkTheme
@@ -353,8 +366,8 @@ export function NewProjectSetupModal({
                       role="option"
                       aria-selected={!ecosystemName}
                       onClick={() => {
-                        setEcosystemName('');
-                        setEcosystemDropdownOpen(false);
+                        setEcosystemName('')
+                        setEcosystemDropdownOpen(false)
                       }}
                       className={`px-4 py-2.5 cursor-pointer text-[14px] transition-colors ${
                         darkTheme
@@ -370,13 +383,11 @@ export function NewProjectSetupModal({
                         role="option"
                         aria-selected={ecosystemName === eco.name}
                         onClick={() => {
-                          setEcosystemName(eco.name);
-                          setEcosystemDropdownOpen(false);
+                          setEcosystemName(eco.name)
+                          setEcosystemDropdownOpen(false)
                         }}
                         className={`px-4 py-2.5 cursor-pointer text-[14px] transition-colors ${
-                          darkTheme
-                            ? 'hover:bg-white/15'
-                            : 'hover:bg-white/40'
+                          darkTheme ? 'hover:bg-white/15' : 'hover:bg-white/40'
                         } ${ecosystemName === eco.name ? (darkTheme ? 'bg-white/10' : 'bg-white/30') : ''}`}
                       >
                         {eco.name}
@@ -466,7 +477,7 @@ export function NewProjectSetupModal({
         </form>
       </div>
     </div>
-  );
+  )
 
-  return createPortal(modalContent, document.body);
+  return createPortal(modalContent, document.body)
 }


### PR DESCRIPTION
Closes #767

## Summary
`AddRepositoryModal`, `NewProjectSetupModal`, and `InstallGitHubAppModal` each rendered their icon-only close (`X`) button with no accessible name at all — no `aria-label`, and the `X` icon had no `aria-hidden`. A screen reader announces an unlabeled button (or nothing meaningful from the raw SVG), giving no indication the control closes the modal.

Added `aria-label="Close"` to each button and `aria-hidden="true"` to each `X` icon.

**Why plain `"Close"` instead of a more descriptive label** (e.g. `"Close install GitHub app dialog"`, closer to the issue's suggested wording): several existing tests select each modal's primary action button via a substring regex, e.g. `screen.getByRole('button', { name: /install github app/i })`. A close-button label containing that same substring would also match, turning those `getByRole` calls ambiguous ("found multiple elements") and breaking 17 pre-existing tests. Plain `"Close"` avoids any such collision while still being a fully valid, WCAG-compliant accessible name.

## Note on diff size
`NewProjectSetupModal.tsx`/`.test.tsx` show a much larger diff than the other two files. That file was written with semicolons, inconsistent with the rest of the codebase's (semicolon-free) Prettier config — my one-line edit triggered this repo's `lint-staged` pre-commit hook (`prettier --write` + `eslint --fix`), which normalized the *entire* file to the project's actual configured style. This is a mechanical, behavior-preserving reformat (confirmed via the diff and by all tests still passing), not a manual change on my part.

## Tests
Added one test per modal asserting the close button has an accessible name (`getByRole('button', { name: 'Close' })`).

## Verification
`npx vitest run` on all three test files — 47/47 pass (3 new + 44 pre-existing). `npx tsc --noEmit` shows no new errors. `npx eslint` shows the same 9 pre-existing warnings present identically on `main` (unrelated to this change).
