### PR TITLE
fix: format terms acceptance date by locale

### DIFF
--- a/src/features/settings/components/terms/TermsTab.test.tsx
+++ b/src/features/settings/components/terms/TermsTab.test.tsx
@@ -11,9 +11,13 @@ vi.mock('../../../../shared/api/client', () => ({
   acceptTerms: vi.fn(),
 }))
 
-const renderWithTheme = (ui: React.ReactElement, messages: Record<string, string> = en) => {
+const renderWithTheme = (
+  ui: React.ReactElement,
+  messages: Record<string, string> = en,
+  locale: 'en' | 'es' = 'en'
+) => {
   return render(
-    <I18nProvider messages={messages}>
+    <I18nProvider locale={locale} messages={messages}>
       <ThemeProvider>{ui}</ThemeProvider>
     </I18nProvider>
   )
@@ -114,6 +118,22 @@ describe('TermsTab', () => {
     // Check version and date message
     const message = await screen.findByText(/✓ Accepted version 1\.0\.0 on/)
     expect(message).toBeInTheDocument()
+  })
+
+  it('formats the accepted date with the active locale', async () => {
+    const acceptedDate = '2023-10-01T12:00:00Z'
+    vi.mocked(getTermsStatus).mockResolvedValue({
+      accepted: true,
+      version: CURRENT_TERMS_VERSION,
+      accepted_at: acceptedDate,
+    })
+
+    renderWithTheme(<TermsTab />, en, 'es')
+
+    const expectedDate = new Intl.DateTimeFormat('es').format(new Date(acceptedDate))
+    expect(
+      await screen.findByText(`✓ Accepted version ${CURRENT_TERMS_VERSION} on ${expectedDate}`)
+    ).toBeInTheDocument()
   })
 
   it('handles successful terms acceptance', async () => {

--- a/src/features/settings/components/terms/TermsTab.tsx
+++ b/src/features/settings/components/terms/TermsTab.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { getTermsStatus, acceptTerms } from '../../../../shared/api/client'
 import { Skeleton } from '../../../../shared/components/ui/skeleton'
 import { logger } from '../../../../shared/utils/logger'
-import { useTranslation } from '../../../../shared/i18n'
+import { useIntlFormatters, useTranslation } from '../../../../shared/i18n'
 
 /**
  * Current version of the terms and conditions.
@@ -24,6 +24,7 @@ export const SKELETON_DELAY_MS = 300
 export function TermsTab() {
   const { theme } = useTheme()
   const { t } = useTranslation()
+  const { formatDate } = useIntlFormatters()
   const loadStatusFailedMessage = t('terms.errors.loadStatusFailed')
   const [isLoading, setIsLoading] = useState(true)
   const [isAccepting, setIsAccepting] = useState(false)
@@ -249,7 +250,7 @@ export function TermsTab() {
               <p className="text-[12px] text-green-500 font-medium">
                 {t('terms.status.acceptedVersion', {
                   version: acceptedVersion,
-                  date: new Date(acceptedDate).toLocaleDateString(),
+                  date: formatDate(acceptedDate),
                 })}
               </p>
             ) : isVersionMismatch ? (


### PR DESCRIPTION
Use the shared useIntlFormatters hook for the terms acceptance date and add coverage for a non-default active locale.

Validation: 13 TermsTab tests passed; typecheck passed.

Closes #884