### PR TITLE
fix: reset RewardsTab columns

### DIFF
--- a/src/features/dashboard/components/RewardsTab.test.tsx
+++ b/src/features/dashboard/components/RewardsTab.test.tsx
@@ -191,15 +191,27 @@ describe('RewardsTab', () => {
       expect(screen.queryByText('Rewards columns')).not.toBeInTheDocument()
     })
 
-    it('closes the popover when the Pending request button is clicked', async () => {
+    it('resets selected columns and closes when Reset columns is clicked', async () => {
       mockGetProfileRewards.mockResolvedValue({ rewards: [] })
       renderRewardsTab()
 
       await userEvent.click(screen.getByRole('button', { name: /toggle column visibility/i }))
       expect(screen.getByText('Rewards columns')).toBeInTheDocument()
 
-      await userEvent.click(screen.getByRole('button', { name: /pending request/i }))
+      await userEvent.click(screen.getByRole('button', { name: /^status$/i }))
+      expect(JSON.parse(localStorage.getItem('rewards_selected_columns') ?? '[]')).not.toContain('Status')
+
+      await userEvent.click(screen.getByRole('button', { name: /reset columns/i }))
       expect(screen.queryByText('Rewards columns')).not.toBeInTheDocument()
+      expect(JSON.parse(localStorage.getItem('rewards_selected_columns') ?? '[]')).toEqual([
+        'Date',
+        'ID',
+        'Project',
+        'From',
+        'Contributions',
+        'Amount',
+        'Status',
+      ])
     })
 
     it('column search filters the visible column options inside the popover', async () => {

--- a/src/features/dashboard/components/RewardsTab.tsx
+++ b/src/features/dashboard/components/RewardsTab.tsx
@@ -302,10 +302,13 @@ export function RewardsTab() {
 
           <div className="px-5 py-4 border-t border-white/20 flex items-center justify-between">
             <button
-              onClick={() => setIsColumnsModalOpen(false)}
+              onClick={() => {
+                setSelectedColumns(columns)
+                setIsColumnsModalOpen(false)
+              }}
               className="text-[13px] text-[#7a6b5a] hover:text-[#2d2820] transition-all font-medium"
             >
-              Pending request
+              Reset columns
             </button>
             <button
               onClick={() => setIsColumnsModalOpen(false)}


### PR DESCRIPTION
## Summary
- replace the misleading Pending request footer action with Reset columns
- restore all default reward columns before closing the picker
- cover the reset action and persisted column selection

## Verification
- `npx vitest run src/features/dashboard/components/RewardsTab.test.tsx` (18 tests)

Closes #735