### PR TITLE
fix: clear KYC polling interval/timeout on BillingTab unmount

### DIFF
--- a/src/features/settings/components/billing/BillingTab.test.tsx
+++ b/src/features/settings/components/billing/BillingTab.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BillingTab } from './BillingTab'
 import { toast } from 'sonner'
 
@@ -138,6 +138,53 @@ describe('BillingTab', () => {
         (n) => n.nodeType === Node.TEXT_NODE && n.textContent?.trim()
       )
       expect(textNodes).toHaveLength(0)
+    })
+  })
+
+  describe('KYC poll cleanup on unmount', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('stops polling getKYCStatus once the component unmounts', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+      mockGetKYCStatus.mockResolvedValue({ status: 'pending' })
+      const originalStatus = mockProfiles[0].status
+      mockProfiles[0].status = 'missing-verification'
+
+      try {
+        const { unmount } = render(<BillingTab />)
+        const card = await screen.findByText('John Doe')
+        await act(async () => {
+          fireEvent.click(card)
+        })
+
+        const verifyBtn = await screen.findByRole('button', { name: 'Verify KYC' })
+        await act(async () => {
+          fireEvent.click(verifyBtn)
+        })
+
+        // Flush the initial (non-interval) status check triggered right after the window opens.
+        await act(async () => {
+          await Promise.resolve()
+        })
+
+        const callsAtUnmount = mockGetKYCStatus.mock.calls.length
+        expect(callsAtUnmount).toBeGreaterThan(0)
+
+        unmount()
+
+        // Advance well past several 3s poll ticks.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000)
+        })
+
+        expect(mockGetKYCStatus.mock.calls.length).toBe(callsAtUnmount)
+      } finally {
+        mockProfiles[0].status = originalStatus
+        openSpy.mockRestore()
+      }
     })
   })
 })

--- a/src/features/settings/components/billing/BillingTab.tsx
+++ b/src/features/settings/components/billing/BillingTab.tsx
@@ -159,6 +159,8 @@ export function BillingTab() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isCheckingKYC, setIsCheckingKYC] = useState(false)
   const [kycWindowOpened, setKycWindowOpened] = useState(false)
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleCreateProfile = () => {
     if (!profileName.trim()) return
@@ -205,6 +207,16 @@ export function BillingTab() {
         .finally(() => setLoadingProfiles(false))
     }
   }, [useMock])
+
+  // Clear any in-flight KYC poll interval/timeout on unmount. Without this,
+  // navigating away mid-poll leaves the interval running for up to 5
+  // minutes, calling getKYCStatus() and setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current)
+    }
+  }, [])
 
   // Existing KYC effect stays unchanged
   useEffect(() => {
@@ -289,13 +301,13 @@ export function BillingTab() {
         }
 
         // Poll for status updates
-        const pollInterval = setInterval(async () => {
+        pollIntervalRef.current = setInterval(async () => {
           try {
             const statusResponse = await getKYCStatus()
             setKycStatus(statusResponse.status || null)
 
             if (statusResponse.status === 'verified') {
-              clearInterval(pollInterval)
+              if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
               setKycWindowOpened(false)
               if (statusResponse.extracted) {
                 updateProfileWithKYCData(statusResponse.extracted)
@@ -304,7 +316,7 @@ export function BillingTab() {
               statusResponse.status === 'rejected' ||
               statusResponse.status === 'expired'
             ) {
-              clearInterval(pollInterval)
+              if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
               setKycWindowOpened(false)
             }
           } catch (error) {
@@ -316,9 +328,9 @@ export function BillingTab() {
         }, 3000) // Poll every 3 seconds
 
         // Stop polling after 5 minutes
-        setTimeout(
+        pollTimeoutRef.current = setTimeout(
           () => {
-            clearInterval(pollInterval)
+            if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
             setKycWindowOpened(false)
           },
           5 * 60 * 1000


### PR DESCRIPTION
Closes #710\n\nApply the focused fix requested by issue #710, including the existing regression coverage.