### PR TITLE
fix: consolidate Vitest configuration

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,27 +60,4 @@ export default defineConfig({
       },
     },
   },
-  test: {
-    // jsdom gives component tests a DOM; node-only tests still work under it.
-    // Tests can still opt into a different environment per-file via a
-    // `// @vitest-environment <env>` docblock.
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test-setup.ts', './src/test/setup.ts'],
-    css: false,
-    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
-    exclude: ['e2e/**', 'node_modules/**', 'dist/**', '**/node_modules/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'text-summary', 'html'],
-      include: [
-        'src/shared/api/client.ts',
-        'src/shared/contexts/AuthContext.tsx',
-        'src/shared/hooks/useOptimisticData.ts',
-        'src/shared/utils/errorHandler.ts',
-        'src/shared/utils/projectFilter.ts',
-        'src/features/settings/contexts/BillingProfilesContext.tsx',
-      ],
-    },
-  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
         'src/**/*.test.{ts,tsx}',
         'src/**/*.spec.{ts,tsx}',
         'src/test/**',
-        'src/test-setup.ts',
         'src/**/*.d.ts',
         // app entry point — wires providers, no logic to test
         'src/main.tsx',


### PR DESCRIPTION
Remove the inactive Vitest test block from vite.config.ts and rely on vitest.config.ts as the single test configuration. Remove the unused setup stub and its stale exclusion.

Validation: 50 test files / 686 tests passed; typecheck passed.

Closes #880