### PR TITLE
chore: remove unused settings mock data

### DIFF
--- a/src/features/settings/README.md
+++ b/src/features/settings/README.md
@@ -24,8 +24,6 @@ The Settings page has been refactored into a clean, modular, feature-based archi
 │   └── terms/                # Tab 5: Terms components
 │       └── TermsTab.tsx
 ├── data/
-│   ├── billingProfilesData.ts
-│   └── payoutProjectsData.ts
 ├── pages/
 │   └── SettingsPage.tsx       # Main page with tab navigation
 └── types/
@@ -157,4 +155,3 @@ Inputs with validation constraints are explicitly configured for assistive techn
 - `aria-invalid` triggers automatically on fields with validation errors.
 - `aria-describedby` links the input element with its corresponding inline error message (marked with `role="alert"`), ensuring descriptive speech feedback for screen readers.
 - Submit action is disabled during background API request submission or when any form fields violate constraints.
-

--- a/src/features/settings/data/billingProfilesData.ts
+++ b/src/features/settings/data/billingProfilesData.ts
@@ -1,3 +1,0 @@
-import { BillingProfile } from '../types';
-
-export const initialBillingProfiles: BillingProfile[] = [];

--- a/src/features/settings/data/payoutProjectsData.ts
+++ b/src/features/settings/data/payoutProjectsData.ts
@@ -1,8 +1,0 @@
-import { PayoutProject } from '../types';
-
-export const payoutProjectsData: PayoutProject[] = [
-  { id: 1, initial: 'R', name: 'React Ecosystem', billingProfile: null },
-  { id: 2, initial: 'N', name: 'Next.js Framework', billingProfile: null },
-  { id: 3, initial: 'V', name: 'Vue.js', billingProfile: null },
-  { id: 4, initial: 'A', name: 'Angular', billingProfile: null },
-];


### PR DESCRIPTION
Remove the unused billingProfilesData.ts and payoutProjectsData.ts mock modules and update the settings feature tree documentation.

Validation: typecheck and production build passed; no references remain.

Closes #882