### PR TITLE
Fix project row keys for tied ranks

### DIFF
--- a/src/features/leaderboard/components/ProjectsTable.test.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.test.tsx
@@ -60,6 +60,16 @@ function renderTable(data: ProjectData[] = projects) {
 }
 
 describe('ProjectsTable — View Project navigation', () => {
+  it('keeps projects with tied ranks as distinct rows', () => {
+    renderTable([
+      projects[0],
+      { ...projects[1], id: 'proj-3', name: 'Another Protocol', rank: projects[0].rank },
+    ])
+
+    expect(screen.getByText('DeFi Protocol')).toBeInTheDocument()
+    expect(screen.getByText('Another Protocol')).toBeInTheDocument()
+  })
+
   it('renders a View Project link per project pointing at its detail route', () => {
     renderTable()
 

--- a/src/features/leaderboard/components/ProjectsTable.tsx
+++ b/src/features/leaderboard/components/ProjectsTable.tsx
@@ -110,7 +110,7 @@ export function ProjectsTable({
             const detailPath = projectDetailPath(project.id)
             return (
               <div
-                key={project.rank}
+                key={project.id ?? project.name}
                 className="grid grid-cols-12 gap-4 px-8 py-5 hover:bg-white/[0.08] transition-all duration-300 cursor-pointer group"
                 style={{
                   animation: isLoaded


### PR DESCRIPTION
## Summary
Use each project's stable id (falling back to its name for legacy seed rows) as the React row key, preserving displayed rank/order while preventing duplicate-key reconciliation problems. Added a tied-rank regression test.

## Validation
The focused Vitest command could not run because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #716