### PR TITLE
fix: link FeaturedPost story CTA

### DIFF
--- a/src/features/blog/components/FeaturedPost.test.tsx
+++ b/src/features/blog/components/FeaturedPost.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../../../shared/contexts/ThemeContext'
+import { FeaturedPost } from './FeaturedPost'
+
+const post = {
+  id: 1,
+  slug: 'featured-story',
+  title: 'Featured Story',
+  excerpt: 'A featured article.',
+  date: 'June 20, 2026',
+  readTime: '5 min read',
+  image: '✨',
+}
+
+describe('FeaturedPost', () => {
+  it('links Read Full Story to the featured article route', () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <FeaturedPost post={post} />
+        </MemoryRouter>
+      </ThemeProvider>
+    )
+
+    expect(screen.getByRole('link', { name: /read full story/i })).toHaveAttribute(
+      'href',
+      '/dashboard/blog/featured-story'
+    )
+  })
+})

--- a/src/features/blog/components/FeaturedPost.tsx
+++ b/src/features/blog/components/FeaturedPost.tsx
@@ -1,4 +1,5 @@
 import { Calendar, Clock, User, ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useTheme } from '../../../shared/contexts/ThemeContext';
 import { BlogPost } from '../types';
 
@@ -80,10 +81,14 @@ export function FeaturedPost({ post }: FeaturedPostProps) {
                     }`}>{post.author}</span>
                   </div>
                 )}
-                <button className="px-6 py-3 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[14px] font-semibold text-[14px] shadow-[0_6px_20px_rgba(162,121,44,0.35)] hover:shadow-[0_8px_24px_rgba(162,121,44,0.5)] transition-all flex items-center gap-2 border border-white/10 group-hover:scale-105">
+                <Link
+                  to={`/dashboard/blog/${post.slug}`}
+                  aria-label={`Read Full Story: ${post.title}`}
+                  className="px-6 py-3 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[14px] font-semibold text-[14px] shadow-[0_6px_20px_rgba(162,121,44,0.35)] hover:shadow-[0_8px_24px_rgba(162,121,44,0.5)] transition-all flex items-center gap-2 border border-white/10 group-hover:scale-105"
+                >
                   Read Full Story
                   <ArrowRight className="w-4 h-4" />
-                </button>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- turn FeaturedPost Read Full Story into a deep link for the featured post slug
- preserve the existing visual treatment and add a navigation regression test

## Verification
- `npx vitest run src/features/blog/components/FeaturedPost.test.tsx` (1 test)

Closes #739