### PR TITLE
fix: format admin event dates by locale

### DIFF
--- a/src/features/admin/pages/AdminPage.test.tsx
+++ b/src/features/admin/pages/AdminPage.test.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { I18nProvider } from '../../../shared/i18n'
 import { AdminPage } from './AdminPage'
 
 // ---------------------------------------------------------------------------
@@ -48,11 +49,13 @@ vi.mock('../../../shared/components/ui/DatePicker', () => ({
   DatePicker: () => null,
 }))
 
-function renderAdminPage() {
+function renderAdminPage(locale: 'en' | 'es' = 'en') {
   return render(
-    <ThemeProvider>
-      <AdminPage />
-    </ThemeProvider>
+    <I18nProvider locale={locale}>
+      <ThemeProvider>
+        <AdminPage />
+      </ThemeProvider>
+    </I18nProvider>
   )
 }
 
@@ -147,6 +150,18 @@ describe('AdminPage pagination', () => {
       expect(await screen.findByText(`Event ${i}`)).toBeInTheDocument()
     }
     expect(screen.queryByRole('button', { name: /load more events/i })).not.toBeInTheDocument()
+  })
+
+  it('formats Open Source Week event dates with the active locale', async () => {
+    mockGetAdminEcosystems.mockResolvedValue({ ecosystems: [] })
+    mockGetAdminOpenSourceWeekEvents.mockResolvedValue({ events: [makeOswEvent(0)] })
+
+    renderAdminPage('es')
+
+    const expectedRange = `${new Intl.DateTimeFormat('es').format(
+      new Date('2026-01-01T00:00:00Z')
+    )} → ${new Intl.DateTimeFormat('es').format(new Date('2026-01-08T00:00:00Z'))}`
+    expect(await screen.findByText(expectedRange)).toBeInTheDocument()
   })
 
   it('resets the visible ecosystems page back to the first page on refetch', async () => {

--- a/src/features/admin/pages/AdminPage.tsx
+++ b/src/features/admin/pages/AdminPage.tsx
@@ -32,6 +32,7 @@ import {
   deleteOpenSourceWeekEvent,
 } from '../../../shared/api/client'
 import { clampLimit, hasMoreByTotal } from '../../../shared/utils/pagination'
+import { useIntlFormatters } from '../../../shared/i18n'
 
 // The admin ecosystems/events endpoints don't accept limit/offset params (see
 // shared/api/client.ts), so the full list is still fetched in one request.
@@ -70,6 +71,7 @@ interface Ecosystem {
 
 export function AdminPage() {
   const { theme } = useTheme()
+  const { formatDate } = useIntlFormatters()
   const [showAddModal, setShowAddModal] = useState(false)
   const [ecosystems, setEcosystems] = useState<Ecosystem[]>([])
   const [ecosystemsVisibleCount, setEcosystemsVisibleCount] = useState(() =>
@@ -1148,8 +1150,7 @@ export function AdminPage() {
                         theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
                       }`}
                     >
-                      {new Date(ev.start_at).toLocaleDateString()} →{' '}
-                      {new Date(ev.end_at).toLocaleDateString()}
+                      {formatDate(ev.start_at)} → {formatDate(ev.end_at)}
                     </p>
                   </div>
                   <button


### PR DESCRIPTION
Use the shared useIntlFormatters hook for Open-Source Week event dates and add coverage for a non-default active locale.

Validation: 5 AdminPage tests passed; typecheck passed.

Closes #886