### PR TITLE
fix: wire OpenSource Week join action

### DIFF
--- a/src/features/dashboard/pages/OpenSourceWeekPage.test.tsx
+++ b/src/features/dashboard/pages/OpenSourceWeekPage.test.tsx
@@ -101,4 +101,28 @@ describe('OpenSourceWeekPage', () => {
 
     expect(mockOnEventClick).toHaveBeenCalledWith('123', 'Click Me')
   })
+
+  it('navigates to the event when Join Event is clicked', async () => {
+    ;(getOpenSourceWeekEvents as any).mockResolvedValue({
+      events: [
+        {
+          id: '456',
+          title: 'Join Me',
+          description: 'Desc',
+          location: 'Remote',
+          status: 'upcoming',
+          start_at: '2023-01-01T10:00:00Z',
+          end_at: '2023-01-07T10:00:00Z',
+        },
+      ],
+    })
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Join Me')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: 'Join Event' }))
+
+    expect(mockOnEventClick).toHaveBeenCalledTimes(1)
+    expect(mockOnEventClick).toHaveBeenCalledWith('456', 'Join Me')
+  })
 })

--- a/src/features/dashboard/pages/OpenSourceWeekPage.tsx
+++ b/src/features/dashboard/pages/OpenSourceWeekPage.tsx
@@ -237,7 +237,14 @@ export function OpenSourceWeekPage({ onEventClick }: OpenSourceWeekPageProps) {
                     </span>
                   </div>
                 </div>
-                <button className="w-full sm:w-auto px-6 py-3 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[14px] font-semibold text-[13px] sm:text-[14px] shadow-[0_6px_20px_rgba(162,121,44,0.35)] hover:shadow-[0_8px_24px_rgba(162,121,44,0.4)] transition-all border border-white/10">
+                <button
+                  type="button"
+                  onClick={(clickEvent) => {
+                    clickEvent.stopPropagation()
+                    onEventClick(event.id, event.title)
+                  }}
+                  className="w-full sm:w-auto px-6 py-3 bg-gradient-to-br from-[#c9983a] to-[#a67c2e] text-white rounded-[14px] font-semibold text-[13px] sm:text-[14px] shadow-[0_6px_20px_rgba(162,121,44,0.35)] hover:shadow-[0_8px_24px_rgba(162,121,44,0.4)] transition-all border border-white/10"
+                >
                   Join Event
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- make each Join Event button invoke the existing event-detail callback
- stop the nested button click from triggering the parent card twice
- add a regression test for the button action

## Verification
- `npx vitest run src/features/dashboard/pages/OpenSourceWeekPage.test.tsx` (5 tests)

Closes #741