### PR TITLE
fix: format payment method dates by locale

### DIFF
--- a/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { screen, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { PaymentMethodsTab, validateWalletAddress } from './PaymentMethodsTab'
 import { renderWithTheme } from '../../../../test/renderWithTheme'
+import { ThemeProvider } from '../../../../shared/contexts/ThemeContext'
+import { I18nProvider } from '../../../../shared/i18n'
 import type { PaymentMethod } from '../../types'
 
 function createValidAddress(prefix: 'G' | 'M' | 'C'): string {
@@ -269,6 +271,25 @@ describe('PaymentMethodsTab - delete confirmation', () => {
       createdAt: '2024-01-15T10:00:00Z',
     },
   ]
+
+  it('formats the added date with the active locale', () => {
+    const createdAt = '2024-01-15T10:00:00Z'
+    render(
+      <I18nProvider locale="es">
+        <ThemeProvider>
+          <PaymentMethodsTab
+            paymentMethods={[{ ...sampleMethods[0], createdAt }]}
+            onAddPaymentMethod={vi.fn()}
+            onRemovePaymentMethod={vi.fn()}
+            onSetDefault={vi.fn()}
+          />
+        </ThemeProvider>
+      </I18nProvider>
+    )
+
+    const expectedDate = new Intl.DateTimeFormat('es').format(new Date(createdAt))
+    expect(screen.getByText(`Added ${expectedDate}`)).toBeInTheDocument()
+  })
 
   it('does not call onRemovePaymentMethod when delete button is clicked', async () => {
     const { onRemovePaymentMethod } = setup(sampleMethods)

--- a/src/features/settings/components/billing/PaymentMethodsTab.tsx
+++ b/src/features/settings/components/billing/PaymentMethodsTab.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Plus, Trash2, Wallet, Copy, CheckCircle2, Star, X } from 'lucide-react'
 import { useTheme } from '../../../../shared/contexts/ThemeContext'
 import { Modal, ModalFooter, ModalButton } from '../../../../shared/components/ui/Modal'
+import { useIntlFormatters } from '../../../../shared/i18n'
 import { PaymentMethod, EcosystemType, CryptoType } from '../../types'
 
 /**
@@ -52,6 +53,7 @@ export function PaymentMethodsTab({
   onSetDefault,
 }: PaymentMethodsTabProps) {
   const { theme } = useTheme()
+  const { formatDate } = useIntlFormatters()
   const [showAddModal, setShowAddModal] = useState(false)
   const selectedEcosystem: EcosystemType = 'stellar'
   const [selectedCrypto, setSelectedCrypto] = useState<CryptoType>('usdc')
@@ -208,7 +210,7 @@ export function PaymentMethodsTab({
                         theme === 'dark' ? 'text-[#8a7e70]' : 'text-[#9a8b7a]'
                       }`}
                     >
-                      Added {new Date(method.createdAt).toLocaleDateString()}
+                      Added {formatDate(method.createdAt)}
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
Use the shared useIntlFormatters hook for payment method creation dates and add coverage for a non-default active locale.

Validation: 31 PaymentMethodsTab tests passed; typecheck passed.

Closes #885