### PR TITLE
fix(security): add noopener,noreferrer to ProfileTab GitHub settings window.open

### DIFF
--- a/src/features/settings/components/profile/ProfileTab.test.tsx
+++ b/src/features/settings/components/profile/ProfileTab.test.tsx
@@ -212,4 +212,23 @@ describe('ProfileTab', () => {
     resolveAvatar()
     await waitFor(() => expect(toast.success).toHaveBeenCalled())
   })
+
+  it('opens the GitHub settings page with noopener,noreferrer', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => expect(screen.getByDisplayValue('John')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/settings/profile',
+      '_blank',
+      'noopener,noreferrer'
+    )
+
+    openSpy.mockRestore()
+  })
 })

--- a/src/features/settings/components/profile/ProfileTab.tsx
+++ b/src/features/settings/components/profile/ProfileTab.tsx
@@ -172,7 +172,7 @@ export function ProfileTab() {
 
   const handleEditGitHub = () => {
     // Open GitHub settings page in a new tab
-    window.open('https://github.com/settings/profile', '_blank')
+    window.open('https://github.com/settings/profile', '_blank', 'noopener,noreferrer')
   }
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

`ProfileTab.tsx`'s `handleEditGitHub` opened `https://github.com/settings/profile` in a new tab via `window.open(url, '_blank')` without `noopener`/`noreferrer`, leaving `window.opener` set on the new tab. Per the classic reverse-tabnabbing issue, this lets the opened page navigate the original GrantFox tab via `window.opener.location = ...`. Matches the pattern already established elsewhere in this codebase (`PRRow.tsx`, and `ProjectDetailPage.tsx`'s `activity.url` call).

## Fix

`window.open('https://github.com/settings/profile', '_blank', 'noopener,noreferrer')` -- no other behavior change.

## Testing

Added a test asserting the "Edit" button in the GitHub account section calls `window.open` with the exact `noopener,noreferrer` features string. Full suite passes (`pnpm test`).

Closes #711