### PR TITLE
fix(security): add noopener,noreferrer to ProjectDetailPage GitHub link window.open

### DIFF
--- a/src/features/dashboard/pages/ProjectDetailPage.test.tsx
+++ b/src/features/dashboard/pages/ProjectDetailPage.test.tsx
@@ -285,5 +285,30 @@ describe('ProjectDetailPage', () => {
 
       expect(writeTextMock).toHaveBeenCalled()
     })
+
+    it('opens the GitHub repo link with noopener,noreferrer', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+      renderComponent({ projectId: 'proj-123' })
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1, name: 'test-repo' })).toBeInTheDocument()
+      })
+
+      const buttons = screen.getAllByRole('button')
+      const githubButton = buttons.find(
+        (btn) => btn.querySelector('svg.lucide-external-link') !== null
+      )
+      expect(githubButton).toBeDefined()
+      fireEvent.click(githubButton!)
+
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://github.com/testorg/test-repo',
+        '_blank',
+        'noopener,noreferrer'
+      )
+
+      openSpy.mockRestore()
+    })
   })
 })

--- a/src/features/dashboard/pages/ProjectDetailPage.tsx
+++ b/src/features/dashboard/pages/ProjectDetailPage.tsx
@@ -851,7 +851,7 @@ export function ProjectDetailPage({
             </div>
             <div className="flex items-center gap-2">
               <button
-                onClick={() => githubUrl && window.open(githubUrl, '_blank')}
+                onClick={() => githubUrl && window.open(githubUrl, '_blank', 'noopener,noreferrer')}
                 className={`p-3 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all ${
                   theme === 'dark'
                     ? 'bg-white/[0.08] text-[#f5f5f5]'

--- a/src/features/dashboard/pages/ProjectDetailPage.tsx
+++ b/src/features/dashboard/pages/ProjectDetailPage.tsx
@@ -1,29 +1,33 @@
-import { logger } from '../../../shared/utils/logger';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { ExternalLink, Copy, Circle, ArrowLeft, GitPullRequest } from 'lucide-react';
-import { useTheme } from '../../../shared/contexts/ThemeContext';
-import { getPublicProject, getPublicProjectIssues, getPublicProjectPRs } from '../../../shared/api/client';
-import { SkeletonLoader } from '../../../shared/components/SkeletonLoader';
-import ReactMarkdown from 'react-markdown';
-import { LanguageIcon } from '../../../shared/components/LanguageIcon';
-import { ResourceNotFound } from '../../../shared/components/ResourceNotFound';
+import { logger } from '../../../shared/utils/logger'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { ExternalLink, Copy, Circle, ArrowLeft, GitPullRequest } from 'lucide-react'
+import { useTheme } from '../../../shared/contexts/ThemeContext'
+import {
+  getPublicProject,
+  getPublicProjectIssues,
+  getPublicProjectPRs,
+} from '../../../shared/api/client'
+import { SkeletonLoader } from '../../../shared/components/SkeletonLoader'
+import ReactMarkdown from 'react-markdown'
+import { LanguageIcon } from '../../../shared/components/LanguageIcon'
+import { ResourceNotFound } from '../../../shared/components/ResourceNotFound'
 
-const InPreContext = createContext(false);
+const InPreContext = createContext(false)
 
 interface ProjectDetailPageProps {
-  onBack?: () => void;
-  onIssueClick?: (issueId: string, projectId: string) => void;
-  projectId?: string;
-  onClose?: () => void;
-  backLabel?: string;
+  onBack?: () => void
+  onIssueClick?: (issueId: string, projectId: string) => void
+  projectId?: string
+  onClose?: () => void
+  backLabel?: string
 }
 
 function OverviewMarkdown({ readme, theme }: { readme: string; theme: string }) {
-  const inPre = useContext(InPreContext);
-  const dark = theme === 'dark';
-  const textColor = dark ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]';
-  const headingColor = dark ? 'text-[#f5f5f5]' : 'text-[#2d2820]';
+  const inPre = useContext(InPreContext)
+  const dark = theme === 'dark'
+  const textColor = dark ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
+  const headingColor = dark ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
 
   return (
     <ReactMarkdown
@@ -40,9 +44,7 @@ function OverviewMarkdown({ readme, theme }: { readme: string; theme: string }) 
         h4: ({ ...props }) => (
           <h4 className={`text-[16px] font-semibold mb-2 mt-3 ${headingColor}`} {...props} />
         ),
-        p: ({ ...props }) => (
-          <p className={`mb-4 leading-relaxed ${textColor}`} {...props} />
-        ),
+        p: ({ ...props }) => <p className={`mb-4 leading-relaxed ${textColor}`} {...props} />,
         a: ({ ...props }) => (
           <a
             className={`font-semibold hover:underline ${dark ? 'text-[#f5c563] hover:text-[#ffd700]' : 'text-[#b8872f] hover:text-[#8b6f3a]'}`}
@@ -53,19 +55,14 @@ function OverviewMarkdown({ readme, theme }: { readme: string; theme: string }) 
         ),
         code: ({ ...props }) => {
           if (inPre) {
-            return (
-              <code
-                className={`text-[13px] font-mono ${textColor}`}
-                {...props}
-              />
-            );
+            return <code className={`text-[13px] font-mono ${textColor}`} {...props} />
           }
           return (
             <code
               className={`inline px-1.5 py-0.5 rounded text-[13px] font-mono ${dark ? 'bg-white/[0.15] text-[#f5c563]' : 'bg-[#e8e0d0] text-[#6b5d4d]'}`}
               {...props}
             />
-          );
+          )
         },
         pre: ({ children, ...props }) => (
           <InPreContext.Provider value={true}>
@@ -83,9 +80,7 @@ function OverviewMarkdown({ readme, theme }: { readme: string; theme: string }) 
         ol: ({ ...props }) => (
           <ol className={`list-decimal pl-6 mb-4 space-y-1.5 ${textColor}`} {...props} />
         ),
-        li: ({ ...props }) => (
-          <li className={`leading-relaxed ${textColor}`} {...props} />
-        ),
+        li: ({ ...props }) => <li className={`leading-relaxed ${textColor}`} {...props} />,
         blockquote: ({ ...props }) => (
           <blockquote
             className={`border-l-4 pl-4 italic my-4 ${dark ? 'border-[#c9983a]/60 text-[#d4d4d4] bg-white/[0.05]' : 'border-[#c9983a]/70 text-[#4a3f2f] bg-white/[0.10]'}`}
@@ -95,226 +90,242 @@ function OverviewMarkdown({ readme, theme }: { readme: string; theme: string }) 
         img: ({ ...props }) => (
           <img className="rounded-[12px] max-w-full h-auto my-4" alt="" {...props} />
         ),
-        strong: ({ ...props }) => (
-          <strong className={`font-bold ${headingColor}`} {...props} />
-        ),
+        strong: ({ ...props }) => <strong className={`font-bold ${headingColor}`} {...props} />,
       }}
     >
       {readme}
     </ReactMarkdown>
-  );
+  )
 }
 
-export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProjectId, onClose, backLabel }: ProjectDetailPageProps) {
-  const { theme } = useTheme();
-  const { projectId: paramProjectId } = useParams<{ projectId: string }>();
-  const projectId = propProjectId || paramProjectId;
-  const [retryCount, setRetryCount] = useState(0);
-  const [activeIssueTab, setActiveIssueTab] = useState('all');
-  const [copiedLink, setCopiedLink] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<null | { message: string; notFound?: boolean }>(null);
-  const [project, setProject] = useState<null | Awaited<ReturnType<typeof getPublicProject>>>(null);
-  const [issues, setIssues] = useState<Array<{
-    github_issue_id: number;
-    number: number;
-    state: string;
-    title: string;
-    description: string | null;
-    author_login: string;
-    labels: any[];
-    url: string;
-    updated_at: string | null;
-    last_seen_at: string;
-  }>>([]);
-  const [prs, setPRs] = useState<Array<{
-    github_pr_id: number;
-    number: number;
-    state: string;
-    title: string;
-    author_login: string;
-    url: string;
-    merged: boolean;
-    created_at: string | null;
-    updated_at: string | null;
-    closed_at: string | null;
-    merged_at: string | null;
-    last_seen_at: string;
-  }>>([]);
+export function ProjectDetailPage({
+  onBack,
+  onIssueClick,
+  projectId: propProjectId,
+  onClose,
+  backLabel,
+}: ProjectDetailPageProps) {
+  const { theme } = useTheme()
+  const { projectId: paramProjectId } = useParams<{ projectId: string }>()
+  const projectId = propProjectId || paramProjectId
+  const [retryCount, setRetryCount] = useState(0)
+  const [activeIssueTab, setActiveIssueTab] = useState('all')
+  const [copiedLink, setCopiedLink] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<null | { message: string; notFound?: boolean }>(null)
+  const [project, setProject] = useState<null | Awaited<ReturnType<typeof getPublicProject>>>(null)
+  const [issues, setIssues] = useState<
+    Array<{
+      github_issue_id: number
+      number: number
+      state: string
+      title: string
+      description: string | null
+      author_login: string
+      labels: any[]
+      url: string
+      updated_at: string | null
+      last_seen_at: string
+    }>
+  >([])
+  const [prs, setPRs] = useState<
+    Array<{
+      github_pr_id: number
+      number: number
+      state: string
+      title: string
+      author_login: string
+      url: string
+      merged: boolean
+      created_at: string | null
+      updated_at: string | null
+      closed_at: string | null
+      merged_at: string | null
+      last_seen_at: string
+    }>
+  >([])
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
     const load = async () => {
       if (!projectId) {
-        logger.warn('ProjectDetailPage: No projectId provided');
-        setError({ message: 'Project not found', notFound: true });
-        setIsLoading(false);
-        return;
+        logger.warn('ProjectDetailPage: No projectId provided')
+        setError({ message: 'Project not found', notFound: true })
+        setIsLoading(false)
+        return
       }
-      setIsLoading(true);
-      setError(null);
+      setIsLoading(true)
+      setError(null)
       try {
-        logger.debug('ProjectDetailPage: Fetching project data for ID:', projectId);
+        logger.debug('ProjectDetailPage: Fetching project data for ID:', projectId)
         const [p, i, pr] = await Promise.all([
           getPublicProject(projectId),
           getPublicProjectIssues(projectId),
           getPublicProjectPRs(projectId),
-        ]);
-        if (cancelled) return;
+        ])
+        if (cancelled) return
         if (!p) {
-          setError({ message: 'Project not found', notFound: true });
-          return;
+          setError({ message: 'Project not found', notFound: true })
+          return
         }
         logger.debug('ProjectDetailPage: Data fetched successfully', {
           project: p,
           issuesCount: i?.issues?.length || 0,
           prsCount: pr?.prs?.length || 0,
-        });
-        setProject(p);
-        setIssues(i?.issues || []);
-        setPRs(pr?.prs || []);
+        })
+        setProject(p)
+        setIssues(i?.issues || [])
+        setPRs(pr?.prs || [])
       } catch (e: any) {
-        if (cancelled) return;
-        logger.error('ProjectDetailPage: Error loading project data', e);
-        const status = e?.response?.status;
+        if (cancelled) return
+        logger.error('ProjectDetailPage: Error loading project data', e)
+        const status = e?.response?.status
         if (status === 404) {
-          setError({ message: 'Project not found', notFound: true });
+          setError({ message: 'Project not found', notFound: true })
         } else {
-          setError({ message: 'Failed to load project data. Please try again.' });
+          setError({ message: 'Failed to load project data. Please try again.' })
         }
       } finally {
-        if (cancelled) return;
-        setIsLoading(false);
+        if (cancelled) return
+        setIsLoading(false)
       }
-    };
-    load();
+    }
+    load()
     return () => {
-      cancelled = true;
-    };
-  }, [projectId, retryCount]);
+      cancelled = true
+    }
+  }, [projectId, retryCount])
 
   const repoName = useMemo(() => {
-    const full = project?.github_full_name || '';
-    const parts = full.split('/');
-    return parts[1] || full || 'Project';
-  }, [project?.github_full_name]);
+    const full = project?.github_full_name || ''
+    const parts = full.split('/')
+    return parts[1] || full || 'Project'
+  }, [project?.github_full_name])
 
-  const ownerLogin = project?.repo?.owner_login || (project?.github_full_name?.split('/')[0] || '');
+  const ownerLogin = project?.repo?.owner_login || project?.github_full_name?.split('/')[0] || ''
   const ownerAvatar =
     project?.repo?.owner_avatar_url ||
-    (ownerLogin ? `https://github.com/${ownerLogin}.png?size=200` : 'https://github.com/github.png?size=200');
-  
-  // Use project avatar if available, otherwise fallback to owner avatar
-  const projectAvatar = project?.repo?.owner_avatar_url || ownerAvatar;
+    (ownerLogin
+      ? `https://github.com/${ownerLogin}.png?size=200`
+      : 'https://github.com/github.png?size=200')
 
-  const githubUrl = project?.repo?.html_url || (project?.github_full_name ? `https://github.com/${project.github_full_name}` : '');
-  const websiteUrl = project?.repo?.homepage || '';
-  const description = project?.repo?.description || '';
+  // Use project avatar if available, otherwise fallback to owner avatar
+  const projectAvatar = project?.repo?.owner_avatar_url || ownerAvatar
+
+  const githubUrl =
+    project?.repo?.html_url ||
+    (project?.github_full_name ? `https://github.com/${project.github_full_name}` : '')
+  const websiteUrl = project?.repo?.homepage || ''
+  const description = project?.repo?.description || ''
 
   const languages = useMemo(() => {
     const list = (project?.languages || [])
       .slice()
       .sort((a, b) => b.percentage - a.percentage)
       .map((l) => {
-        const pct = Number(l.percentage) || 0;
-        const isTiny = pct > 0 && pct < 1;
+        const pct = Number(l.percentage) || 0
+        const isTiny = pct > 0 && pct < 1
         return {
           name: l.name,
           percentage: pct,
           displayLabel: isTiny ? '<1%' : `${Math.round(pct)}%`,
           barWidth: isTiny ? 1 : Math.round(pct),
-        };
-      });
-    if (list.length) return list;
-    return project?.language ? [{ name: project.language, percentage: 100, displayLabel: '100%', barWidth: 100 }] : [];
-  }, [project?.languages, project?.language]);
+        }
+      })
+    if (list.length) return list
+    return project?.language
+      ? [{ name: project.language, percentage: 100, displayLabel: '100%', barWidth: 100 }]
+      : []
+  }, [project?.languages, project?.language])
 
   const labelName = (l: any): string | null => {
-    if (!l) return null;
-    if (typeof l === 'string') return l;
-    if (typeof l?.name === 'string') return l.name;
-    return null;
-  };
+    if (!l) return null
+    if (typeof l === 'string') return l
+    if (typeof l?.name === 'string') return l.name
+    return null
+  }
 
   const issueTabs = useMemo(() => {
     // Only count open issues
-    const openIssues = issues.filter((it) => it.state === 'open');
-    const counts = new Map<string, number>();
+    const openIssues = issues.filter((it) => it.state === 'open')
+    const counts = new Map<string, number>()
     for (const it of openIssues) {
-      const labels = Array.isArray(it.labels) ? it.labels : [];
+      const labels = Array.isArray(it.labels) ? it.labels : []
       for (const l of labels) {
-        const name = labelName(l);
-        if (!name) continue;
-        counts.set(name, (counts.get(name) || 0) + 1);
+        const name = labelName(l)
+        if (!name) continue
+        counts.set(name, (counts.get(name) || 0) + 1)
       }
     }
     const top = Array.from(counts.entries())
       .sort((a, b) => b[1] - a[1])
       .slice(0, 6)
-      .map(([name, count]) => ({ id: name, label: name, count }));
-    return [{ id: 'all', label: 'All issues', count: openIssues.length }, ...top];
-  }, [issues]);
+      .map(([name, count]) => ({ id: name, label: name, count }))
+    return [{ id: 'all', label: 'All issues', count: openIssues.length }, ...top]
+  }, [issues])
 
   const filteredIssues = useMemo(() => {
     // First filter to only open issues
-    const openIssues = issues.filter((it) => it.state === 'open');
-    
+    const openIssues = issues.filter((it) => it.state === 'open')
+
     // Then apply label filter if not 'all'
-    if (activeIssueTab === 'all') return openIssues;
-    return openIssues.filter((it) => (Array.isArray(it.labels) ? it.labels : []).some((l) => labelName(l) === activeIssueTab));
-  }, [issues, activeIssueTab]);
+    if (activeIssueTab === 'all') return openIssues
+    return openIssues.filter((it) =>
+      (Array.isArray(it.labels) ? it.labels : []).some((l) => labelName(l) === activeIssueTab)
+    )
+  }, [issues, activeIssueTab])
 
   const timeAgo = (iso?: string | null) => {
-    const s = iso || '';
-    const d = s ? new Date(s) : null;
-    if (!d || Number.isNaN(d.getTime())) return '';
-    const diffMs = Date.now() - d.getTime();
-    const mins = Math.floor(diffMs / 60000);
-    if (mins < 60) return `${mins}m ago`;
-    const hrs = Math.floor(mins / 60);
-    if (hrs < 24) return `${hrs}h ago`;
-    const days = Math.floor(hrs / 24);
-    return `${days}d ago`;
-  };
+    const s = iso || ''
+    const d = s ? new Date(s) : null
+    if (!d || Number.isNaN(d.getTime())) return ''
+    const diffMs = Date.now() - d.getTime()
+    const mins = Math.floor(diffMs / 60000)
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    const days = Math.floor(hrs / 24)
+    return `${days}d ago`
+  }
 
   const contributors = useMemo(() => {
-    const uniq = new Map<string, { name: string; avatar: string }>();
+    const uniq = new Map<string, { name: string; avatar: string }>()
     for (const it of [...issues, ...prs]) {
-      const login = (it as any).author_login;
-      if (!login || uniq.has(login)) continue;
-      uniq.set(login, { name: login, avatar: `https://github.com/${login}.png?size=80` });
-      if (uniq.size >= 5) break; // Get top 5
+      const login = (it as any).author_login
+      if (!login || uniq.has(login)) continue
+      uniq.set(login, { name: login, avatar: `https://github.com/${login}.png?size=80` })
+      if (uniq.size >= 5) break // Get top 5
     }
-    return Array.from(uniq.values());
-  }, [issues, prs]);
-  
+    return Array.from(uniq.values())
+  }, [issues, prs])
+
   const recentPRs = useMemo(() => {
     const allPRs = prs.map((p) => {
       // Determine PR status: merged takes priority, then state
-      let status: 'merged' | 'open' | 'closed' = 'open';
+      let status: 'merged' | 'open' | 'closed' = 'open'
       if (p.merged) {
-        status = 'merged';
+        status = 'merged'
       } else if (p.state === 'open') {
-        status = 'open';
+        status = 'open'
       } else {
-        status = 'closed';
+        status = 'closed'
       }
-      
+
       // Use the most appropriate GitHub timestamp
       // Priority: merged_at > closed_at > created_at > updated_at > last_seen_at
-      let dateStr: string | null = null;
+      let dateStr: string | null = null
       if (p.merged && p.merged_at) {
-        dateStr = p.merged_at;
+        dateStr = p.merged_at
       } else if (p.state === 'closed' && p.closed_at) {
-        dateStr = p.closed_at;
+        dateStr = p.closed_at
       } else if (p.state === 'open' && p.created_at) {
-        dateStr = p.created_at;
+        dateStr = p.created_at
       } else if (p.updated_at) {
-        dateStr = p.updated_at;
+        dateStr = p.updated_at
       } else {
-        dateStr = p.last_seen_at;
+        dateStr = p.last_seen_at
       }
-      
+
       return {
         type: 'pr' as const,
         id: p.github_pr_id,
@@ -323,93 +334,93 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         date: timeAgo(dateStr),
         status: status,
         url: p.url,
-      };
-    });
+      }
+    })
 
     const allIssues = issues.map((issue) => {
       // For issues, use updated_at (GitHub timestamp) with last_seen_at as fallback
-      const dateStr = issue.updated_at || issue.last_seen_at;
-      
+      const dateStr = issue.updated_at || issue.last_seen_at
+
       return {
         type: 'issue' as const,
         id: issue.github_issue_id,
         number: issue.number,
         title: issue.title,
         date: timeAgo(dateStr),
-        status: issue.state === 'open' ? 'open' : 'closed' as 'open' | 'closed',
+        status: issue.state === 'open' ? 'open' : ('closed' as 'open' | 'closed'),
         url: issue.url,
-      };
-    });
+      }
+    })
 
     const combined = [...allPRs, ...allIssues].sort((a, b) => {
       // Get the most appropriate date for sorting
-      let dateA = '';
-      let dateB = '';
-      
-      if (a.type === 'pr') {
-        const pr = prs.find(p => p.github_pr_id === a.id);
-        if (pr) {
-          if (pr.merged && pr.merged_at) {
-            dateA = pr.merged_at;
-          } else if (pr.state === 'closed' && pr.closed_at) {
-            dateA = pr.closed_at;
-          } else if (pr.state === 'open' && pr.created_at) {
-            dateA = pr.created_at;
-          } else {
-            dateA = pr.updated_at || pr.last_seen_at || '';
-          }
-        }
-      } else {
-        const issue = issues.find(i => i.github_issue_id === a.id);
-        if (issue) {
-          dateA = issue.updated_at || issue.last_seen_at || '';
-        }
-      }
-      
-      if (b.type === 'pr') {
-        const pr = prs.find(p => p.github_pr_id === b.id);
-        if (pr) {
-          if (pr.merged && pr.merged_at) {
-            dateB = pr.merged_at;
-          } else if (pr.state === 'closed' && pr.closed_at) {
-            dateB = pr.closed_at;
-          } else if (pr.state === 'open' && pr.created_at) {
-            dateB = pr.created_at;
-          } else {
-            dateB = pr.updated_at || pr.last_seen_at || '';
-          }
-        }
-      } else {
-        const issue = issues.find(i => i.github_issue_id === b.id);
-        if (issue) {
-          dateB = issue.updated_at || issue.last_seen_at || '';
-        }
-      }
-      
-      return new Date(dateB).getTime() - new Date(dateA).getTime();
-    });
+      let dateA = ''
+      let dateB = ''
 
-    return combined;
-  }, [prs, issues, timeAgo]);
-  
-  const [showAllIssues, setShowAllIssues] = useState(false);
-  const [showAllActivity, setShowAllActivity] = useState(false);
-  
+      if (a.type === 'pr') {
+        const pr = prs.find((p) => p.github_pr_id === a.id)
+        if (pr) {
+          if (pr.merged && pr.merged_at) {
+            dateA = pr.merged_at
+          } else if (pr.state === 'closed' && pr.closed_at) {
+            dateA = pr.closed_at
+          } else if (pr.state === 'open' && pr.created_at) {
+            dateA = pr.created_at
+          } else {
+            dateA = pr.updated_at || pr.last_seen_at || ''
+          }
+        }
+      } else {
+        const issue = issues.find((i) => i.github_issue_id === a.id)
+        if (issue) {
+          dateA = issue.updated_at || issue.last_seen_at || ''
+        }
+      }
+
+      if (b.type === 'pr') {
+        const pr = prs.find((p) => p.github_pr_id === b.id)
+        if (pr) {
+          if (pr.merged && pr.merged_at) {
+            dateB = pr.merged_at
+          } else if (pr.state === 'closed' && pr.closed_at) {
+            dateB = pr.closed_at
+          } else if (pr.state === 'open' && pr.created_at) {
+            dateB = pr.created_at
+          } else {
+            dateB = pr.updated_at || pr.last_seen_at || ''
+          }
+        }
+      } else {
+        const issue = issues.find((i) => i.github_issue_id === b.id)
+        if (issue) {
+          dateB = issue.updated_at || issue.last_seen_at || ''
+        }
+      }
+
+      return new Date(dateB).getTime() - new Date(dateA).getTime()
+    })
+
+    return combined
+  }, [prs, issues, timeAgo])
+
+  const [showAllIssues, setShowAllIssues] = useState(false)
+  const [showAllActivity, setShowAllActivity] = useState(false)
+
   const displayedIssues = useMemo(() => {
-    if (showAllIssues) return filteredIssues;
-    return filteredIssues.slice(0, 5);
-  }, [filteredIssues, showAllIssues]);
-  
+    if (showAllIssues) return filteredIssues
+    return filteredIssues.slice(0, 5)
+  }, [filteredIssues, showAllIssues])
+
   const displayedActivity = useMemo(() => {
-    if (showAllActivity) return recentPRs;
-    return recentPRs.slice(0, 5);
-  }, [recentPRs, showAllActivity]);
+    if (showAllActivity) return recentPRs
+    return recentPRs.slice(0, 5)
+  }, [recentPRs, showAllActivity])
 
   const handleCopyLink = () => {
-    navigator.clipboard.writeText(window.location.href);
-    setCopiedLink(true);
-    setTimeout(() => setCopiedLink(false), 2000);
-  };
+    navigator.clipboard.writeText(window.location.href)
+    setCopiedLink(true)
+    setTimeout(() => setCopiedLink(false), 2000)
+  }
 
   if (!isLoading && error?.notFound) {
     return (
@@ -419,7 +430,7 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         backTo="/dashboard/browse"
         backLabel={backLabel || 'Back to Browse'}
       />
-    );
+    )
   }
 
   if (!isLoading && error && !error.notFound) {
@@ -454,7 +465,7 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
           </div>
         </div>
       </div>
-    );
+    )
   }
 
   return (
@@ -462,22 +473,22 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
       {/* Left Sidebar */}
       <div className="w-[280px] flex-shrink-0 overflow-y-auto overflow-x-hidden space-y-6 scrollbar-hide">
         {/* Project Logo */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
           <div className="aspect-square rounded-[20px] overflow-hidden bg-gradient-to-br from-[#c9983a]/20 to-[#d4af37]/10">
             {isLoading ? (
               <SkeletonLoader className="w-full h-full" />
             ) : (
-              <img 
-                src={projectAvatar} 
+              <img
+                src={projectAvatar}
                 alt={repoName}
                 className="w-full h-full object-cover"
                 onError={(e) => {
                   // Fallback to GitHub default avatar if image fails to load
-                  (e.target as HTMLImageElement).src = 'https://github.com/github.png?size=200';
+                  ;(e.target as HTMLImageElement).src = 'https://github.com/github.png?size=200'
                 }}
               />
             )}
@@ -485,34 +496,42 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Community */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Community</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Community
+          </h3>
           <div className="flex flex-col gap-2">
             {!!websiteUrl && (
-            <a
+              <a
                 href={websiteUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`flex items-center gap-2 px-4 py-2.5 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all text-[13px] font-semibold ${
-                theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
-              }`}
-            >
-              <ExternalLink className="w-4 h-4" />
-              Website
-            </a>
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`flex items-center gap-2 px-4 py-2.5 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all text-[13px] font-semibold ${
+                  theme === 'dark'
+                    ? 'bg-white/[0.08] text-[#f5f5f5]'
+                    : 'bg-white/[0.08] text-[#2d2820]'
+                }`}
+              >
+                <ExternalLink className="w-4 h-4" />
+                Website
+              </a>
             )}
             <a
               href={githubUrl}
               target="_blank"
               rel="noopener noreferrer"
               className={`flex items-center gap-2 px-4 py-2.5 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all text-[13px] font-semibold ${
-                theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                theme === 'dark'
+                  ? 'bg-white/[0.08] text-[#f5f5f5]'
+                  : 'bg-white/[0.08] text-[#2d2820]'
               }`}
             >
               <ExternalLink className="w-4 h-4" />
@@ -522,14 +541,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Languages */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Languages</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Languages
+          </h3>
           <div className="space-y-3">
             {isLoading ? (
               <>
@@ -549,14 +572,20 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                   <div className="flex items-center justify-between mb-1.5">
                     <div className="flex items-center gap-2">
                       <LanguageIcon language={lang.name} className="w-4 h-4 flex-shrink-0" />
-                      <span className={`text-[13px] font-semibold transition-colors ${
-                        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                      }`}>{lang.name}</span>
+                      <span
+                        className={`text-[13px] font-semibold transition-colors ${
+                          theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                        }`}
+                      >
+                        {lang.name}
+                      </span>
                     </div>
-                    <span className="text-[12px] font-bold text-[#c9983a]">{lang.displayLabel}</span>
+                    <span className="text-[12px] font-bold text-[#c9983a]">
+                      {lang.displayLabel}
+                    </span>
                   </div>
                   <div className="h-2 rounded-full backdrop-blur-[15px] bg-white/[0.08] border border-white/15 overflow-hidden">
-                    <div 
+                    <div
                       className="h-full bg-gradient-to-r from-[#c9983a] to-[#d4af37] rounded-full transition-all duration-500"
                       style={{ width: `${lang.barWidth}%` }}
                     />
@@ -564,7 +593,9 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                 </div>
               ))
             ) : (
-              <div className={`text-[13px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
+              <div
+                className={`text-[13px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+              >
                 No language data
               </div>
             )}
@@ -572,14 +603,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Ecosystems */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Ecosystems</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Ecosystems
+          </h3>
           <div className="flex flex-wrap gap-2">
             {isLoading ? (
               <>
@@ -591,14 +626,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                 <span
                   key={idx}
                   className={`px-3 py-1.5 rounded-[8px] text-[12px] font-bold backdrop-blur-[20px] border border-white/25 transition-colors ${
-                    theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                    theme === 'dark'
+                      ? 'bg-white/[0.08] text-[#f5f5f5]'
+                      : 'bg-white/[0.08] text-[#2d2820]'
                   }`}
                 >
                   {eco}
                 </span>
               ))
             ) : (
-              <span className={`text-[12px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
+              <span
+                className={`text-[12px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+              >
                 No ecosystems
               </span>
             )}
@@ -606,14 +645,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Categories */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Categories</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Categories
+          </h3>
           <div className="flex flex-wrap gap-2">
             {isLoading ? (
               <>
@@ -625,14 +668,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                 <span
                   key={idx}
                   className={`px-3 py-1.5 rounded-[8px] text-[12px] font-bold backdrop-blur-[20px] border border-white/25 transition-colors ${
-                    theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                    theme === 'dark'
+                      ? 'bg-white/[0.08] text-[#f5f5f5]'
+                      : 'bg-white/[0.08] text-[#2d2820]'
                   }`}
                 >
                   {cat}
                 </span>
               ))
             ) : (
-              <span className={`text-[12px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
+              <span
+                className={`text-[12px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+              >
                 No categories
               </span>
             )}
@@ -640,14 +687,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Owner */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Owner</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Owner
+          </h3>
           <div className="space-y-3">
             {isLoading ? (
               <div className="flex items-center gap-3">
@@ -656,20 +707,26 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
               </div>
             ) : ownerLogin ? (
               <div className="flex items-center gap-3">
-                <img 
-                  src={ownerAvatar} 
+                <img
+                  src={ownerAvatar}
                   alt={ownerLogin}
                   className="w-8 h-8 rounded-full border-2 border-[#c9983a]/30"
                   onError={(e) => {
-                    (e.target as HTMLImageElement).src = 'https://github.com/github.png?size=80';
+                    ;(e.target as HTMLImageElement).src = 'https://github.com/github.png?size=80'
                   }}
                 />
-                <span className={`text-[13px] font-semibold transition-colors ${
-                  theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                }`}>{ownerLogin}</span>
+                <span
+                  className={`text-[13px] font-semibold transition-colors ${
+                    theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                  }`}
+                >
+                  {ownerLogin}
+                </span>
               </div>
             ) : (
-              <div className={`text-[13px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}>
+              <div
+                className={`text-[13px] ${theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'}`}
+              >
                 Unknown
               </div>
             )}
@@ -677,40 +734,50 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Contributors */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h3 className={`text-[16px] font-bold mb-4 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Contributors</h3>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-6 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h3
+            className={`text-[16px] font-bold mb-4 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Contributors
+          </h3>
           <div className="flex items-center gap-2 mb-3">
             {isLoading ? (
               <div className="flex -space-x-2">
                 {[1, 2, 3, 4, 5].map((i) => (
-                  <SkeletonLoader key={i} variant="circle" className="w-10 h-10 border-2 border-[#c9983a]/30" />
+                  <SkeletonLoader
+                    key={i}
+                    variant="circle"
+                    className="w-10 h-10 border-2 border-[#c9983a]/30"
+                  />
                 ))}
               </div>
             ) : (
               <div className="flex -space-x-2">
                 {contributors.slice(0, 5).map((contributor) => (
-                  <img 
+                  <img
                     key={contributor.name}
-                    src={contributor.avatar} 
+                    src={contributor.avatar}
                     alt={contributor.name}
                     className="w-10 h-10 rounded-full border-2 border-[#c9983a]/30 hover:z-10 transition-transform hover:scale-110"
                     onError={(e) => {
-                      (e.target as HTMLImageElement).src = 'https://github.com/github.png?size=80';
+                      ;(e.target as HTMLImageElement).src = 'https://github.com/github.png?size=80'
                     }}
                   />
                 ))}
                 {project?.contributors_count && project.contributors_count > 5 && (
-                  <div className={`w-10 h-10 rounded-full border-2 border-[#c9983a]/30 flex items-center justify-center text-[12px] font-bold transition-colors ${
-                    theme === 'dark' 
-                      ? 'bg-white/[0.12] text-[#f5f5f5]' 
-                      : 'bg-white/[0.15] text-[#2d2820]'
-                  }`}>
+                  <div
+                    className={`w-10 h-10 rounded-full border-2 border-[#c9983a]/30 flex items-center justify-center text-[12px] font-bold transition-colors ${
+                      theme === 'dark'
+                        ? 'bg-white/[0.12] text-[#f5f5f5]'
+                        : 'bg-white/[0.15] text-[#2d2820]'
+                    }`}
+                  >
                     +{project.contributors_count - 5}
                   </div>
                 )}
@@ -720,9 +787,11 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
           {isLoading ? (
             <SkeletonLoader className="h-4 w-full" />
           ) : (
-            <p className={`text-[12px] transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-            }`}>
+            <p
+              className={`text-[12px] transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+              }`}
+            >
               {project?.contributors_count
                 ? `${project.contributors_count} ${project.contributors_count === 1 ? 'contributor' : 'contributors'}`
                 : 'No contributors yet'}
@@ -749,11 +818,11 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         )}
 
         {/* Header */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
           <div className="flex items-start justify-between mb-4">
             <div className="flex-1">
               {isLoading ? (
@@ -763,12 +832,20 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                 </>
               ) : (
                 <>
-                  <h1 className={`text-[32px] font-bold mb-2 transition-colors ${
-                    theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                  }`}>{repoName}</h1>
-                  <p className={`text-[15px] transition-colors ${
-                    theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                  }`}>{description || project?.github_full_name || 'No description available'}</p>
+                  <h1
+                    className={`text-[32px] font-bold mb-2 transition-colors ${
+                      theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                    }`}
+                  >
+                    {repoName}
+                  </h1>
+                  <p
+                    className={`text-[15px] transition-colors ${
+                      theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                    }`}
+                  >
+                    {description || project?.github_full_name || 'No description available'}
+                  </p>
                 </>
               )}
             </div>
@@ -776,7 +853,9 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
               <button
                 onClick={() => githubUrl && window.open(githubUrl, '_blank')}
                 className={`p-3 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all ${
-                  theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                  theme === 'dark'
+                    ? 'bg-white/[0.08] text-[#f5f5f5]'
+                    : 'bg-white/[0.08] text-[#2d2820]'
                 }`}
               >
                 <ExternalLink className="w-5 h-5" />
@@ -784,7 +863,9 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
               <button
                 onClick={handleCopyLink}
                 className={`p-3 rounded-[12px] backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] transition-all ${
-                  theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                  theme === 'dark'
+                    ? 'bg-white/[0.08] text-[#f5f5f5]'
+                    : 'bg-white/[0.08] text-[#2d2820]'
                 }`}
               >
                 <Copy className={`w-5 h-5 ${copiedLink ? 'text-[#c9983a]' : ''}`} />
@@ -797,15 +878,17 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Overview */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.08] border-white/10'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.08] border-white/10' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
           <div className="flex items-center justify-between mb-6">
-            <h2 className={`text-[18px] font-bold flex items-center gap-2 transition-colors ${
-              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-            }`}>
+            <h2
+              className={`text-[18px] font-bold flex items-center gap-2 transition-colors ${
+                theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+              }`}
+            >
               <span className="text-[#c9983a]">✦</span>
               Overview
             </h2>
@@ -821,38 +904,50 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
               <OverviewMarkdown readme={project.readme} theme={theme} />
             </div>
           ) : description ? (
-            <p className={`text-[15px] leading-relaxed transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
-            }`}>
+            <p
+              className={`text-[15px] leading-relaxed transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
+              }`}
+            >
               {description}
             </p>
           ) : (
-            <p className={`text-[15px] leading-relaxed transition-colors ${
-              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
-            }`}>
-              No description available. Visit the <a 
-                href={githubUrl} 
-                target="_blank" 
+            <p
+              className={`text-[15px] leading-relaxed transition-colors ${
+                theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
+              }`}
+            >
+              No description available. Visit the{' '}
+              <a
+                href={githubUrl}
+                target="_blank"
                 rel="noopener noreferrer"
                 className={`font-semibold hover:underline transition-colors ${
-                  theme === 'dark' 
-                    ? 'text-[#f5c563] hover:text-[#ffd700]' 
+                  theme === 'dark'
+                    ? 'text-[#f5c563] hover:text-[#ffd700]'
                     : 'text-[#b8872f] hover:text-[#8b6f3a]'
                 }`}
-              >GitHub repository</a> for more information.
+              >
+                GitHub repository
+              </a>{' '}
+              for more information.
             </p>
           )}
         </div>
 
         {/* Issues */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h2 className={`text-[18px] font-bold mb-6 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Issues</h2>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h2
+            className={`text-[18px] font-bold mb-6 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Issues
+          </h2>
 
           {/* Issue Tabs */}
           <div className="flex flex-wrap items-center gap-2 mb-6">
@@ -871,7 +966,9 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                     activeIssueTab === tab.id
                       ? 'bg-[#c9983a] text-white'
                       : `backdrop-blur-[20px] border border-white/25 hover:bg-white/[0.2] ${
-                          theme === 'dark' ? 'bg-white/[0.08] text-[#f5f5f5]' : 'bg-white/[0.08] text-[#2d2820]'
+                          theme === 'dark'
+                            ? 'bg-white/[0.08] text-[#f5f5f5]'
+                            : 'bg-white/[0.08] text-[#2d2820]'
                         }`
                   }`}
                 >
@@ -907,78 +1004,97 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
             ) : (
               <>
                 {displayedIssues.map((issue) => (
-              <div
-                key={issue.github_issue_id}
-                className={`p-6 rounded-[16px] backdrop-blur-[25px] border border-white/25 hover:bg-white/[0.15] transition-all cursor-pointer ${
-                  theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.08]'
-                }`}
-                onClick={() => {
-                  if (!projectId) return;
-                  onIssueClick?.(String(issue.github_issue_id), String(projectId));
-                }}
-              >
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex items-start gap-3 flex-1">
-                    {/* Issue Icon - Same as maintainers */}
-                    <div className="w-5 h-5 rounded-full bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40 flex items-center justify-center border border-[#c9983a]/40 flex-shrink-0 mt-0.5">
-                      <Circle className="w-2.5 h-2.5 text-white fill-white" strokeWidth={0} />
+                  <div
+                    key={issue.github_issue_id}
+                    className={`p-6 rounded-[16px] backdrop-blur-[25px] border border-white/25 hover:bg-white/[0.15] transition-all cursor-pointer ${
+                      theme === 'dark' ? 'bg-white/[0.08]' : 'bg-white/[0.08]'
+                    }`}
+                    onClick={() => {
+                      if (!projectId) return
+                      onIssueClick?.(String(issue.github_issue_id), String(projectId))
+                    }}
+                  >
+                    <div className="flex items-start justify-between mb-3">
+                      <div className="flex items-start gap-3 flex-1">
+                        {/* Issue Icon - Same as maintainers */}
+                        <div className="w-5 h-5 rounded-full bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40 flex items-center justify-center border border-[#c9983a]/40 flex-shrink-0 mt-0.5">
+                          <Circle className="w-2.5 h-2.5 text-white fill-white" strokeWidth={0} />
+                        </div>
+                        <h3
+                          className={`text-[15px] font-bold transition-colors ${
+                            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                          }`}
+                        >
+                          {issue.title}
+                        </h3>
+                      </div>
                     </div>
-                    <h3 className={`text-[15px] font-bold transition-colors ${
-                      theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                    }`}>{issue.title}</h3>
-                  </div>
-                </div>
-                <div className="flex items-center justify-between ml-8">
-                  <div className="flex items-center gap-2">
-                    {(Array.isArray(issue.labels) ? issue.labels : [])
-                      .map((l) => labelName(l))
-                      .filter(Boolean)
-                      .slice(0, 4)
-                      .map((tag, idx) => (
-                      <span
-                        key={idx}
-                        className={`px-3 py-1 rounded-[6px] text-[11px] font-bold backdrop-blur-[20px] border border-white/20 transition-colors ${
-                          theme === 'dark' ? 'bg-white/[0.1] text-[#d4d4d4]' : 'bg-white/[0.1] text-[#4a3f2f]'
-                        }`}
-                      >
-                        {String(tag)}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className={`text-[12px] transition-colors ${
-                      theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                    }`}>{timeAgo(issue.updated_at || issue.last_seen_at)}</span>
-                    <div className="flex items-center gap-2">
-                      <img 
-                        src={`https://github.com/${issue.author_login}.png?size=40`} 
-                        alt={issue.author_login}
-                        className="w-5 h-5 rounded-full border border-[#c9983a]/30"
-                      />
-                      <span className={`text-[12px] font-semibold transition-colors ${
-                        theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                      }`}>By {issue.author_login}</span>
+                    <div className="flex items-center justify-between ml-8">
+                      <div className="flex items-center gap-2">
+                        {(Array.isArray(issue.labels) ? issue.labels : [])
+                          .map((l) => labelName(l))
+                          .filter(Boolean)
+                          .slice(0, 4)
+                          .map((tag, idx) => (
+                            <span
+                              key={idx}
+                              className={`px-3 py-1 rounded-[6px] text-[11px] font-bold backdrop-blur-[20px] border border-white/20 transition-colors ${
+                                theme === 'dark'
+                                  ? 'bg-white/[0.1] text-[#d4d4d4]'
+                                  : 'bg-white/[0.1] text-[#4a3f2f]'
+                              }`}
+                            >
+                              {String(tag)}
+                            </span>
+                          ))}
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={`text-[12px] transition-colors ${
+                            theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                          }`}
+                        >
+                          {timeAgo(issue.updated_at || issue.last_seen_at)}
+                        </span>
+                        <div className="flex items-center gap-2">
+                          <img
+                            src={`https://github.com/${issue.author_login}.png?size=40`}
+                            alt={issue.author_login}
+                            className="w-5 h-5 rounded-full border border-[#c9983a]/30"
+                          />
+                          <span
+                            className={`text-[12px] font-semibold transition-colors ${
+                              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                            }`}
+                          >
+                            By {issue.author_login}
+                          </span>
+                        </div>
+                        <div
+                          className={`flex items-center gap-1.5 px-2 py-1 rounded-[6px] backdrop-blur-[20px] border border-white/20 transition-colors ${
+                            theme === 'dark' ? 'bg-white/[0.1]' : 'bg-white/[0.1]'
+                          }`}
+                        >
+                          <img
+                            src={projectAvatar}
+                            alt={repoName}
+                            className="w-4 h-4 rounded-full border border-[#c9983a]/30 object-cover"
+                            onError={(e) => {
+                              ;(e.target as HTMLImageElement).src =
+                                'https://github.com/github.png?size=40'
+                            }}
+                          />
+                          <span
+                            className={`text-[11px] font-bold transition-colors ${
+                              theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
+                            }`}
+                          >
+                            {repoName}
+                          </span>
+                        </div>
+                      </div>
                     </div>
-                    <div className={`flex items-center gap-1.5 px-2 py-1 rounded-[6px] backdrop-blur-[20px] border border-white/20 transition-colors ${
-                      theme === 'dark' ? 'bg-white/[0.1]' : 'bg-white/[0.1]'
-                    }`}>
-                      <img 
-                        src={projectAvatar} 
-                        alt={repoName}
-                        className="w-4 h-4 rounded-full border border-[#c9983a]/30 object-cover"
-                        onError={(e) => {
-                          (e.target as HTMLImageElement).src = 'https://github.com/github.png?size=40';
-                        }}
-                      />
-                      <span className={`text-[11px] font-bold transition-colors ${
-                        theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#4a3f2f]'
-                      }`}>
-                        {repoName}
-                      </span>
-                    </div>
                   </div>
-                </div>
-              </div>
                 ))}
                 {!showAllIssues && filteredIssues.length > 5 && (
                   <button
@@ -989,15 +1105,21 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                         : 'bg-white/[0.12] border-white/25 text-[#2d2820] hover:bg-white/[0.15]'
                     }`}
                   >
-                    <span className="text-[14px] font-semibold">View All ({filteredIssues.length} issues)</span>
+                    <span className="text-[14px] font-semibold">
+                      View All ({filteredIssues.length} issues)
+                    </span>
                   </button>
                 )}
               </>
             )}
             {!isLoading && filteredIssues.length === 0 && (
-              <div className={`p-6 rounded-[16px] border text-center ${
-                theme === 'dark' ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]' : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'
-              }`}>
+              <div
+                className={`p-6 rounded-[16px] border text-center ${
+                  theme === 'dark'
+                    ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]'
+                    : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'
+                }`}
+              >
                 <p className="text-[14px] font-semibold">No issues found</p>
               </div>
             )}
@@ -1005,14 +1127,18 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
 
         {/* Recent Activity */}
-        <div className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
-          theme === 'dark'
-            ? 'bg-white/[0.12] border-white/20'
-            : 'bg-white/[0.12] border-white/20'
-        }`}>
-          <h2 className={`text-[18px] font-bold mb-6 transition-colors ${
-            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-          }`}>Recent Activity</h2>
+        <div
+          className={`backdrop-blur-[40px] rounded-[24px] border p-8 transition-colors ${
+            theme === 'dark' ? 'bg-white/[0.12] border-white/20' : 'bg-white/[0.12] border-white/20'
+          }`}
+        >
+          <h2
+            className={`text-[18px] font-bold mb-6 transition-colors ${
+              theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+            }`}
+          >
+            Recent Activity
+          </h2>
           <div className="space-y-3">
             {isLoading ? (
               <>
@@ -1035,54 +1161,54 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
               <>
                 {displayedActivity.map((activity, idx) => {
                   // Determine colors based on type and status
-                  let iconBgColor = '';
-                  let iconColor = '';
-                  let badgeBgColor = '';
-                  let badgeBorderColor = '';
-                  
+                  let iconBgColor = ''
+                  let iconColor = ''
+                  let badgeBgColor = ''
+                  let badgeBorderColor = ''
+
                   if (activity.type === 'pr') {
                     if (activity.status === 'merged') {
                       // Merged PR: Purple
-                      iconBgColor = 'bg-[#8b5cf6]/50';
-                      iconColor = 'text-[#8b5cf6]';
-                      badgeBgColor = 'bg-[#8b5cf6]/50';
-                      badgeBorderColor = 'border-[#8b5cf6]/40';
+                      iconBgColor = 'bg-[#8b5cf6]/50'
+                      iconColor = 'text-[#8b5cf6]'
+                      badgeBgColor = 'bg-[#8b5cf6]/50'
+                      badgeBorderColor = 'border-[#8b5cf6]/40'
                     } else if (activity.status === 'open') {
                       // Open PR: Green
-                      iconBgColor = 'bg-[#22c55e]/50';
-                      iconColor = 'text-[#22c55e]';
-                      badgeBgColor = 'bg-[#22c55e]/50';
-                      badgeBorderColor = 'border-[#22c55e]/40';
+                      iconBgColor = 'bg-[#22c55e]/50'
+                      iconColor = 'text-[#22c55e]'
+                      badgeBgColor = 'bg-[#22c55e]/50'
+                      badgeBorderColor = 'border-[#22c55e]/40'
                     } else {
                       // Closed PR: Gray/Red
-                      iconBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]';
-                      iconColor = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]';
-                      badgeBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]';
-                      badgeBorderColor = theme === 'dark' ? 'border-white/20' : 'border-white/30';
+                      iconBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]'
+                      iconColor = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                      badgeBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]'
+                      badgeBorderColor = theme === 'dark' ? 'border-white/20' : 'border-white/30'
                     }
                   } else {
                     // Issue
                     if (activity.status === 'open') {
                       // Open Issue: Golden/Yellow
-                      iconBgColor = 'bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40';
-                      iconColor = 'text-white';
-                      badgeBgColor = 'bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40';
-                      badgeBorderColor = 'border-[#c9983a]/40';
+                      iconBgColor = 'bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40'
+                      iconColor = 'text-white'
+                      badgeBgColor = 'bg-gradient-to-br from-[#c9983a]/50 to-[#d4af37]/40'
+                      badgeBorderColor = 'border-[#c9983a]/40'
                     } else {
                       // Closed Issue: Gray
-                      iconBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]';
-                      iconColor = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]';
-                      badgeBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]';
-                      badgeBorderColor = theme === 'dark' ? 'border-white/20' : 'border-white/30';
+                      iconBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]'
+                      iconColor = theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
+                      badgeBgColor = theme === 'dark' ? 'bg-white/[0.15]' : 'bg-white/[0.2]'
+                      badgeBorderColor = theme === 'dark' ? 'border-white/20' : 'border-white/30'
                     }
                   }
-                  
+
                   const handleClick = () => {
                     if (activity.url) {
-                      window.open(activity.url, '_blank', 'noopener,noreferrer');
+                      window.open(activity.url, '_blank', 'noopener,noreferrer')
                     }
-                  };
-                  
+                  }
+
                   return (
                     <div
                       key={idx}
@@ -1094,32 +1220,58 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                       <div className="flex items-center gap-3">
                         {activity.type === 'issue' ? (
                           // Issue Icon
-                          <div className={`w-5 h-5 rounded-full ${iconBgColor} flex items-center justify-center border ${badgeBorderColor} flex-shrink-0`}>
-                            <Circle className={`w-2.5 h-2.5 ${iconColor} ${activity.status === 'open' ? 'fill-white' : 'fill-current'}`} strokeWidth={0} />
+                          <div
+                            className={`w-5 h-5 rounded-full ${iconBgColor} flex items-center justify-center border ${badgeBorderColor} flex-shrink-0`}
+                          >
+                            <Circle
+                              className={`w-2.5 h-2.5 ${iconColor} ${activity.status === 'open' ? 'fill-white' : 'fill-current'}`}
+                              strokeWidth={0}
+                            />
                           </div>
                         ) : (
                           // PR Icon
-                          <div className={`w-5 h-5 rounded-full ${iconBgColor} flex items-center justify-center border ${badgeBorderColor} flex-shrink-0`}>
+                          <div
+                            className={`w-5 h-5 rounded-full ${iconBgColor} flex items-center justify-center border ${badgeBorderColor} flex-shrink-0`}
+                          >
                             <GitPullRequest className={`w-3 h-3 ${iconColor}`} strokeWidth={2.5} />
                           </div>
                         )}
-                        <div className={`px-2 py-1 rounded-[6px] ${badgeBgColor} border ${badgeBorderColor}`}>
-                          <span className={`text-[11px] font-bold ${
-                            activity.status === 'open' && activity.type === 'issue' ? 'text-white' :
-                            activity.status === 'merged' ? 'text-white' :
-                            activity.status === 'open' && activity.type === 'pr' ? 'text-white' :
-                            theme === 'dark' ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
-                          }`}>#{activity.number}</span>
+                        <div
+                          className={`px-2 py-1 rounded-[6px] ${badgeBgColor} border ${badgeBorderColor}`}
+                        >
+                          <span
+                            className={`text-[11px] font-bold ${
+                              activity.status === 'open' && activity.type === 'issue'
+                                ? 'text-white'
+                                : activity.status === 'merged'
+                                  ? 'text-white'
+                                  : activity.status === 'open' && activity.type === 'pr'
+                                    ? 'text-white'
+                                    : theme === 'dark'
+                                      ? 'text-[#b8a898]'
+                                      : 'text-[#7a6b5a]'
+                            }`}
+                          >
+                            #{activity.number}
+                          </span>
                         </div>
-                        <span className={`text-[14px] font-semibold transition-colors ${
-                          theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
-                        }`}>{activity.title}</span>
+                        <span
+                          className={`text-[14px] font-semibold transition-colors ${
+                            theme === 'dark' ? 'text-[#f5f5f5]' : 'text-[#2d2820]'
+                          }`}
+                        >
+                          {activity.title}
+                        </span>
                       </div>
-                      <span className={`text-[13px] transition-colors ${
-                        theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
-                      }`}>{activity.date}</span>
+                      <span
+                        className={`text-[13px] transition-colors ${
+                          theme === 'dark' ? 'text-[#d4d4d4]' : 'text-[#7a6b5a]'
+                        }`}
+                      >
+                        {activity.date}
+                      </span>
                     </div>
-                  );
+                  )
                 })}
                 {!showAllActivity && recentPRs.length > 5 && (
                   <button
@@ -1130,15 +1282,21 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
                         : 'bg-white/[0.12] border-white/25 text-[#2d2820] hover:bg-white/[0.15]'
                     }`}
                   >
-                    <span className="text-[14px] font-semibold">View All ({recentPRs.length} activities)</span>
+                    <span className="text-[14px] font-semibold">
+                      View All ({recentPRs.length} activities)
+                    </span>
                   </button>
                 )}
               </>
             )}
             {!isLoading && recentPRs.length === 0 && (
-              <div className={`p-6 rounded-[16px] border text-center ${
-                theme === 'dark' ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]' : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'
-              }`}>
+              <div
+                className={`p-6 rounded-[16px] border text-center ${
+                  theme === 'dark'
+                    ? 'bg-white/[0.08] border-white/15 text-[#d4d4d4]'
+                    : 'bg-white/[0.15] border-white/25 text-[#7a6b5a]'
+                }`}
+              >
                 <p className="text-[14px] font-semibold">No recent pull requests</p>
               </div>
             )}
@@ -1146,5 +1304,5 @@ export function ProjectDetailPage({ onBack, onIssueClick, projectId: propProject
         </div>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary

`ProjectDetailPage.tsx`'s GitHub-link button opened `githubUrl` via `window.open(githubUrl, '_blank')` without `noopener`/`noreferrer`. `githubUrl` is derived from project/repository data (`repo.html_url`, falling back to `https://github.com/${github_full_name}`) rather than a hardcoded string, so this is inconsistent with the existing pattern later in the same file (`window.open(activity.url, '_blank', 'noopener,noreferrer')` at what's now a different line post-formatting) and a real reverse-tabnabbing exposure.

## A note on this PR's two commits

This file wasn't prettier-clean on `main` (pre-existing, unrelated to this issue), and this repo's `lint-staged` config runs `prettier --write` on the whole file the moment any line is touched. To keep the actual fix reviewable, I split this into:
1. `chore: format ProjectDetailPage.tsx with prettier` -- pure formatting, no logic change (verified via the full existing test suite passing unchanged before/after).
2. `fix(security): ...` -- the actual one-line fix, a clean 26-line diff (mostly the new test).

## Fix

`window.open(githubUrl, '_blank', 'noopener,noreferrer')`. The other `window.open(activity.url, ...)` call in the same file is untouched and already correct.

## Testing

Added a test: renders the page, finds the GitHub-link button (via its `lucide-external-link` icon, matching this test file's existing pattern for the Copy button), clicks it, and asserts `window.open` is called with the project's resolved GitHub URL, `'_blank'`, and `'noopener,noreferrer'`. Full suite passes: 135 test files, 1559 passed (up from 1558 baseline).

Closes #713