### PR TITLE
fix: add noopener,noreferrer to ProfileTab GitHub settings window.open

### DIFF
--- a/src/features/settings/components/profile/ProfileTab.test.tsx
+++ b/src/features/settings/components/profile/ProfileTab.test.tsx
@@ -212,4 +212,23 @@ describe('ProfileTab', () => {
     resolveAvatar()
     await waitFor(() => expect(toast.success).toHaveBeenCalled())
   })
+
+  it('opens the GitHub settings page with noopener,noreferrer', async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    mockGetCurrentUser.mockResolvedValue(mockUser)
+    renderWithTheme(<ProfileTab />)
+
+    await waitFor(() => expect(screen.getByDisplayValue('John')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/settings/profile',
+      '_blank',
+      'noopener,noreferrer'
+    )
+
+    openSpy.mockRestore()
+  })
 })

--- a/src/features/settings/components/profile/ProfileTab.tsx
+++ b/src/features/settings/components/profile/ProfileTab.tsx
@@ -172,7 +172,7 @@ export function ProfileTab() {
 
   const handleEditGitHub = () => {
     // Open GitHub settings page in a new tab
-    window.open('https://github.com/settings/profile', '_blank')
+    window.open('https://github.com/settings/profile', '_blank', 'noopener,noreferrer')
   }
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes #711\n\nApply the focused fix requested by issue #711, including the existing regression coverage.