### PR TITLE
fix(dropdown): name options by filter context

### DIFF
--- a/src/features/maintainers/components/pull-requests/PRFilterDropdown.tsx
+++ b/src/features/maintainers/components/pull-requests/PRFilterDropdown.tsx
@@ -20,6 +20,7 @@ export function PRFilterDropdown({ value, onChange, isOpen, onToggle, onClose }:
       isOpen={isOpen}
       onToggle={onToggle}
       onClose={onClose}
+      ariaLabel="Pull request status"
     />
   );
 }

--- a/src/shared/components/GlassDropdown.test.tsx
+++ b/src/shared/components/GlassDropdown.test.tsx
@@ -52,6 +52,14 @@ describe('GlassDropdown accessibility', () => {
     expect(screen.getAllByRole('option')).toHaveLength(OPTIONS.length);
   });
 
+  it('uses a contextual accessible name for the options list', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<GlassHarness />);
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-label', 'Select option');
+  });
+
   it('marks the selected option with aria-selected', async () => {
     const user = userEvent.setup();
     renderWithTheme(<GlassHarness initialValue="Merged" />);

--- a/src/shared/components/GlassDropdown.tsx
+++ b/src/shared/components/GlassDropdown.tsx
@@ -9,6 +9,8 @@ interface GlassDropdownProps<T extends string> {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  /** Accessible name describing the filter represented by the menu. */
+  ariaLabel?: string;
 }
 
 /**
@@ -33,6 +35,7 @@ export function GlassDropdown<T extends string>({
   isOpen,
   onToggle,
   onClose,
+  ariaLabel = 'Select option',
 }: GlassDropdownProps<T>) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
@@ -147,7 +150,7 @@ export function GlassDropdown<T extends string>({
           <div
             id={menuId}
             role="listbox"
-            aria-label="Options"
+            aria-label={ariaLabel}
             onKeyDown={handleMenuKeyDown}
             className={`absolute top-full right-0 mt-2 w-48 rounded-[16px] border z-50 overflow-hidden ${
               isDark ? 'bg-[#3a3228] border-white/30' : 'bg-[#d4c5b0] border-white/40'


### PR DESCRIPTION
## Summary
- Replace the generic GlassDropdown `Options` label with a configurable accessible name.
- Name the pull-request status menu contextually and cover the default behavior with a regression test.

## Test plan
- [x] npm test -- --run src/shared/components/GlassDropdown.test.tsx (12 tests)

Closes #724