### PR TITLE
test: add active-filter count badge accuracy coverage for PRFilterDropdown (Closes #518)

### DIFF
--- a/src/features/maintainers/components/pull-requests/PRFilterDropdown.test.tsx
+++ b/src/features/maintainers/components/pull-requests/PRFilterDropdown.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '../../../../test/renderWithProviders'
+import { PRFilterDropdown } from './PRFilterDropdown'
+import { PRFilterType } from '../../types'
+
+const options: PRFilterType[] = ['All states', 'Open', 'Merged', 'Closed', 'Draft']
+
+function makeProps(overrides: Partial<Parameters<typeof PRFilterDropdown>[0]> = {}) {
+  return {
+    value: 'All states' as PRFilterType,
+    onChange: vi.fn(),
+    isOpen: false,
+    onToggle: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('PRFilterDropdown', () => {
+  it('renders all filter options in the list', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} />)
+    // All options are rendered as menu buttons in the DOM; the trigger shows the current value.
+    expect(screen.getByRole('button', { name: /All states/i })).toBeInTheDocument()
+  })
+
+  it('shows no count badge by default when activeCount is undefined', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} />)
+    expect(screen.queryByTestId('filter-count-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows no count badge when activeCount is 0 (no active filters)', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} activeCount={0} />)
+    expect(screen.queryByTestId('filter-count-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows a badge with the active-filter count after one filter is added', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} activeCount={1} />)
+    const badge = screen.getByTestId('filter-count-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent('1')
+  })
+
+  it('shows a badge that matches the active-filter count after several filters are added', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} activeCount={3} />)
+    const badge = screen.getByTestId('filter-count-badge')
+    expect(badge).toHaveTextContent('3')
+  })
+
+  it('removes the badge when the last filter is removed (count drops to 0)', () => {
+    const { rerender } = renderWithProviders(<PRFilterDropdown {...makeProps()} activeCount={2} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('2')
+
+    rerender(<PRFilterDropdown {...makeProps()} activeCount={1} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('1')
+
+    rerender(<PRFilterDropdown {...makeProps()} activeCount={0} />)
+    expect(screen.queryByTestId('filter-count-badge')).not.toBeInTheDocument()
+  })
+
+  it('keeps the badge count in sync across rapid filter toggles (no stale count)', () => {
+    const { rerender } = renderWithProviders(<PRFilterDropdown {...makeProps()} activeCount={0} />)
+    expect(screen.queryByTestId('filter-count-badge')).not.toBeInTheDocument()
+
+    // Rapid toggle sequence: add, add, remove, add — the badge must never
+    // lag behind the prop (no stale count from a previous render).
+    rerender(<PRFilterDropdown {...makeProps()} value="Open" activeCount={1} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('1')
+
+    rerender(<PRFilterDropdown {...makeProps()} value="Merged" activeCount={2} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('2')
+
+    rerender(<PRFilterDropdown {...makeProps()} value="Merged" activeCount={1} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('1')
+
+    rerender(<PRFilterDropdown {...makeProps()} value="Merged" activeCount={2} />)
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('2')
+  })
+
+  it('keeps the trigger showing the current value and toggling when a badge is present', async () => {
+    const user = userEvent.setup()
+    const onToggle = vi.fn()
+    renderWithProviders(<PRFilterDropdown {...makeProps()} value="Open" onToggle={onToggle} activeCount={1} />)
+
+    // Badge is rendered alongside the trigger button.
+    expect(screen.getByTestId('filter-count-badge')).toHaveTextContent('1')
+
+    // Trigger click still opens the dropdown (badge must not intercept clicks).
+    await user.click(screen.getByRole('button', { name: /Open/i }))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('selecting an option calls onChange with the chosen filter and closes the dropdown', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const onClose = vi.fn()
+    renderWithProviders(
+      <PRFilterDropdown
+        {...makeProps()}
+        onChange={onChange}
+        onClose={onClose}
+        isOpen
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Merged/i }))
+    expect(onChange).toHaveBeenCalledWith('Merged')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('PRFilterDropdown option list', () => {
+  it('covers all PR filter states exposed by the dropdown', () => {
+    renderWithProviders(<PRFilterDropdown {...makeProps()} isOpen />)
+    for (const opt of options) {
+      expect(screen.getAllByRole('button').map((b) => b.textContent)).toEqual(
+        expect.arrayContaining([opt])
+      )
+    }
+  })
+})

--- a/src/features/maintainers/components/pull-requests/PRFilterDropdown.tsx
+++ b/src/features/maintainers/components/pull-requests/PRFilterDropdown.tsx
@@ -7,11 +7,14 @@ interface PRFilterDropdownProps {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  /** Number of currently active filters (status filter, search...), shown as a
+   * small count badge on the trigger button. Hidden when 0/undefined. */
+  activeCount?: number;
 }
 
 const filterOptions: PRFilterType[] = ['All states', 'Open', 'Merged', 'Closed', 'Draft'];
 
-export function PRFilterDropdown({ value, onChange, isOpen, onToggle, onClose }: PRFilterDropdownProps) {
+export function PRFilterDropdown({ value, onChange, isOpen, onToggle, onClose, activeCount }: PRFilterDropdownProps) {
   return (
     <GlassDropdown
       value={value}
@@ -20,6 +23,7 @@ export function PRFilterDropdown({ value, onChange, isOpen, onToggle, onClose }:
       isOpen={isOpen}
       onToggle={onToggle}
       onClose={onClose}
+      badgeCount={activeCount}
     />
   );
 }

--- a/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
+++ b/src/features/maintainers/components/pull-requests/PullRequestsTab.tsx
@@ -198,6 +198,7 @@ export function PullRequestsTab({ selectedProjects, onRefresh: _onRefresh, isLoa
           isOpen={isFilterDropdownOpen}
           onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
           onClose={() => setIsFilterDropdownOpen(false)}
+          activeCount={(filter !== 'All states' ? 1 : 0) + (searchQuery !== '' ? 1 : 0)}
         />
 
         {/* Clear Filters Button */}

--- a/src/shared/components/GlassDropdown.tsx
+++ b/src/shared/components/GlassDropdown.tsx
@@ -8,6 +8,9 @@ interface GlassDropdownProps<T extends string> {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  /** Number of currently active filters, shown as a small count badge on the
+   * trigger button. Hidden when 0/undefined. */
+  badgeCount?: number;
 }
 
 export function GlassDropdown<T extends string>({ 
@@ -16,10 +19,12 @@ export function GlassDropdown<T extends string>({
   options, 
   isOpen, 
   onToggle, 
-  onClose 
+  onClose,
+  badgeCount,
 }: GlassDropdownProps<T>) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const showBadge = typeof badgeCount === 'number' && badgeCount > 0;
 
   const handleSelect = (option: T) => {
     onChange(option);
@@ -30,7 +35,7 @@ export function GlassDropdown<T extends string>({
     <div className="relative">
       {/* Dropdown Button */}
       <button 
-        className={`flex items-center gap-2 px-5 py-3 rounded-[14px] backdrop-blur-[25px] border transition-all ${
+        className={`relative flex items-center gap-2 px-5 py-3 rounded-[14px] backdrop-blur-[25px] border transition-all ${
           isDark
             ? 'bg-white/[0.08] border-white/15 hover:bg-white/[0.12] hover:border-[#e8c571]/30'
             : 'bg-white/[0.15] border-white/25 hover:bg-white/[0.2] hover:border-[#c9983a]/30'
@@ -45,6 +50,14 @@ export function GlassDropdown<T extends string>({
         <ChevronDown className={`w-4 h-4 transition-transform ${
           isDark ? 'text-[#b8a898]' : 'text-[#7a6b5a]'
         } ${isOpen ? 'rotate-180' : ''}`} />
+        {showBadge && (
+          <span
+            className="absolute -top-2 -right-2 min-w-[20px] h-5 px-1 bg-gradient-to-br from-[#e8c571] to-[#c9983a] rounded-full text-[12px] font-bold text-white flex items-center justify-center"
+            data-testid="filter-count-badge"
+          >
+            {badgeCount}
+          </span>
+        )}
       </button>
       
       {/* Dropdown Menu */}


### PR DESCRIPTION
## What

Adds a filter-count badge to the PRFilterDropdown trigger button and tests its accuracy across add/remove/rapid toggle sequences.

## Changes

### New files
- `PRFilterDropdown.test.tsx` — 10 tests covering badge count accuracy, add/remove sequences, rapid toggle, zero-state, and existing filter behaviour

### Modified files
- **GlassDropdown.tsx** — Added optional `badgeCount` prop that renders a small gold count badge on the trigger button when > 0
- **PRFilterDropdown.tsx** — Added `activeCount` prop, forwarded to GlassDropdown as `badgeCount`
- **PullRequestsTab.tsx** — Computes `activeCount = (filter !== 'All states' ? 1 : 0) + (searchQuery !== '' ? 1 : 0)`, passes it to PRFilterDropdown

## Acceptance criteria

- [x] Badge count always matches the actual number of active filters across all tested sequences
- [x] Badge is hidden when no filters are active (activeCount = 0 or undefined)
- [x] Rapid toggle sequences do not leave a stale count
- [x] Existing filter-application behaviour (independent of the badge) is unaffected

## Test results

```
✓ PRFilterDropdown (10 tests)
✓ All 681 tests across 85 test files — no regressions
```

Closes #518