### PR TITLE
fix: add aria-label to AdminPage icon-only Edit/Delete buttons

### DIFF
--- a/src/features/admin/pages/AdminPage.test.tsx
+++ b/src/features/admin/pages/AdminPage.test.tsx
@@ -170,3 +170,23 @@ describe('AdminPage pagination', () => {
     expect(screen.queryByText('Ecosystem 14')).not.toBeInTheDocument()
   })
 })
+
+describe('AdminPage icon-only action buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('has an accessible name on the ecosystem edit/delete buttons and event delete button', async () => {
+    mockGetAdminEcosystems.mockResolvedValue({ ecosystems: [makeEcosystem(0)] })
+    mockGetAdminOpenSourceWeekEvents.mockResolvedValue({ events: [makeOswEvent(0)] })
+
+    renderAdminPage()
+
+    expect(await screen.findByText('Ecosystem 0')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit ecosystem' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete ecosystem' })).toBeInTheDocument()
+
+    expect(await screen.findByText('Event 0')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete event' })).toBeInTheDocument()
+  })
+})

--- a/src/features/admin/pages/AdminPage.tsx
+++ b/src/features/admin/pages/AdminPage.tsx
@@ -904,6 +904,7 @@ export function AdminPage() {
                               : 'hover:bg-amber-500/30 text-amber-600'
                           }`}
                           title="Edit ecosystem"
+                          aria-label="Edit ecosystem"
                         >
                           <Pencil className="w-4 h-4" />
                         </button>
@@ -918,6 +919,7 @@ export function AdminPage() {
                                 : 'hover:bg-red-500/30 text-red-600'
                           }`}
                           title="Delete ecosystem"
+                          aria-label="Delete ecosystem"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
@@ -1160,6 +1162,7 @@ export function AdminPage() {
                         : 'hover:bg-red-500/30 text-red-600'
                     }`}
                     title="Delete event"
+                    aria-label="Delete event"
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
Closes #770

## Summary
`AdminPage`'s ecosystem "Edit"/"Delete" action buttons and the Open Source Week "Delete event" button used the `title` HTML attribute as their only accessible-name mechanism. `title` isn't announced consistently across screen reader/browser combinations, and — being tooltip-based — is undiscoverable without a mouse hover, with no keyboard/touch equivalent. For icon-only buttons like these (`Pencil`/`Trash2`, no visible text), `aria-label` is the WCAG-aligned mechanism.

Added `aria-label` (matching each existing `title` text: `"Edit ecosystem"`, `"Delete ecosystem"`, `"Delete event"`) alongside the existing `title` attributes, which stay in place as a supplementary hover tooltip.

## Tests
Added a test rendering one ecosystem and one Open Source Week event, asserting all three buttons are reachable via `getByRole('button', { name: '...' })`.

## Verification
`npx vitest run src/features/admin/pages/AdminPage.test.tsx` — 5/5 pass (1 new + 4 pre-existing). `npx tsc --noEmit` shows no new errors. `npx eslint` shows the same 3 pre-existing warnings present identically on `main` (unrelated to this change).
