### PR TITLE
fix: fetch real invoices in BillingTab instead of hardcoded empty array

### DIFF
--- a/src/features/settings/components/billing/BillingTab.test.tsx
+++ b/src/features/settings/components/billing/BillingTab.test.tsx
@@ -1,7 +1,16 @@
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BillingTab } from './BillingTab'
 import { toast } from 'sonner'
+import { I18nProvider } from '../../../../shared/i18n'
+
+function renderBillingTab() {
+  return render(
+    <I18nProvider>
+      <BillingTab />
+    </I18nProvider>
+  )
+}
 
 vi.mock('../../../../shared/contexts/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
@@ -28,15 +37,17 @@ vi.mock('../../contexts/BillingProfilesContext', () => ({
 }))
 
 const mockGetKYCStatus = vi.fn().mockResolvedValue({ status: 'verified' })
+const mockGetInvoices = vi.fn().mockResolvedValue([])
 
 vi.mock('../../../../shared/api/client', () => ({
   getBillingProfiles: vi.fn().mockResolvedValue([]),
   getKYCStatus: (...args: unknown[]) => mockGetKYCStatus(...args),
   startKYCVerification: vi.fn().mockResolvedValue({ url: 'https://example.com' }),
+  getInvoices: (...args: unknown[]) => mockGetInvoices(...args),
 }))
 
 async function navigateToDetailView() {
-  render(<BillingTab />)
+  renderBillingTab()
   const card = await screen.findByText('John Doe')
   await act(async () => {
     fireEvent.click(card)
@@ -47,11 +58,12 @@ describe('BillingTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetKYCStatus.mockResolvedValue({ status: 'verified' })
+    mockGetInvoices.mockResolvedValue([])
     vi.stubEnv('VITE_USE_MOCK_DATA', 'true')
   })
 
   it('shows an error toast when trying to create a duplicate individual profile', async () => {
-    render(<BillingTab />)
+    renderBillingTab()
 
     const newProfileBtn = await screen.findByText('New Profile')
     fireEvent.click(newProfileBtn)
@@ -138,6 +150,76 @@ describe('BillingTab', () => {
         (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
       )
       expect(textNodes).toHaveLength(0)
+    })
+  })
+
+  describe('Invoices tab', () => {
+    async function openInvoicesTab() {
+      await navigateToDetailView()
+      await act(async () => {
+        fireEvent.click(screen.getByText('Invoices'))
+      })
+    }
+
+    it('fetches invoices for the selected profile when the tab is opened', async () => {
+      await openInvoicesTab()
+
+      await waitFor(() => {
+        expect(mockGetInvoices).toHaveBeenCalledWith(1)
+      })
+    })
+
+    it('renders a genuine empty state when the backend returns no invoices', async () => {
+      await openInvoicesTab()
+
+      await waitFor(() => expect(mockGetInvoices).toHaveBeenCalled())
+      expect(await screen.findByText('No invoices yet')).toBeInTheDocument()
+    })
+
+    it('renders real invoice rows returned by the backend', async () => {
+      mockGetInvoices.mockResolvedValue([
+        {
+          id: 'inv-1',
+          invoiceNumber: 'INV-2024-001',
+          date: '2024-01-01',
+          amount: 100,
+          currency: 'USD',
+          status: 'paid',
+          description: 'Monthly fee',
+          billingPeriod: 'Jan 2024',
+        },
+      ])
+
+      await openInvoicesTab()
+
+      expect(await screen.findByText('INV-2024-001')).toBeInTheDocument()
+    })
+
+    it('shows the loading state while invoices are being fetched', async () => {
+      let resolveInvoices: (value: unknown[]) => void = () => {}
+      mockGetInvoices.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveInvoices = resolve
+          })
+      )
+
+      await openInvoicesTab()
+
+      expect(screen.getByTestId('invoices-loading')).toBeInTheDocument()
+
+      resolveInvoices([])
+      await waitFor(() => {
+        expect(screen.queryByTestId('invoices-loading')).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows an error state when fetching invoices fails', async () => {
+      mockGetInvoices.mockRejectedValue(new Error('network error'))
+
+      await openInvoicesTab()
+
+      expect(await screen.findByTestId('invoices-error')).toBeInTheDocument()
     })
   })
 })

--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -8,9 +8,9 @@ import {
   BillingProfileStatus,
   ProfileDetailTabType,
   PaymentMethod,
+  Invoice,
 } from '../../types'
-import { getBillingProfiles } from '../../../../shared/api/client'
-import { sampleInvoices } from '../../data/invoicesData'
+import { getBillingProfiles, getInvoices } from '../../../../shared/api/client'
 import { BillingProfileCard } from './BillingProfileCard'
 import { PaymentMethodsTab } from './PaymentMethodsTab'
 import { InvoicesTab } from './InvoicesTab'
@@ -159,6 +159,9 @@ export function BillingTab() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isCheckingKYC, setIsCheckingKYC] = useState(false)
   const [kycWindowOpened, setKycWindowOpened] = useState(false)
+  const [invoices, setInvoices] = useState<Invoice[]>([])
+  const [invoicesLoading, setInvoicesLoading] = useState(false)
+  const [invoicesError, setInvoicesError] = useState<string | null>(null)
 
   const handleCreateProfile = () => {
     if (!profileName.trim()) return
@@ -217,6 +220,33 @@ export function BillingTab() {
       }
     }
   }, [selectedProfile])
+
+  // Fetch this profile's invoices when the Invoices sub-tab becomes active.
+  // Always hits the real endpoint regardless of useMock, matching the KYC
+  // calls above (which are also not gated by mock mode) -- useMock only
+  // controls whether the *profiles list* comes from local seed data.
+  useEffect(() => {
+    if (!selectedProfile || detailTab !== 'invoices') return
+
+    let cancelled = false
+    setInvoicesLoading(true)
+    setInvoicesError(null)
+    getInvoices(selectedProfile.id)
+      .then((data) => {
+        if (!cancelled) setInvoices(data)
+      })
+      .catch((err) => {
+        logger.error('Failed to fetch invoices:', err)
+        if (!cancelled) setInvoicesError('Failed to load invoices. Please try again.')
+      })
+      .finally(() => {
+        if (!cancelled) setInvoicesLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedProfile, detailTab])
 
   const checkKYCStatus = async () => {
     setIsCheckingKYC(true)
@@ -901,7 +931,9 @@ export function BillingTab() {
         )}
 
         {/* Invoices Tab */}
-        {detailTab === 'invoices' && <InvoicesTab invoices={sampleInvoices} />}
+        {detailTab === 'invoices' && (
+          <InvoicesTab invoices={invoices} isLoading={invoicesLoading} error={invoicesError} />
+        )}
       </div>
     )
   }

--- a/src/features/settings/data/invoicesData.ts
+++ b/src/features/settings/data/invoicesData.ts
@@ -1,3 +1,0 @@
-import { Invoice } from '../types';
-
-export const sampleInvoices: Invoice[] = [];

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -5,7 +5,7 @@
 import { API_BASE_URL } from '../config/api'
 import { getErrorCodeMessage } from '../i18n/errors'
 import { readStoredLocale } from '../i18n/LocaleProvider'
-import { BillingProfile, NotificationSettings } from '../../features/settings/types'
+import { BillingProfile, Invoice, NotificationSettings } from '../../features/settings/types'
 import { BlogPost } from '../../features/blog/types'
 
 // Token management
@@ -1200,6 +1200,10 @@ export const getKYCStatus = () =>
 
 export const getBillingProfiles = () =>
   apiRequest<BillingProfile[]>('/billing/profiles', { requiresAuth: true })
+
+/** Fetches the invoices belonging to a single billing profile. */
+export const getInvoices = (profileId: number) =>
+  apiRequest<Invoice[]>(`/billing/profiles/${profileId}/invoices`, { requiresAuth: true })
 
 /** A single project-to-billing-profile assignment. */
 export type PayoutMappingEntry = {


### PR DESCRIPTION
## Summary

`sampleInvoices` (`src/features/settings/data/invoicesData.ts`) was a `const` initialized to `[]` and never reassigned or fetched from anywhere. `BillingTab.tsx` passed it directly to `InvoicesTab`, so every user who opened Settings -> Billing -> a profile's Invoices tab saw the empty state regardless of how many real invoices existed, with no error surfaced since the UI rendered successfully.

## Changes

- Adds `getInvoices(profileId)` to `shared/api/client.ts`, following the existing `apiRequest` conventions.
- `BillingTab` now fetches invoices when the Invoices sub-tab becomes active for the selected profile, storing them in state and passing loading/error state into `InvoicesTab`'s existing `isLoading`/`error` props (previously defined but never actually driven by real state -- `InvoicesTab.tsx` and its own tests already handled these props correctly).
- The fetch is **not** gated behind `VITE_USE_MOCK_DATA`, matching this file's existing KYC calls (`getKYCStatus`/`startKYCVerification`, which also always hit the real endpoint) rather than the profiles-list fetch (which *is* mock-gated, since `useMock` there only controls where the profile list itself comes from).
- Deletes the now-unused `src/features/settings/data/invoicesData.ts` and its import.

## A note on the endpoint path

I picked `GET /billing/profiles/:profileId/invoices`, mirroring the existing `downloadInvoice`'s `/billing/invoices/:id/download` convention (both use path segments to express the resource hierarchy). I don't have visibility into the actual backend route -- a maintainer familiar with the API should confirm this matches, or point me to the right path if it's e.g. `/billing/invoices?profile_id=` instead. Happy to adjust in review.

## Testing

Added 5 tests to `BillingTab.test.tsx`: fetches with the selected profile's id when the tab opens, renders a genuine empty state when the backend returns none, renders real invoice rows when populated, shows the loading skeleton while in flight, shows the error state on failure. Also had to wrap this test file's render calls in `I18nProvider` -- `InvoicesTab` uses `useTranslation`, and no existing test in this file had exercised that code path before (none of them ever opened the Invoices tab). Full suite: 135 test files, 1563 passed (up from 1558 baseline).

Closes #709