### PR TITLE
fix(security): add noopener,noreferrer to BillingTab KYC window.open

### DIFF
--- a/src/features/settings/components/billing/BillingTab.test.tsx
+++ b/src/features/settings/components/billing/BillingTab.test.tsx
@@ -139,5 +139,30 @@ describe('BillingTab', () => {
       )
       expect(textNodes).toHaveLength(0)
     })
+
+    it('opens the KYC verification window with noopener,noreferrer', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+      mockGetKYCStatus.mockResolvedValue({ status: 'not_started' })
+      const originalStatus = mockProfiles[0].status
+      mockProfiles[0].status = 'missing-verification'
+
+      try {
+        await navigateToDetailView()
+
+        const verifyBtn = await screen.findByRole('button', { name: 'Verify KYC' })
+        await act(async () => {
+          fireEvent.click(verifyBtn)
+        })
+
+        expect(openSpy).toHaveBeenCalledWith(
+          'https://example.com',
+          '_blank',
+          'width=800,height=600,noopener,noreferrer'
+        )
+      } finally {
+        mockProfiles[0].status = originalStatus
+        openSpy.mockRestore()
+      }
+    })
   })
 })

--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -270,7 +270,11 @@ export function BillingTab() {
 
       // Open the KYC URL in a new window
       if (response.url) {
-        const kycWindow = window.open(response.url, '_blank', 'width=800,height=600')
+        const kycWindow = window.open(
+          response.url,
+          '_blank',
+          'width=800,height=600,noopener,noreferrer'
+        )
         setErrorMessage('')
 
         // Window opened successfully - update state to reflect this


### PR DESCRIPTION
## Summary

`BillingTab.tsx`'s `handleVerifyKYC` opens `response.url` (returned by the third-party `startKYCVerification()` provider, not a value the frontend controls or validates) via `window.open(response.url, '_blank', 'width=800,height=600')` -- missing `noopener`/`noreferrer`. This leaves `window.opener` set on the KYC provider tab; if that provider page is ever compromised, it could redirect the origin GrantFox billing tab to a phishing page while the user completes identity verification in the second tab (reverse tabnabbing), which is more sensitive here since the flow deals with identity documents.

## Fix

`window.open(response.url, '_blank', 'width=800,height=600,noopener,noreferrer')` -- preserves the existing `width=800,height=600` sizing, no other behavior change.

## Testing

Added a test (in the "Profile Detail View" suite) that sets up a `missing-verification` profile, clicks "Verify KYC", and asserts `window.open` is called with `'https://example.com'`, `'_blank'`, `'width=800,height=600,noopener,noreferrer'`. Full suite passes: 135 test files, 1559 passed (up from 1558 baseline).

Closes #712